### PR TITLE
Create mac-scroll class that fixes disappearing scrollbar problem

### DIFF
--- a/src/app/components/single-select/single-select.hbs
+++ b/src/app/components/single-select/single-select.hbs
@@ -1,2 +1,2 @@
 <div class="selected-button has-dropdown"></div>
-<div class="option-list hidden"></div>
+<div class="option-list mac-scroll hidden"></div>

--- a/src/app/components/single-select/single-select.js
+++ b/src/app/components/single-select/single-select.js
@@ -31,27 +31,6 @@ export default class SingleSelect extends BaseView {
         this.optionScroller.scroll(e);
     }
 
-    @on('scroll .option-list')
-    whileScrolling() {
-        this.freezePosition = document.documentElement.scrollTop || document.body.scrollTop;
-    }
-
-    @on('mouseleave .option-list')
-    leaveOptionList(e) {
-        if (!e.target.contains(e.relatedTarget)) {
-            delete this.freezePosition;
-        }
-    }
-
-    @on('mousewheel .option-list')
-    wheelScrollOptionList(e) {
-        let el = this.el.querySelector('.option-list'),
-            delta = e.deltaY || e.wheelDelta / 4;
-
-        el.scrollTop = el.scrollTop + delta;
-        e.preventDefault();
-    }
-
     constructor() {
         super();
         this.stateCollection = new BaseCollection();
@@ -143,6 +122,7 @@ export default class SingleSelect extends BaseView {
     }
 
     onRender() {
+        super.onRender();
         this.selectedButtonEl = this.el.querySelector('.selected-button');
         this.optionListEl = this.el.querySelector('.option-list');
         this.hasDropdownEl = this.el.querySelector('.has-dropdown');
@@ -153,11 +133,6 @@ export default class SingleSelect extends BaseView {
             this.regions.optionList.append(ssOption);
             model.set('listItem', ssOption);
             this.synchronizeModel(model);
-        });
-        this.attachListenerTo(window, 'scroll', () => {
-            if (this.freezePosition) {
-                window.scrollTo(0, this.freezePosition);
-            }
         });
     }
 }

--- a/src/app/components/tag-multi-select/tag-multi-select.hbs
+++ b/src/app/components/tag-multi-select/tag-multi-select.hbs
@@ -1,3 +1,3 @@
 <div class="tag-list has-dropdown"></div>
-<div class="option-list hidden"></div>
+<div class="option-list mac-scroll hidden"></div>
 <span class="required"></span>

--- a/src/app/components/tag-multi-select/tag-multi-select.js
+++ b/src/app/components/tag-multi-select/tag-multi-select.js
@@ -29,27 +29,6 @@ export default class TagMultiSelect extends BaseView {
         e.preventDefault();
     }
 
