### PR TITLE
Make Subject selection work with router

### DIFF
--- a/src/app/pages/subjects/subjects.js
+++ b/src/app/pages/subjects/subjects.js
@@ -5,6 +5,7 @@ import {on, props} from '~/helpers/backbone/decorators';
 import {template} from './subjects.hbs';
 import FilterButton from './filter-button/filter-button';
 import CategorySection from './category-section/category-section';
+import router from '~/router';
 
 const categories = ['Math', 'Science', 'Social Sciences', 'History', 'AP®'];
 
@@ -26,6 +27,10 @@ function organizeBooksByCategory(books) {
     return result;
 }
 
+function canonicalSubject(string) {
+    return string.toLowerCase().match(/(\w+)/g).join(' ');
+}
+
 @props({
     template: template,
     regions: {
@@ -41,11 +46,31 @@ export default class Subjects extends BaseView {
 
     constructor() {
         super();
+
         this.model = new BaseModel({
             filterButtons: ['View All', ...categories],
             selectedFilter: 'View All',
             selectedBook: null
         });
+
+        let updateSelectedFilterFromPath = () => {
+            let pathMatch = window.location.pathname.match(/\/subjects\/(.+)/),
+                selectedFilter = 'View All';
+
+            if (pathMatch) {
+                let subject = canonicalSubject(pathMatch[1]);
+
+                for (let c of categories) {
+                    if (canonicalSubject(c) === subject) {
+                        selectedFilter = c;
+                    }
+                }
+            }
+            this.model.set('selectedFilter', selectedFilter);
+        };
+
+        this.listenTo(router, 'route', updateSelectedFilterFromPath);
+        updateSelectedFilterFromPath();
     }
 
     renderCategorySections(booksByCategory) {

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -12,6 +12,13 @@ class Router extends Backbone.Router {
             shell.load('home');
         });
 
+        this.route(/subjects\/.*/, 'subjects', () => {
+            if (!(shell.regions.main.views &&
+                shell.regions.main.views[0].constructor.name === 'Subjects')) {
+                shell.load('subjects');
+            }
+        });
+
         ['about', 'books', 'contact', 'news', 'license', 'subjects', 'details',
         'interest', 'adoption', 'adoption-confirmation', 'comp-copy', 'accessibility-statement']
         .forEach(this.standardRoute, this);


### PR DESCRIPTION
Router only loads Subjects page if it is not the currently-loaded page.
Subjects page listens to the router and updates selected filter
accordingly.