### PR TITLE
Clean up Adopters, footer, and ULs where IE leaves bullets

### DIFF
--- a/src/app/components/shell/footer/footer.hbs
+++ b/src/app/components/shell/footer/footer.hbs
@@ -4,7 +4,7 @@
         <div class="hero-quote">Access. The Future of Education.</div>
 
         <div class="copyright">
-            <ul>
+            <ul class="no-bullets">
                 <!--<li>
                     <a href="/news">News</a>
                 </li>-->
@@ -47,7 +47,7 @@
         </div>
 
         <div class="social">
-            <ul>
+            <ul class="no-bullets">
                 <li>
                     <a class="btn btn-social facebook" href="https://www.facebook.com/openstax" title="facebook">
                         Facebook

--- a/src/app/components/shell/footer/footer.scss
+++ b/src/app/components/shell/footer/footer.scss
@@ -19,20 +19,13 @@
 
     .boxed {
         margin: 0 auto;
+        max-width: 90%;
         opacity: 0.85;
         padding: 4rem 8vw;
-        max-width: $boxed-width;
-    }
-
-    ul {
-        display: flex;
-        flex-flow: row wrap;
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
+        width: 90rem;
 
         @include desktop {
-            justify-content: center;
+            padding: 4rem 9.6rem;
         }
     }
 
@@ -60,7 +53,14 @@
         padding-bottom: 1rem;
 
         ul {
+            display: flex;
+            flex-flow: row wrap;
             margin: 0 0 2rem;
+            padding: 0;
+
+            @include desktop {
+                justify-content: center;
+            }
         }
 
         li > a {
@@ -89,6 +89,7 @@
             display: flex;
             flex-wrap: wrap;
             justify-content: center;
+            padding: 0;
         }
     }
 }

--- a/src/app/components/shell/header/header.hbs
+++ b/src/app/components/shell/header/header.hbs
@@ -6,7 +6,7 @@
 
     <nav class="meta-nav">
         <div class="container">
-            <ul class="nav-menu meta-menu" role="menu" aria-label="Meta navigation menu">
+            <ul class="nav-menu meta-menu no-bullets" role="menu" aria-label="Meta navigation menu">
                 <li class="nav-menu-item"><a href="/about-us" role="menuitem">About Us</a></li>
                 <li class="nav-menu-item"><a href="/contact" role="menuitem">Contact</a></li>
                 <li class="nav-menu-item login"><a href="#" role="menuitem">Login<svg width="0" class="chevron" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 30"><title>arrow</title><path d="M12,1L26,16,12,31,8,27,18,16,8,5Z" transform="translate(-8 -1)"/></svg></a>
@@ -38,7 +38,7 @@
                 <span class="logo-quote">Access. The future of education.</span>
             </span>
 
-            <ul class="nav-menu main-menu">
+            <ul class="nav-menu main-menu no-bullets">
                 <li class="nav-menu-item dropdown" role="presentation">
                     <a href="/subjects" role="menuitem" aria-haspopup="true">Subjects<svg width="0" class="chevron" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 30"><title>arrow</title><path d="M12,1L26,16,12,31,8,27,18,16,8,5Z" transform="translate(-8 -1)"/></svg></a>
                     <ul class="dropdown-menu" role="menu" aria-expanded="false" aria-label="Subjects menu">

--- a/src/app/components/shell/header/header.scss
+++ b/src/app/components/shell/header/header.scss
@@ -80,9 +80,6 @@ $transition: 0.3s;
     .nav-menu {
         margin: 0;
         padding: 0;
-        list-style: none;
-        // Hide bullets in IE
-        list-style-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
         transform: scale3d(0, 0, 0);
         flex: 0 auto;
         opacity: 0;
@@ -153,8 +150,9 @@ $transition: 0.3s;
             right: -2rem;
 
             @include desktop {
-                bottom: 2.2rem;
-                right: -2.5rem;
+                bottom: 1.1rem;
+                padding-bottom: 25%;
+                right: -1.5rem;
                 transform: rotate3d(0, 0, 1, 90deg);
                 fill: color(neutral-medium);
 
@@ -198,9 +196,6 @@ $transition: 0.3s;
 
         .dropdown-menu {
             overflow: hidden;
-            list-style: none;
-            // Hide bullets in IE
-            list-style-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
             margin: 0;
             padding: 0;
             font-weight: 300;

--- a/src/app/components/shell/shell.js
+++ b/src/app/components/shell/shell.js
@@ -56,6 +56,10 @@ class AppView extends BaseView {
                     }, 200);
             } else {
                 window.scrollTo(0, 0);
+                // Another stab at fixing IE rendering issue
+                setTimeout(() => {
+                    this.header.resetHeader();
+                }, 250);
             }
         });
 

