### PR TITLE
Componentize product boxes, update pages to use them

### DIFF
--- a/src/app/components/filter-button/filter-button.js
+++ b/src/app/components/filter-button/filter-button.js
@@ -50,3 +50,7 @@ export default class FilterButton extends BaseView {
         window.removeEventListener('resize', this.removeOpenCategories.bind(this));
     }
 }
+
+FilterButton.canonicalSubject = function (string) {
+    return string.toLowerCase().replace(/\W.*/, '').match(/(\w+)/g).join(' ');
+};

--- a/src/app/components/product-box/product-box.hbs
+++ b/src/app/components/product-box/product-box.hbs
@@ -1,0 +1,6 @@
+<div class="image"></div>
+<div class="caption">
+    <h3 class="title">{{{title}}}</h3>
+    <p class="blurb">{{{blurb}}}</p>
+    <a class="btn" href="{{url}}">{{linkText}}</a>
+</div>

--- a/src/app/components/product-box/product-box.js
+++ b/src/app/components/product-box/product-box.js
@@ -1,0 +1,15 @@
+import BaseView from '~/helpers/backbone/view';
+import {props} from '~/helpers/backbone/decorators';
+import {template} from './product-box.hbs';
+
+@props({template})
+export default class ProductBox extends BaseView {
+    constructor(data) {
+        super();
+        this.templateHelpers = data;
+    }
+
+    onRender() {
+        this.el.classList.add('product-box', this.templateHelpers.name);
+    }
+}

--- a/src/app/components/products-boxes/products-boxes.hbs
+++ b/src/app/components/products-boxes/products-boxes.hbs
@@ -3,39 +3,5 @@
 </style>
 
 <div class="products-boxes">
