### PR TITLE
fix mobile flyout menu font color

### DIFF
--- a/src/app/components/shell/header/header.scss
+++ b/src/app/components/shell/header/header.scss
@@ -305,7 +305,7 @@ $transition: 0.3s;
 
         .nav-menu-item {
 
-            a {
+            > a {
                 color: color(cyan);
 
                 @include desktop {


### PR DESCRIPTION
Font color of the flyout menu had changed after the svg arrow updates. Corrected the color back to neutral-medium variable.