### PR TITLE
Reduce gulp watch CPU usage

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -15,5 +15,12 @@ module.exports = {
     ],
     name: project.name,
     version: project.version,
-    license: project.license
+    license: project.license,
+    watchOpts: {
+        interval: 300,
+        binaryInterval: 600,
+        usePolling: true,
+        useFsEvents: true,
+        awaitWriteFinish: true
+    }
 };

--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -23,9 +23,5 @@ function copy() {
 gulp.task(copy);
 
 gulp.task('copy:watch', () => {
-    gulp.watch(`${config.src}/*.{json,txt,ico}`, {
-        interval: 1000, // default 100
-        debounceDelay: 500, // default 500
-        usePolling: true
-    }, copy);
+    gulp.watch(`${config.src}/*.{json,txt,ico}`, config.watchOpts, copy);
 });

--- a/gulp/tasks/html.js
+++ b/gulp/tasks/html.js
@@ -16,5 +16,5 @@ function html() {
 gulp.task(html);
 
 gulp.task('html:watch', () => {
-    gulp.watch(`${config.src}/**/*.html`, html);
+    gulp.watch(`${config.src}/**/*.html`, config.watchOpts, html);
 });

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -23,5 +23,5 @@ function images() {
 gulp.task(images);
 
 gulp.task('images:watch', () => {
-    gulp.watch(`${config.src}/**/*.{png,jpg,jpeg,gif,svg,mp4}`, images);
+    gulp.watch(`${config.src}/**/*.{png,jpg,jpeg,gif,svg,mp4}`, config.watchOpts, images);
 });

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -196,11 +196,7 @@ gulp.task('scripts', gulp.series(
 ));
 
 gulp.task('scripts:watch', () => {
-    gulp.watch(`${config.src}/**/*.js`, {
-        interval: 1000, // default 100
-        debounceDelay: 500, // default 500
-        mode: 'poll'
-    }, gulp.series(
+    gulp.watch(`${config.src}/**/*.js`, config.watchOpts, gulp.series(
         eslint,
         compileScripts,
         bs.reload

--- a/gulp/tasks/service-worker.js
+++ b/gulp/tasks/service-worker.js
@@ -38,7 +38,5 @@ function precache() {
 gulp.task(precache);
 
 gulp.task('precache:watch', () => {
-    gulp.watch(shellFiles.map((uri) => `${config.dest}${uri}`), {
-        usePolling: true
-    }, precache);
+    gulp.watch(shellFiles.map((uri) => `${config.dest}${uri}`), config.watchOpts, precache);
 });

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -104,7 +104,7 @@ gulp.task('styles:watch', () => {
     gulp.watch([
         `${config.src}/**/*.scss`,
         `!${config.src}/styles/{components,mixins,variables}/**/*.scss`
-    ], gulp.series(
+    ], config.watchOpts, gulp.series(
         scsslint,
         compileChangedStyles,
         bs.reload // Only necessary if BS stream isn't piped in above
@@ -114,7 +114,7 @@ gulp.task('styles:watch', () => {
 gulp.task('component-styles:watch', () => {
     gulp.watch([
         `${config.src}/styles/components/**/*.scss`
-    ], gulp.series(
+    ], config.watchOpts, gulp.series(
         scsslint,
         compileMainStyle,
         bs.reload // Only necessary if BS stream isn't piped in above
@@ -124,7 +124,7 @@ gulp.task('component-styles:watch', () => {
 gulp.task('fundamental-styles:watch', () => {
     gulp.watch([
         `${config.src}/styles/{mixins,variables}/**/*.scss`
-    ], gulp.series(
+    ], config.watchOpts, gulp.series(
         scsslint,
         compileAllStyles,
         bs.reload // Only necessary if BS stream isn't piped in above

--- a/gulp/tasks/systemjs-builder.js
+++ b/gulp/tasks/systemjs-builder.js
@@ -32,7 +32,5 @@ function systemjs() {
 gulp.task(systemjs);
 
 gulp.task('systemjs:watch', () => {
-    gulp.watch('./jspm_packages/**/*', {
-        usePolling: true
-    }, systemjs);
+    gulp.watch('./jspm_packages/**/*', config.watchOpts, systemjs);
 });

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -74,7 +74,7 @@ gulp.task('templates', gulp.parallel(
 ));
 
 gulp.task('templates:watch', () => {
-    gulp.watch(`${config.src}/**/*.part.hbs`, gulp.series(
+    gulp.watch(`${config.src}/**/*.part.hbs`, config.watchOpts, gulp.series(
         precompilePartials,
         bs.reload
     ));
@@ -82,7 +82,7 @@ gulp.task('templates:watch', () => {
     gulp.watch([
         `${config.src}/**/*.hbs`,
         `!${config.src}/**/*.part.hbs`
-    ], gulp.series(
+    ], config.watchOpts, gulp.series(
         precompileTemplates,
         bs.reload
     ));


### PR DESCRIPTION
Drastically reduce gulp CPU usage, especially on OS X, and also ensure files are done writing before re-loading to prevent empty reloads.