### PR TITLE
Add touchmove eventlistener to prevent body scrolling

### DIFF
--- a/src/app/components/shell/header/header.js
+++ b/src/app/components/shell/header/header.js
@@ -300,7 +300,8 @@ class Header extends BaseView {
         thisLi.setAttribute('role', 'presentation');
         thisLi.setAttribute('class', 'clone');
 
-        parent.setAttribute('href', '#');
+        parent.removeAttribute('href');
+        parent.removeAttribute('aria-haspopup');
         back.setAttribute('class', 'back');
         back.text = 'Back';
         thisLi.appendChild(back);
@@ -324,6 +325,10 @@ class Header extends BaseView {
         }
     }
 
+    preventMobileMenuScroll(e) {
+        e.preventDefault();
+    }
+
     onRender() {
         this.updateHeaderStyle();
         document.addEventListener('load', this.appendURL.bind(this), true);
@@ -331,6 +336,11 @@ class Header extends BaseView {
         window.addEventListener('scroll', this.updateHeaderStyle.bind(this));
         window.addEventListener('scroll', this.removeAllOpenClasses.bind(this));
         window.addEventListener('resize', this.closeFullScreenNav.bind(this));
+
+        // prevent scrolling on iOS when mobile menu is active
+        let header = document.querySelector('.page-header');
+
+        header.addEventListener('touchmove', this.preventMobileMenuScroll.bind(this), false);
     }
 
     onBeforeClose() {

--- a/src/app/components/shell/header/header.scss
+++ b/src/app/components/shell/header/header.scss
@@ -14,7 +14,7 @@ $transition: 0.3s;
     flex-flow: column nowrap;
     width: 100%;
     height: 6rem;
-    background-color: rgba(color(neutral-lightest), 0.99);
+    background-color: rgba(color(neutral-lightest), 0.98);
     justify-content: center;
     align-items: center;
 

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -3,7 +3,10 @@
 
 .home-page {
     flex: 1 0 auto;
-    margin-top: -7rem;
+
+    @include desktop {
+        margin-top: -6rem;
+    }
 }
 
 .quote-buckets {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -84,7 +84,6 @@ sup {
 
 .no-scroll {
     overflow: hidden;
-    position: fixed;
 }
 
 #main {


### PR DESCRIPTION
Body would scroll when mobile menu was open without position: fixed on body. However, using fixed positioning caused regressions with click events. Instead, I use a `touchmove` eventlistener on page-header to prevent scrolling.