-    <div class="content">
-        <div class="product-box books">
-            <div class="image"></div>
-            <div class="caption">
-                <h3 class="title">Our Books</h3>
-                <p class="blurb">{{ourBooksBlurb}}</p>
-                <a class="btn" href="/subjects{{subjectExplore}}">Explore Our Subjects</a>
-            </div>
-        </div>
-
-        {{#if cc}}
-        <div class="product-box cc">
-            <div class="image"></div>
-            <div class="caption">
-                <h3 class="title">Concept Coach</h3>
-                <p class="blurb">
-                    We're integrating our adaptive learning technology with our college textbooks to
-                    improve student reading comprehension at zero cost.
-                </p>
-                <a class="btn" href="//cc.openstax.org">Learn More</a>
-            </div>
-        </div>
-        {{/if}}
-
-        <div class="product-box cnx">
-            <div class="image"></div>
-            <div class="caption">
-                <h3 class="title">OpenStax CNX</h3>
-                <p class="blurb">
-                    OpenStax CNX is an open library of educational content where anyone can contribute. View, share, and add material that you can remix and reuse for your course.
-                </p>
-                <a class="btn" href="https://cnx.org">Discover Free Content</a>
-            </div>
-        </div>
-    </div>
+    <div class="content"></div>
 </div>

--- a/src/app/components/products-boxes/products-boxes.js
+++ b/src/app/components/products-boxes/products-boxes.js
@@ -1,8 +1,14 @@
 import BaseView from '~/helpers/backbone/view';
+import ProductBox from '~/components/product-box/product-box';
 import {props} from '~/helpers/backbone/decorators';
 import {template} from './products-boxes.hbs';
 
-@props({template})
+@props({
+    template,
+    regions: {
+        'boxes': '.content'
+    }
+})
 export default class ProductsBoxes extends BaseView {
     constructor(options = {}) {
         super();
@@ -11,20 +17,60 @@ export default class ProductsBoxes extends BaseView {
             products: options.products || []
         };
 
-        if (options.subject === 'ap') {
-            this.templateHelpers.ourBooksBlurb = `Our college­ level textbooks for Advanced Placement®
-                courses are peer-reviewed, completely free online, and will soon be available for a
-                very low cost in print.`;
-            this.templateHelpers.subjectExplore = '/ap';
-        } else {
-            this.templateHelpers.ourBooksBlurb = `All of our textbooks are peer-reviewed and absolutely
-                free. They meet standard scope and sequence requirements and come in web view, PDF,
-                iBooks, or a low cost print version.`;
-            this.templateHelpers.subjectExplore = '';
-        }
+        let boxData = {
+            books: {
+                name: 'books',
+                title: 'Our Books',
+                linkText: 'Explore Our Subjects',
+                blurb: `All of our textbooks are peer-reviewed and absolutely free.
+                They meet standard scope and sequence requirements and come in web
+                view, PDF, iBooks, or a low cost print version.`,
+                url: '/subjects'
+            },
+            ap: {
+                name: 'books',
+                title: 'Books for Advanced Placement<sup>&reg;</sup>',
+                linkText: 'Explore Our Subjects',
+                blurb: `Our college­ level textbooks for Advanced Placement<sup>&reg;</sup>
+                    courses are peer-reviewed, completely free online, and will soon be
+                    available for a very low cost in print.`,
+                url: '/subjects/ap'
+            },
+            'Concept Coach': {
+                name: 'cc',
+                title: 'Concept Coach',
+                linkText: 'Learn More',
+                url: '//cc.openstax.org',
+                blurb: `We're integrating our adaptive learning technology with our
+                college textbooks to improve student reading comprehension at zero cost.`
+            },
+            'Tutor': {
+                name: 'tutor',
+                title: 'OpenStax Tutor Pilot',
+                linkText: 'Sign up',
+                url: '/contact?subject=OpenStax Tutor Pilot Sign-up',
+                blurb: `We’re recruiting for our Fall 2016 OpenStax Tutor high school pilot.
+                Sign up to partner with us in perfecting this full-service digital courseware
+                and help impact the future of education.
+`
+            },
+            'OpenStax CNX': {
+                name: 'cnx',
+                title: 'OpenStax CNX',
+                linkText: 'Discover Free Content',
+                url: '//cnx.org',
+                blurb: `OpenStax CNX is an open library of educational content where anyone
+                can contribute. View, share, and add material that you can remix and reuse
+                for your course.`
+            }
+        };
 
-        if (options.products.indexOf('Concept Coach') !== -1) {
-            this.templateHelpers.cc = true;
+        this.boxes = options.products.map((product) => new ProductBox(boxData[product]));
+    }
+
+    onRender() {
+        for (let box of this.boxes) {
+            this.regions.boxes.append(box);
         }
     }
 }

--- a/src/app/components/products-boxes/products-boxes.scss
+++ b/src/app/components/products-boxes/products-boxes.scss
@@ -89,4 +89,8 @@
     .cc > .image {
         background-image: url('/images/k-12/student.jpg');
     }
+
+    .tutor > .image {
+        background-image: url('/images/k-12/bx-cnx-2x.jpg');
+    }
 }

--- a/src/app/pages/allies/allies.js
+++ b/src/app/pages/allies/allies.js
@@ -64,12 +64,29 @@ export default class Allies extends BaseView {
         $.scrollTo(e.target, 60);
     }
 
+    updateSelectedFilterFromPath() {
+        let pathMatch = window.location.pathname.match(/\/allies\/(.+)/),
+            selectedFilter = 'View All';
+
+        if (pathMatch) {
+            let subject = FilterButton.canonicalSubject(pathMatch[1]);
+
+            for (let c of categories) {
+                if (FilterButton.canonicalSubject(c) === subject) {
+                    selectedFilter = c;
+                }
+            }
+        }
+        this.stateModel.set('selectedFilter', selectedFilter);
+    }
+
     constructor() {
         super();
         this.stateModel = new BaseModel({
             selectedFilter: 'View All',
             selectedBook: null
         });
+        this.updateSelectedFilterFromPath();
     }
 
     handlePageData(data) {

--- a/src/app/pages/higher-ed/higher-ed.js
+++ b/src/app/pages/higher-ed/higher-ed.js
@@ -31,7 +31,7 @@ export default class HigherEd extends BaseView {
     onRender() {
         this.regions.products.show(new ProductsBoxes({
             products: [
-                'Our Books',
+                'books',
                 'Concept Coach',
                 'OpenStax CNX'
             ]

--- a/src/app/pages/k-12/k-12.js
+++ b/src/app/pages/k-12/k-12.js
@@ -28,21 +28,20 @@ export default class K12 extends BaseView {
             bucketClass: 'allies',
             hasImage: false,
             titleText: 'OpenStax Allies',
-            blurbHtml: `We partner with OpenStax Allies to provide additional integrated
-            resources for our AP&reg; course textbooks. Discover the courseware, online homework,
-             and adaptive learning tools alongside our titles.`,
+            blurbHtml: `OpenStax Allies have united with us to increase access to
+            high-quality learning materials. Their low-cost tools integrate seamlessly
+            with our books for AP<sup>&reg;</sup> courses.`,
             btnClass: 'btn-yellow',
-            linkUrl: '/allies',
+            linkUrl: '/allies/ap',
             linkText: 'View Allies'
         }));
 
         this.regions.banner.show(new Banner());
         this.regions.tutor.show(new Tutor());
         this.regions.products.show(new ProductsBoxes({
-            subject: 'ap',
             products: [
-                'Our Books',
-                'OpenStax CNX'
+                'ap',
+                'Tutor'
             ]
         }));
     }

--- a/src/app/pages/subjects/subjects.js
+++ b/src/app/pages/subjects/subjects.js
@@ -31,10 +31,6 @@ function organizeBooksByCategory(books) {
     return result;
 }
 
-function canonicalSubject(string) {
-    return string.toLowerCase().replace(/\W.*/, '').match(/(\w+)/g).join(' ');
-}
-
 @props({
     template: template,
     templateHelpers: {strips},
@@ -59,10 +55,10 @@ export default class Subjects extends BaseView {
             selectedFilter = 'View All';
 
         if (pathMatch) {
-            let subject = canonicalSubject(pathMatch[1]);
+            let subject = FilterButton.canonicalSubject(pathMatch[1]);
 
             for (let c of categories) {
-                if (canonicalSubject(c) === subject) {
+                if (FilterButton.canonicalSubject(c) === subject) {
                     selectedFilter = c;
                 }
             }

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -52,6 +52,13 @@ class Router extends Backbone.Router {
             }
         });
 
+        this.route(/allies\/.*/, 'allies', () => {
+            if (!(shell.regions.main.views &&
+                shell.regions.main.views[0].constructor.name === 'Allies')) {
+                shell.load('allies');
+            }
+        });
+
         this.route(/details\/.*/, 'details', () => {
             shell.load('details');
         });


### PR DESCRIPTION
Allies page now takes filter path like Subjects page
ProductBox is now a separate component
ProductsBoxes is called a little differently; Higher Ed and K-12
updated accordingly