### PR TITLE
Fix AP filter button

### DIFF
--- a/src/app/pages/about-us/bios.js
+++ b/src/app/pages/about-us/bios.js
@@ -797,7 +797,9 @@ let bios = {
         {
             name: 'Linda Pallares',
             title: '',
-            bio: '',
+            bio: `Linda Pallares is an Administrative Assistant with OpenStax.
+            She assists with daily operations. She attends the University of Houston
+            and is working towards a degree in Social Work.`,
             image: 'Linda.png',
             bgColor: 'deep-green',
             textColor: 'blue'

--- a/src/app/pages/subjects/subjects.js
+++ b/src/app/pages/subjects/subjects.js
@@ -32,7 +32,7 @@ function organizeBooksByCategory(books) {
 }
 
 function canonicalSubject(string) {
-    return string.toLowerCase().match(/(\w+)/g).join(' ');
+    return string.toLowerCase().replace(/\W.*/, '').match(/(\w+)/g).join(' ');
 }
 
 @props({


### PR DESCRIPTION
Putting `<sup>reg;</sup>` in the tag made it stop matching the path
element. Edited canonicalizer to strip that out.