### PR TITLE
Use logo URLs directly

### DIFF
--- a/src/app/models/pagemodel.js
+++ b/src/app/models/pagemodel.js
@@ -1,5 +1,5 @@
 import BaseModel from '~/helpers/backbone/model';
-import {ApiOrigin} from '/settings.js';
+import {ApiOrigin} from '~/../settings.js';
 
 let pageUrl = `${ApiOrigin}/api/v1/pages`;
 

--- a/src/app/models/usermodel.js
+++ b/src/app/models/usermodel.js
@@ -1,5 +1,5 @@
 import BaseModel from '~/helpers/backbone/model';
-import {ApiOrigin} from '/settings.js';
+import {ApiOrigin} from '~/../settings.js';
 
 let url = `${ApiOrigin}/api/user/`;
 

--- a/src/app/pages/allies/allies.js
+++ b/src/app/pages/allies/allies.js
@@ -16,8 +16,6 @@ let alliesData = {},
 
 
 function handleAlliesData(data) {
-    let imageModel = new BaseModel();
-
     for (let page of data.pages) {
         let name = page.heading;
 
@@ -28,11 +26,7 @@ function handleAlliesData(data) {
             bookLinks: []
         };
         if (page.ally_logo) {
-            logoPromises.push(
-                imageModel.fetch({url: page.ally_logo}).then((logoData) => {
-                    alliesData[name].logoUrl = logoData.file;
-                })
-            );
+            alliesData[name].logoUrl = page.ally_logo;
         }
     }
 }
@@ -67,7 +61,6 @@ export default class Allies extends BaseView {
             selectedFilter: 'View All',
             selectedBook: null
         });
-        this.imageModel = new BaseModel();
     }
 
     handlePageData(data) {

--- a/src/app/pages/details/ally/ally.js
+++ b/src/app/pages/details/ally/ally.js
@@ -1,14 +1,6 @@
 import BaseView from '~/helpers/backbone/view';
-import BaseModel from '~/helpers/backbone/model';
 import {props} from '~/helpers/backbone/decorators';
 import {template} from './ally.hbs';
-
-class LogoModel extends BaseModel {
-    constructor(urlRoot) {
-        super();
-        this.urlRoot = urlRoot;
-    }
-}
 
 @props({
     template,
@@ -24,14 +16,12 @@ export default class Ally extends BaseView {
 
     onRender() {
         this.el.classList.add('ally-info');
-        if (this.templateHelpers.logoUrlUrl) {
+        if (this.templateHelpers.logoUrl) {
             let logoImg = document.createElement('IMG'),
                 logoDiv = this.el.querySelector('.logo');
 
-            new LogoModel(this.templateHelpers.logoUrlUrl).fetch().then((data) => {
-                logoImg.src = data.file;
-                logoDiv.appendChild(logoImg);
-            });
+            logoImg.src = this.templateHelpers.logoUrl;
+            logoDiv.appendChild(logoImg);
         }
     }
 }

--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -158,7 +158,7 @@ export default class Details extends BaseView {
                                 blurb: ally.ally_short_description,
                                 url: ally.book_link_url,
                                 linkText: ally.book_link_text,
-                                logoUrlUrl: ally.ally_logo
+                                logoUrl: ally.ally_logo
                             };
 
                             this.regions.allies.append(new Ally(allyTemplateHelper));


### PR DESCRIPTION
Previously the API gave a link to a data block that contains the logo
URL. Now the logo URL is included in the data instead.