### PR TITLE
Route bogus subjects to 404

### DIFF
--- a/src/app/pages/allies/allies.js
+++ b/src/app/pages/allies/allies.js
@@ -8,6 +8,7 @@ import $ from '~/helpers/$';
 import {on, props} from '~/helpers/backbone/decorators';
 import {template} from './allies.hbs';
 import {template as strips} from '~/components/strips/strips.hbs';
+import router from '~/router';
 
 const categories = ['Math', 'Science', 'Social Sciences', 'History', 'AP®'],
     filterButtons = ['View All', ...categories];
@@ -90,6 +91,9 @@ export default class Allies extends LoadingView {
                     selectedFilter = c;
                 }
             }
+            if (selectedFilter === 'View All') {
+                router.navigate('404', true);
+            }
         }
         this.stateModel.set('selectedFilter', selectedFilter);
     }
@@ -109,7 +113,6 @@ export default class Allies extends LoadingView {
     }
 
     onRender() {
-        super.onRender();
         this.el.classList.add('allies-page');
         for (let button of filterButtons) {
             this.regions.filterButtons.append(new FilterButton(button, this.stateModel));
@@ -124,6 +127,7 @@ export default class Allies extends LoadingView {
             });
         }));
         pageDataPromise.then(this.handlePageData.bind(this));
+        super.onRender();
     }
 
     onLoaded() {

--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -13,6 +13,7 @@ import Remover from '~/components/remover/remover';
 import GetThisTitle from '~/components/get-this-title/get-this-title';
 import {template as strips} from '~/components/strips/strips.hbs';
 import settings from 'settings';
+import router from '~/router';
 
 function dataToTemplateHelper(data) {
     let quotes = data.book_quotes[0] || {},
@@ -243,7 +244,7 @@ export default class Details extends LoadingView {
             },
             handleBasicBookData = (data) => {
                 if (data.pages.length === 0) {
-                    window.location.href = '404';
+                    router.navigate('404', true);
                 }
 
                 let detailUrl = data.pages[0].meta.detail_url,
@@ -307,6 +308,7 @@ export default class Details extends LoadingView {
         pageModel.fetch({
             data: {type: 'books.Book', slug}
         }).then(handleBasicBookData.bind(this));
+        super.onRender();
     }
 
     onLoaded() {

--- a/src/app/pages/subjects/subjects.js
+++ b/src/app/pages/subjects/subjects.js
@@ -64,6 +64,9 @@ export default class Subjects extends LoadingView {
                     selectedFilter = c;
                 }
             }
+            if (selectedFilter === 'View All') {
+                router.navigate('404', true);
+            }
         }
         this.model.set('selectedFilter', selectedFilter);
     }
@@ -92,7 +95,6 @@ export default class Subjects extends LoadingView {
     }
 
     onRender() {
-        super.onRender();
         let populateBookInfoFields = (data) => {
             let findNode = (name) => this.el.querySelector(`[data-manager="${name}"]`);
 
@@ -134,5 +136,6 @@ export default class Subjects extends LoadingView {
                 resolve();
             });
         }));
+        super.onRender();
     }
 }


### PR DESCRIPTION
On Allies, Subjects, and Details pages, if an invalid subdirectory is given, route to 404