### PR TITLE
Fix get title menu scrolling

### DIFF
--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -44,23 +44,26 @@ export default class Details extends BaseView {
 
     toggleFixedClass() {
         let floatingMenu = document.querySelector('.floating-menu>.box');
-        let footer = document.getElementById('footer');
-        let footerPosition = footer.offsetTop;
-        let floatingMenuHeight = floatingMenu.offsetHeight+200;
-        let menuOffset = footerPosition - floatingMenuHeight;
-        let menuTopPosition = (menuOffset-window.pageYOffset);
 
-        if (window.pageYOffset > menuOffset) {
-            floatingMenu.setAttribute('style', `top: ${menuTopPosition}px`);
-        } else {
-            floatingMenu.removeAttribute('style');
+        if (floatingMenu) {
+            let footer = document.getElementById('footer');
+            let footerPosition = footer.offsetTop;
+            let floatingMenuHeight = floatingMenu.offsetHeight+200;
+            let menuOffset = footerPosition - floatingMenuHeight;
+            let menuTopPosition = ((menuOffset-window.pageYOffset)*1.05);
+
+            if (window.pageYOffset > menuOffset) {
+                floatingMenu.setAttribute('style', `top: ${menuTopPosition}px`);
+            } else {
+                floatingMenu.removeAttribute('style');
+            }
         }
     }
 
     onRender() {
         this.toggleFixedClass();
 
-        window.addEventListener('scroll', this.toggleFixedClass.bind(this), true);
+        window.addEventListener('scroll', this.toggleFixedClass.bind(this));
 
         let slug = decodeURIComponent(window.location.search.substr(1)),
             pageModel = new PageModel(),
@@ -107,6 +110,6 @@ export default class Details extends BaseView {
     }
 
     onBeforeClose() {
-        window.removeEventListener('scroll', this.toggleFixedClass.bind(this), true);
+        window.removeEventListener('scroll', this.toggleFixedClass.bind(this));
     }
 }

--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -301,16 +301,15 @@
             margin-bottom: 1.5rem;
 
             @media (min-width: #{breakpoints(phone) + 1}) {
-                flex: 1 0 46%;
+                flex: 0 0 48%;
 
-                &:nth-child(odd):not(:only-child) {
+                &:nth-child(odd):not(:only-child):not(:last-child) {
                     margin-right: 1.5rem;
                 }
-
             }
 
             @media (min-width: 900px) {
-                flex: 0 0 30%;
+                flex: 0 0 31%;
                 margin-right: 1.5rem;
             }
 


### PR DESCRIPTION
When scrolling down fast, the get-this-title menu on the details page would fall below the footer. Fixed issue by making menu move up slightly faster when above the footer.