### PR TITLE
fix authors section padding

### DIFF
--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -432,6 +432,10 @@
         line-height: 2.6rem;
         padding: 6rem 0 0;
 
+        &:last-child {
+            margin-bottom: 6rem;
+        }
+
         .container {
             flex-flow: column wrap;
 


### PR DESCRIPTION
When authors section is last section on the details page
it was missing padding. The fix adds padding only when
author section is the last section on the page.