### PR TITLE
Add global styles to boxed view pages.

### DIFF
--- a/src/app/pages/accessibility-statement/accessibility-statement.hbs
+++ b/src/app/pages/accessibility-statement/accessibility-statement.hbs
@@ -1,7 +1,7 @@
 <style scoped>
     @import url(/app/pages/accessibility-statement/accessibility-statement.css);
 </style>
-<div class="accessibility-page">
+<div class="accessibility-page page">
 
     <div class="strips">
         <span></span>

--- a/src/app/pages/accessibility-statement/accessibility-statement.scss
+++ b/src/app/pages/accessibility-statement/accessibility-statement.scss
@@ -1,19 +1,2 @@
 @import 'variables';
 @import 'mixins';
-
-.accessibility-page {
-    display: flex;
-    flex-flow: column nowrap;
-    width: 100vw;
-
-    .boxed {
-        display: flex;
-        flex-flow: column nowrap;
-        max-width: $boxed-width;
-        margin: 0 auto 4rem;
-        padding: 0 1.5rem;
-    }
-
-}
-
-

--- a/src/app/pages/license/license.hbs
+++ b/src/app/pages/license/license.hbs
@@ -1,8 +1,17 @@
 <style scoped>
     @import url(/app/pages/license/license.css);
 </style>
-<div class="license-page">
-    <main id="maincontent">
+<div class="license-page page">
+
+    <div class="strips">
+        <span></span>
+        <span></span>
+        <span></span>
+        <span></span>
+        <span></span>
+    </div>
+
+    <main id="maincontent" class="boxed">
         <h1>Legal</h1>
         <h2 class="document-description">Frequently asked IP (Intellectual Property) and legal questions</h2>
         <div class="plain">

--- a/src/app/pages/license/license.scss
+++ b/src/app/pages/license/license.scss
@@ -1,6 +1,2 @@
 @import 'variables';
 @import 'mixins';
-
-.license-page {
-    margin: 7vw 10vw;
-}

--- a/src/app/pages/tos/tos.hbs
+++ b/src/app/pages/tos/tos.hbs
@@ -1,8 +1,17 @@
 <style scoped>
     @import url(/app/pages/tos/tos.css);
 </style>
-<div class="tos-page">
-    <main id="maincontent">
+<div class="tos-page page">
+
+    <div class="strips">
+        <span></span>
+        <span></span>
+        <span></span>
+        <span></span>
+        <span></span>
+    </div>
+
+    <main id="maincontent" class="boxed">
         <h1>Terms of Use</h1>
 
         <p>

--- a/src/app/pages/tos/tos.scss
+++ b/src/app/pages/tos/tos.scss
@@ -1,6 +1,2 @@
 @import 'variables';
 @import 'mixins';
-
-.tos-page {
-    margin: 7vw 10vw;
-}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -87,6 +87,23 @@ a {
     }
 }
 
+// Boxed Page
+
+.page {
+    display: flex;
+    flex-flow: column nowrap;
+    width: 100vw;
+
+    .boxed {
+        display: flex;
+        flex-flow: column nowrap;
+        max-width: $boxed-width;
+        margin: 0 auto 4rem;
+        padding: 0 1.5rem;
+    }
+
+}
+
 //strips
 
 .strips {


### PR DESCRIPTION
- [x] Add strips HTML to TOC, License, and Accessibility pages.
- [x] Added to **main.scss** class `page` with sub-class `boxed` for pages with `max-width: 1200px`