### PR TITLE
Create interest confirmation page, fix download menu issues

### DIFF
--- a/src/app/components/get-this-title/get-this-title.hbs
+++ b/src/app/components/get-this-title/get-this-title.hbs
@@ -8,7 +8,7 @@
             <div class="option">
                 <a href="{{webviewLink}}">
                     <span class="fa fa-laptop"></span>
-                    View online*
+                    View online
                 </a>
             </div>
         {{/if}}
@@ -20,14 +20,18 @@
                 </a>
             </div>
         {{/if}}
-        <div class="option">
-            <span class="fa fa-book"></span>
-            Order a print copy
-        </div>
+        {{#if printCopy}}
+            <div class="option">
+                <span class="fa fa-book"></span>
+                Order a print copy
+            </div>
+        {{/if}}
+        {{#if daisyLink}}
         <div class="option">
             <span class="fa fa-wheelchair"></span>
             DAISY or BRF
         </div>
+        {{/if}}
         {{#if ibookLink}}
             <div class="option">
                 <a href="{{ibookLink}}">

--- a/src/app/pages/adoption-confirmation/adoption-confirmation.js
+++ b/src/app/pages/adoption-confirmation/adoption-confirmation.js
@@ -121,7 +121,7 @@ function hookUpDonationBox(el) {
 @props({
     template: template
 })
-export default class Home extends BaseView {
+export default class AdoptionConfirmation extends BaseView {
 
     onRender() {
         this.el.classList.add('confirmation-page');

--- a/src/app/pages/interest-confirmation/interest-confirmation.hbs
+++ b/src/app/pages/interest-confirmation/interest-confirmation.hbs
@@ -1,0 +1,7 @@
+<h1>Thanks for telling us about yourself!</h1>
+<p class="subhead">
+    Our goal is to increase access for students to get the learning materials
+    they need to succeed. We’ll be sure to send you more information about our
+    free textbooks and low-cost learning tools that are revolutionizing
+    classrooms across the country and the world.
+</p>

--- a/src/app/pages/interest-confirmation/interest-confirmation.js
+++ b/src/app/pages/interest-confirmation/interest-confirmation.js
@@ -1,0 +1,14 @@
+import BaseView from '~/helpers/backbone/view';
+import {props} from '~/helpers/backbone/decorators';
+import {template} from './interest-confirmation.hbs';
+
+@props({
+    template: template
+})
+export default class InterestConfirmation extends BaseView {
+
+    onRender() {
+        this.el.classList.add('confirmation-page', 'text-content');
+    }
+
+}

--- a/src/app/pages/interest/interest.hbs
+++ b/src/app/pages/interest/interest.hbs
@@ -9,7 +9,7 @@
     <h2>Contact Information</h2>
     <div>
         <input type=hidden name="oid" value="00DU0000000Kwch">
-        <input type=hidden name="retURL" value="{{urlOrigin}}/home">
+        <input type=hidden name="retURL" value="{{urlOrigin}}/interest-confirmation">
         <input type=hidden name="lead_source" value="OS Interest Form">
         <input type=hidden name="00NU00000055spw" value="High Interest in Adopting">
     </div>

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -26,7 +26,8 @@ class Router extends Backbone.Router {
         ['about', 'books', 'contact', 'news', 'license', 'subjects', 'details',
         'interest', 'adoption', 'adoption-confirmation', 'comp-copy',
         'accessibility-statement', 'faculty-verification', 'k-12', 'allies',
-        'finish-profile', 'finished-verify', 'finished-no-verify', 'about-us']
+        'finish-profile', 'finished-verify', 'finished-no-verify', 'about-us',
+        'interest-confirmation']
         .forEach(this.standardRoute, this);
 
         this.route(/to[u|s]/, 'tos', () => {


### PR DESCRIPTION
After handling interest form, Salesforce should redirect to
interest-confirmation.
No asterisk on View on Web menu item (download menu)
Hide unavailable download options (get print copy, daisy/BRF)