### PR TITLE
Ensure strong tag is rendered as bold

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -34,6 +34,10 @@ p {
     margin-bottom: 1rem;
 }
 
+strong {
+    font-weight: bold;
+}
+
 .no-bullets {
     // Hide bullets in IE
     list-style-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);


### PR DESCRIPTION
Firefox by default does not render text in `<strong>` tags as bold.