### PR TITLE
Fix IE styling for quotes, buckets, banner overlays

### DIFF
--- a/src/app/components/quotes/quotes.scss
+++ b/src/app/components/quotes/quotes.scss
@@ -31,6 +31,10 @@
             margin: 0;
         }
 
+        > .quote {
+            display: block;
+        }
+
         &.left {
 
             @media (min-width: 700px) {

--- a/src/app/pages/allies/allies.scss
+++ b/src/app/pages/allies/allies.scss
@@ -1,6 +1,5 @@
 @import 'variables';
 @import 'mixins';
-@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css);
 
 $text-dark2: rgba(0, 0, 0, 0.7);
 

--- a/src/app/pages/higher-ed/higher-ed.scss
+++ b/src/app/pages/higher-ed/higher-ed.scss
@@ -83,7 +83,7 @@ $hero-break-width: 820px;
         > .overlay {
             background-color: rgba(color(cyan), 0.8);
             color: color(neutral-lightest);
-            margin: 0 6%;
+            margin: calc(18vw - 15rem) 6%; // calc is for IE; 0 works otherwise
             padding-left: 26%;
             z-index: 1;
 

--- a/src/app/pages/k-12/banner/banner.scss
+++ b/src/app/pages/k-12/banner/banner.scss
@@ -79,7 +79,7 @@ $breakpoint-2: 806px;
                 @include variable-sized-text(1.55, 0.15);
 
                 background-color: rgba(saturate(color(orange), 10%), 0.85);
-                margin: 0 auto;
+                margin: calc(19vw - 15rem) auto; // calc fixes IE; 0 otherwise
                 letter-spacing: 0.06rem;
                 line-height: 1.6;
                 max-width: calc(#{$boxed-width} + 10vw);

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,8 @@
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
         <link rel="stylesheet" href="/styles/main.css">
 
+        <script src="//cdn.rawgit.com/eligrey/classList.js/master/classList.min.js"></script>
+
         <script src="/system.js"></script>
         <script src="/app/config.js"></script>
         <script src="/dependencies.js"></script>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -113,6 +113,7 @@ sup {
 #main {
     flex: 1 0 auto;
     padding-top: 6rem;
+    z-index: 0;
 
     @include desktop {
         padding-top: 11rem;


### PR DESCRIPTION
Added shim for classList (using rawgit CDN)
Added margin for banner overlays
Set z-index of #main to keep elements from passing in front of menu