### PR TITLE
Persist salesforce model in cookies

### DIFF
--- a/src/app/models/salesforce-model.js
+++ b/src/app/models/salesforce-model.js
@@ -1,13 +1,32 @@
-import BaseModel from '~/helpers/backbone/model';
+let salesforceModel = {
+        attributes: {},
+        set: (key, value) => {
+            salesforceModel.attributes[key] = value;
+            let encodedValue = window.btoa(value);
 
-let salesforceModel = new BaseModel();
+            document.cookie = `salesforce.${key}=${encodedValue}`;
+        }
+    },
+    cookies = document.cookie.split(/;\s*/);
+
+for (let c of cookies) {
+    let qualifiedkey, value;
+
+    [qualifiedkey, value] = c.split('=');
+    let qualifier, key;
+
+    [qualifier, key] = qualifiedkey.split('.');
+    if (qualifier === 'salesforce') {
+        salesforceModel.set(key, window.atob(value));
+    }
+}
 
 salesforceModel.prefill = (formElement) => {
-    for (let pair of salesforceModel.pairs()) {
-        let el = formElement.querySelector(`[name=${pair[0]}]`);
+    for (let key of Object.keys(salesforceModel.attributes)) {
+        let el = formElement.querySelector(`[name=${key}]`);
 
         if (el) {
-            el.value = pair[1];
+            el.value = salesforceModel.attributes[key];
         }
     }
 };


### PR DESCRIPTION
Salesforce’s redirect after form submission is a new page load, so our
models don’t persist. Saved attributes to cookies so they do persist.
Didn’t really need a model, so converted salesforceModel implementation
to just a structure.