### PR TITLE
Apply loader to About Us and Details

### DIFF
--- a/src/app/helpers/backbone/loading-view.js
+++ b/src/app/helpers/backbone/loading-view.js
@@ -47,10 +47,14 @@ class LoadingView extends BaseView {
     }
 
     onLoaded() {
+        document.getElementById('header').classList.remove('hidden');
+        document.getElementById('footer').classList.remove('hidden');
         setTimeout(() => {this.loadingSection.remove();}, 500);
-    } // noop
+    }
 
     onRender() {
+        document.getElementById('header').classList.add('hidden');
+        document.getElementById('footer').classList.add('hidden');
         this.regions.self.el = this.el;
         this.regions.self.append(this.loadingSection);
     }

--- a/src/app/pages/about-us/about-us.hbs
+++ b/src/app/pages/about-us/about-us.hbs
@@ -2,7 +2,7 @@
     @import url(/app/pages/about-us/about-us.css);
     @import url(/app/components/remover/remover.css);
 </style>
-<div class="about-us page">
+<div class="about-us page hidden">
     <div class="hero">
         <div class="boxed">
             <h1>About Us</h1>

--- a/src/app/pages/about-us/about-us.js
+++ b/src/app/pages/about-us/about-us.js
@@ -1,4 +1,4 @@
-import BaseView from '~/helpers/backbone/view';
+import LoadingView from '~/helpers/backbone/loading-view';
 import BaseModel from '~/helpers/backbone/model';
 import Headshot from './headshot/headshot';
 import {props} from '~/helpers/backbone/decorators';
@@ -58,10 +58,11 @@ function assignColorsToTeam(team) {
         advisors: '.strategic-advisors>.headshots'
     }
 })
-export default class AboutUs extends BaseView {
+export default class AboutUs extends LoadingView {
     onRender() {
         let stateModel = new BaseModel();
 
+        super.onRender();
         bios.team.sort((a, b) => lastName(a) > lastName(b) ? 1 : -1);
         assignColorsToTeam(bios.team);
         for (let person of bios.team) {
@@ -70,5 +71,10 @@ export default class AboutUs extends BaseView {
         for (let person of bios.advisors.sort((a, b) => lastName(a) > lastName(b) ? 1 : -1)) {
             this.regions.advisors.append(new Headshot(toHeadshot(person)));
         }
+    }
+
+    onLoaded() {
+        super.onLoaded();
+        this.el.querySelector('.page').classList.remove('hidden');
     }
 }

--- a/src/app/pages/about-us/about-us.scss
+++ b/src/app/pages/about-us/about-us.scss
@@ -16,6 +16,10 @@
 .about-us {
     background-color: rgba(color(neutral-lighter), 0.2);
 
+    &.hidden {
+        display: none;
+    }
+
     .hero {
         background-color: color(gray);
         color: color(neutral-lightest);

--- a/src/app/pages/details/details.hbs
+++ b/src/app/pages/details/details.hbs
@@ -2,7 +2,7 @@
     @import url(/app/pages/details/details.css);
     @import url(/app/components/get-this-title/get-this-title.css);
 </style>
-<div class="details-page">
+<div class="details-page hidden">
         <section class="container book-info">
             <img class="book-cover" />
                 <section class="details">

--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -1,5 +1,5 @@
 import Backbone from 'backbone';
-import BaseView from '~/helpers/backbone/view';
+import LoadingView from '~/helpers/backbone/loading-view';
 import $ from '~/helpers/$';
 import PageModel from '~/models/pagemodel';
 import Author from './author/author';
@@ -45,7 +45,7 @@ function dataToTemplateHelper(data) {
         allies: '#allies'
     }
 })
-export default class Details extends BaseView {
+export default class Details extends LoadingView {
     @on('click a[href^="#"]')
     hashClick(e) {
         $.scrollTo($.hashTarget(e));
@@ -119,6 +119,7 @@ export default class Details extends BaseView {
     }
 
     onRender() {
+        super.onRender();
         this.toggleFixedClass();
 
         window.addEventListener('scroll', this.toggleFixedClass.bind(this));
@@ -252,6 +253,11 @@ export default class Details extends BaseView {
         pageModel.fetch({
             data: {type: 'books.Book', slug}
         }).then(handleBasicBookData.bind(this));
+    }
+
+    onLoaded() {
+        super.onLoaded();
+        this.el.querySelector('.details-page').classList.remove('hidden');
     }
 
     onBeforeClose() {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -33,6 +33,19 @@ p {
     margin-bottom: 1rem;
 }
 
+.loader {
+    align-items: center;
+    background-color: color(orange);
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100vw;
+    z-index: 1001;
+}
+
 sup {
     font-size: 66%;
     margin-left: 0.1rem;


### PR DESCRIPTION
Updated loader to hide/show header and footer, take up entire screen.
Applied loader to About Us and Details pages.