--- a/src/app/pages/adopters/adopter-column.hbs
+++ b/src/app/pages/adopters/adopter-column.hbs
@@ -1,0 +1,3 @@
+{{#each names}}
+<div class="adopter">{{this}}</div>
+{{/each}}

--- a/src/app/pages/adopters/adopters.js
+++ b/src/app/pages/adopters/adopters.js
@@ -1,20 +1,40 @@
 import BaseView from '~/helpers/backbone/view';
+import LoadingView from '~/helpers/backbone/loading-view';
 import BaseModel from '~/helpers/backbone/model';
 import {props} from '~/helpers/backbone/decorators';
 import {template} from './adopters.hbs';
+import {template as columnTemplate} from './adopter-column.hbs';
 import settings from 'settings';
 
 let adopterPromise = (new BaseModel()).fetch({url: `${settings.apiOrigin}/api/adopters`});
 
-class AdopterView extends BaseView {
-    constructor(name) {
+@props({
+    template: columnTemplate
+})
+class AdopterColumn extends BaseView {
+    constructor(nameList) {
         super();
-        this.template = name;
+        this.templateHelpers = {
+            names: nameList
+        };
     }
 
     onRender() {
-        this.el.classList.add('adopter');
+        this.el.classList.add('adopter-column');
     }
+}
+
+function makeColumns(list, columnCount) {
+    let perColumn = Math.ceil(list.length / columnCount),
+        views = [];
+
+    for (let col = 0; col < columnCount; ++col) {
+        let begin = col * perColumn,
+            end = begin + perColumn;
+
+        views.push(new AdopterColumn(list.slice(begin, end)));
+    }
+    return views;
 }
 
 @props({
@@ -23,17 +43,42 @@ class AdopterView extends BaseView {
         adopters: '.adopters'
     }
 })
-export default class Adopters extends BaseView {
+export default class Adopters extends LoadingView {
     onRender() {
+        for (let el of Array.from(this.el.querySelectorAll('*'))) {
+            el.classList.add('hidden');
+        }
+        super.onRender();
         this.el.classList.add('adopters-page', 'text-content');
-        adopterPromise.then((data) => {
-            let sortedNames = data.map((obj) => obj.name).sort();
+        this.otherPromises.push(new Promise((resolve) => {
+            adopterPromise.then((data) => {
+                let sortedNames = data.map((obj) => obj.name).sort(),
+                    views = makeColumns(sortedNames, 4);
 
-            for (let name of sortedNames) {
-                let view = new AdopterView(name);
+                for (let view of views) {
+                    this.regions.adopters.append(view);
+                    view.el.classList.add('four-column');
+                }
+
+                views = makeColumns(sortedNames, 3);
+                for (let view of views) {
+                    this.regions.adopters.append(view);
+                    view.el.classList.add('three-column');
+                }
+
+                let view = new AdopterColumn(sortedNames);
 
                 this.regions.adopters.append(view);
-            }
-        });
+                view.el.classList.add('one-column');
+                resolve();
+            });
+        }));
+    }
+
+    onLoaded() {
+        super.onLoaded();
+        for (let el of Array.from(this.el.querySelectorAll('.hidden'))) {
+            el.classList.remove('hidden');
+        }
     }
 }

--- a/src/app/pages/adopters/adopters.scss
+++ b/src/app/pages/adopters/adopters.scss
@@ -7,22 +7,42 @@ h1 {
 
 .adopters {
     display: flex;
-    flex-flow: column wrap;
+    flex-flow: row wrap;
     font-size: 1.5rem;
     font-weight: 400;
-    max-height: 1553rem;
-    width: 25%;
+    justify-content: space-between;
 }
 
-.adopter {
-    flex-basis: 25%;
+.adopter-column {
+    display: none;
     padding: 0.5rem;
 
     @include phone {
-        flex-basis: 100%;
+        &.one-column {
+            display: block;
+        }
     }
 
     @include tablet {
-        flex-basis: 33%;
+        flex-basis: 30%;
+
+        &.three-column {
+            display: block;
+        }
+    }
+
+    @include desktop {
+        flex-basis: 22%;
+
+        &.four-column {
+            display: block;
+        }
+    }
+
+    .adopter {
+        line-height: 1.3;
+        margin-bottom: 1rem;
+        padding-left: 0.5rem;
+        text-indent: -0.5rem;
     }
 }

--- a/src/app/pages/details/details.hbs
+++ b/src/app/pages/details/details.hbs
@@ -133,7 +133,7 @@
                     you have a correction to suggest, submit it here. We'll review your
                     suggestion and make necessary changes.
                 </p>
-                <ul class="links">
+                <ul class="links no-bullets">
                     <li><a class="go-to errata-link">Errata list</a></li>
                     <li><a class="go-to suggest-correction-link">Suggest a correction</a></li>
                 </ul>

--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -531,7 +531,6 @@
         }
 
         .links {
-            list-style: none;
             margin: 0;
             padding: 0;
             cursor: pointer;

--- a/src/app/pages/impact/impact.hbs
+++ b/src/app/pages/impact/impact.hbs
@@ -32,7 +32,7 @@
                 </p>
             </div>
 
-            <ul class="partners">
+            <ul class="partners no-bullets">
                 {{#each highlightedPartners}}
                     <li>
                         <a href="{{url}}">

--- a/src/app/pages/impact/impact.scss
+++ b/src/app/pages/impact/impact.scss
@@ -11,12 +11,6 @@ $breakpoint-3: 1920px;
         display: none;
     }
 
-    ul {
-        list-style-type: none;
-        // Hide bullets in IE
-        list-style-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
-    }
-
     .hero {
         align-items: center;
         background-image: url('/images/impact/banner-bg.jpg');

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -33,6 +33,12 @@ p {
     margin-bottom: 1rem;
 }
 
+.no-bullets {
+    // Hide bullets in IE
+    list-style-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
+    list-style-type: none;
+}
+
 .loader {
     align-items: center;
     background-color: color(orange);


### PR DESCRIPTION
Created no-bullets class for ULs that should have no bullets
Tidied footer, centered social icon group
Fixed the menu chevron placement in IE without breaking it in Chrome
Put adopters in columns (displays faster and correctly in IE)