### PR TITLE
add link to source code

### DIFF
--- a/src/app/components/shell/footer/footer.hbs
+++ b/src/app/components/shell/footer/footer.hbs
@@ -18,6 +18,9 @@
                     <a href="/accessibility-statement">Accessibility Statement</a>
                 </li>
                 <li>
+                    <a href="https://github.com/openstax">Open Source Code</a>
+                </li>
+                <li>
                     <a href="/contact">Contact</a>
                 </li>
             </ul>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/253202/14058110/c98f6a52-f2ec-11e5-8133-6950558f8747.png)

Adds a link to the OpenStax source code in the footer.

@openstax/ux: thoughts on placement/phrasing? I just put it somewhere but it could also be a circle, like the linkedin link but with a black-and-white :octocat: 