### PR TITLE
Use previous Gulp 4 commit

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -17,7 +17,6 @@ module.exports = {
     version: project.version,
     license: project.license,
     watchOpts: {
-        useFsEvents: true,
-        awaitWriteFinish: true
+        useFsEvents: true
     }
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "connect-history-api-fallback": "1.2.0",
     "del": "2.2.0",
     "eslint": "2.8.0",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "github:gulpjs/gulp#37dffae33396e67bf8fa01a174d0920f1ff1ae6b",
     "gulp-autoprefixer": "3.1.0",
     "gulp-babel": "6.1.2",
     "gulp-clip-empty-files": "0.1.2",


### PR DESCRIPTION
The latest Gulp 4 commit using the glob-watcher wrapper
around chokidar appears to have broken reloading.

This commit pins to an older version of Gulp 4 until that
bug can be addressed in Gulp or on our end.