### PR TITLE
Fix Transpilation and Reflect errors

### DIFF
--- a/src/app/components/shell/header/header.js
+++ b/src/app/components/shell/header/header.js
@@ -76,7 +76,7 @@ export default class Header extends BaseView {
         let header = this.el.querySelector('.page-header');
         let height = 0;
 
-        if (typeof header === 'object') {
+        if (header && typeof header === 'object') {
             height = header.offsetHeight;
         }
 
@@ -87,7 +87,7 @@ export default class Header extends BaseView {
         let secondaryNav = this.el.querySelector('.secondary-nav');
         let height = 0;
 
-        if (typeof secondaryNav === 'object') {
+        if (secondaryNav && typeof secondaryNav === 'object') {
             height = secondaryNav.offsetHeight;
         }
 

--- a/src/app/helpers/backbone/view.js
+++ b/src/app/helpers/backbone/view.js
@@ -93,14 +93,15 @@ class BaseView extends Backbone.View {
 
     getTemplateData() {
         let data = this.model ? this.model.toJSON() : {};
+        let view = this;
 
         if (typeof this.templateHelpers === 'function') {
             _.extend(data, this.templateHelpers());
-        } else {
+        } else if (typeof this.templateHelpers === 'object') {
             // Add data from template helpers to the model's data
-            _.each(this.templateHelpers, function (value, key) {
+            _.each(this.templateHelpers, (value, key) => {
                 if (typeof value === 'function') {
-                    data[key] = Reflect.apply(value, this);
+                    data[key] = Reflect.apply(value, view, []);
                 } else {
                     data[key] = value;
                 }

--- a/src/app/pages/home/home.js
+++ b/src/app/pages/home/home.js
@@ -17,6 +17,10 @@ export default class Home extends BaseView {
     }
 
     updateHeaderStyle() {
+        if (!appView.header) {
+            return;
+        }
+
         let secondaryNavHeight = appView.header.secondaryNavHeight;
 
         if (window.pageYOffset > secondaryNavHeight && !appView.header.isPinned()) {


### PR DESCRIPTION
This PR fixes a few issues related to Babel transpilation, which breaks Firefox.

Firefox also correctly throws an error when `Reflect.apply()` is not passed an argument list as the third parameter (Chrome and Safari were not throwing an error).