### PR TITLE
Fix license display and (again) TOC scrolling

### DIFF
--- a/src/app/helpers/$.js
+++ b/src/app/helpers/$.js
@@ -68,22 +68,9 @@ $.applyScrollFix = (view) => {
                     freezePosition = null;
                 }
             }
-        ),
-        scrollStart,
-        startScrolling = (e) => {
-            scrollStart = e.changedTouches[0].pageY + e.currentTarget.scrollTop;
-        },
-        continueScrolling = (e) => {
-            let el = e.currentTarget,
-                newY = e.targetTouches[0].pageY;
-
-            el.scrollTop = scrollStart - newY;
-            e.preventDefault();
-        };
+        );
 
     for (let el of view.el.querySelectorAll('.mac-scroll')) {
-        view.attachListenerTo(el, 'touchstart', startScrolling);
-        view.attachListenerTo(el, 'touchmove', continueScrolling);
         view.attachListenerTo(el, 'scroll', setFreezePosition);
         view.attachListenerTo(el, 'mouseleave', handleMouseLeave);
         view.attachListenerTo(el, 'mousewheel', handleWheelEvent);

--- a/src/app/pages/details/details.hbs
+++ b/src/app/pages/details/details.hbs
@@ -10,8 +10,8 @@
                 <h1 class="title"></h1>
                 <div class="tabs">
                     <a class="table-of-contents-link" class="tab"><span>Table of Contents</span></a>
-                    <div class="table-of-contents hidden mac-scroll">
-                        <div class="box">
+                    <div class="table-of-contents hidden">
+                        <div class="box mac-scroll">
                             <div class="toc-remover"></div>
                             <ol></ol>
                         </div>

--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -35,15 +35,12 @@
         height: 100%;
         width: 100%;
         z-index: 100;
-        overflow-y: scroll;
         opacity: 1;
         transition: opacity 0.3s;
-        -webkit-overflow-scrolling: touch;
         background-color: rgba(color(neutral-lightest), 0.97);
 
         @include desktop {
             background-color: rgba(color(neutral-dark), 0.93);
-            overflow-y: auto;
         }
 
         ol {
@@ -85,7 +82,6 @@
                 max-width: 60rem;
                 width: 100%;
                 max-height: 50rem;
-                overflow-y: auto;
                 transform: translate3d(-50%, -50%, 0);
             }
 
@@ -519,11 +515,12 @@
 
         th {
             text-align: left;
+            vertical-align: top;
         }
 
         .license {
-            align-items: center;
-            display: flex;
+            display: block;
+            vertical-align: top;
 
             img {
                 height: 4rem;


### PR DESCRIPTION
Made License section display: block
Removed touch handlers and added max-height to scrolling TOC container,
so it would be a scrolling region