-    @on('scroll .option-list')
-    whileScrolling() {
-        this.freezePosition = document.documentElement.scrollTop || document.body.scrollTop;
-    }
-
-    @on('mouseleave .option-list')
-    leaveOptionList(e) {
-        if (!e.target.contains(e.relatedTarget)) {
-            delete this.freezePosition;
-        }
-    }
-
-    @on('mousewheel .option-list')
-    wheelScrollOptionList(e) {
-        let el = this.el.querySelector('.option-list');
-        let newY = el.scrollTop + e.deltaY;
-
-        el.scrollTop = newY;
-        e.preventDefault();
-    }
-
     togglePulldown() {
         let optionList = this.el.querySelector('.option-list'),
             isOpen;
@@ -144,11 +123,7 @@ export default class TagMultiSelect extends BaseView {
     }
 
     onRender() {
-        this.attachListenerTo(window, 'scroll', () => {
-            if (this.freezePosition) {
-                window.scrollTo(0, this.freezePosition);
-            }
-        });
+        super.onRender();
         this.el.classList.add('proxy-widget', 'tag-multi-select');
         this.hasDropdownEl = this.el.querySelector('.has-dropdown');
         this.stateCollection.each((model) => {

--- a/src/app/helpers/backbone/view.js
+++ b/src/app/helpers/backbone/view.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import {on} from '~/helpers/backbone/decorators';
 import Backbone from 'backbone';
 import NativeView from 'backbone.nativeview';
 
@@ -73,6 +74,26 @@ class Regions {
 }
 
 class BaseView extends Backbone.View {
+    @on('scroll .mac-scroll')
+    whileScrolling() {
+        this.freezePosition = document.documentElement.scrollTop || document.body.scrollTop;
+    }
+
+    @on('mouseleave .mac-scroll')
+    leaveOptionList(e) {
+        if (!e.target.contains(e.relatedTarget)) {
+            delete this.freezePosition;
+        }
+    }
+
+    @on('mousewheel .mac-scroll')
+    wheelScrollOptionList(e) {
+        let el = this.el.querySelector('.option-list'),
+            delta = e.deltaY || e.wheelDelta / 4;
+
+        el.scrollTop = el.scrollTop + delta;
+        e.preventDefault();
+    }
 
     constructor() {
         super(...arguments);
@@ -224,7 +245,15 @@ class BaseView extends Backbone.View {
 
     onShow() {} // noop
     onBeforeRender() {} // noop
-    onRender() {} // noop
+
+    onRender() {
+        this.attachListenerTo(window, 'scroll', () => {
+            if (this.freezePosition) {
+                window.scrollTo(0, this.freezePosition);
+            }
+        });
+    }
+
     onAfterRender() {} // noop
     onDomRefresh() {} // noop
 

--- a/src/app/pages/details/details.hbs
+++ b/src/app/pages/details/details.hbs
@@ -9,7 +9,7 @@
                     <h1 class="title"></h1>
                     <div class="tabs">
                         <a class="table-of-contents-link" class="tab"><span>Table of Contents</span></a>
-                        <div class="table-of-contents hidden">
+                        <div class="table-of-contents mac-scroll hidden">
                             <div class="box">
                                 <div class="toc-remover"></div>
                                 <ol></ol>

--- a/src/styles/components/option-list.scss
+++ b/src/styles/components/option-list.scss
@@ -20,25 +20,6 @@ $faint-gray: rgba(color(gray), 0.33);
     border-left-color: rgba(color(gray), 0.33);
     box-shadow: 0 0.2rem 0.3rem rgba(color(neutral-lighter), 0.8);
 
-    &::-webkit-scrollbar {
-        -webkit-appearance: none;
-    }
-
-    &::-webkit-scrollbar:vertical {
-        width: 1.1rem;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        border-radius: 0.8rem;
-        border: 0.2rem solid white; /* should match background, can't be transparent */
-        background-color: rgba(0, 0, 0, 0.5);
-    }
-
-    &::-webkit-scrollbar-track {
-        background-color: #fff;
-        border-radius: 0.8rem;
-    }
-
     > .option {
         background-color: color(neutral-lightest);
         font-weight: 600;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -106,6 +106,27 @@ sup {
     overflow: hidden;
 }
 
+.mac-scroll {
+    &::-webkit-scrollbar {
+        -webkit-appearance: none;
+    }
+
+    &::-webkit-scrollbar:vertical {
+        width: 0.8rem;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-color: rgba(color(neutral-darkest), 0.3);
+        border-radius: 0.8rem;
+        border: thin solid color(neutral-lightest);
+    }
+
+    &::-webkit-scrollbar-track {
+        background-color: color(neutral-lightest);
+        border-radius: 0.8rem;
+    }
+}
+
 #main > *,
 .page-header,
 #footer {


### PR DESCRIPTION
Moved Mac scrollbar fix into main.css, attached to `mac-scroll` class
Applied to TOC on details page
Moved freeze-main-window-when-scrolling-popover functionality into
BaseView (requires call to `super.onRender()` in derived class to
activate)