### PR TITLE
Disable SCSS Lint's Default PropertySortOrder

### DIFF
--- a/gulp/.scss-lint.yml
+++ b/gulp/.scss-lint.yml
@@ -21,6 +21,9 @@ linters:
         max_depth: 5
         ignore_parent_selectors: true
 
+    PropertySortOrder:
+        enabled: false
+
     PropertyUnits:
         global: ['em', 'rem', '%', 'vw', 'vh', 'vmin', 'vmax', 's']
 


### PR DESCRIPTION
This disables SCSS Lint's default settings that enforce [sorting properties in alphabetical order](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#propertysortorder).

Rule is being disabled per request.