### PR TITLE
Remove scoped from stylesheet

### DIFF
--- a/src/app/components/loading-section/loading-section.hbs
+++ b/src/app/components/loading-section/loading-section.hbs
@@ -1,4 +1,4 @@
-<style scoped>@import url(/app/components/loading-section/loading-section.css);</style>
+<style>@import url(/app/components/loading-section/loading-section.css);</style>
 <div class="os-overlay"></div>
 <div class="os-loader--inner">
 	<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Firefox ignores @keyframes in scoped styles.