### PR TITLE
Improve build process

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -3,7 +3,7 @@ var project = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 
 module.exports = {
     get env() {
-        return process.env.NODE_ENV || 'production';
+        return process.env.NODE_ENV;
     },
     get dest() {
         return (process.env.NODE_ENV === 'development' ? 'dev' : 'dist');

--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -13,7 +13,7 @@ function copy() {
     polyfilljs = 'jspm_packages/system-polyfills.js';
 
     return gulp.src([
-        `${config.src}/*.{json,txt,ico}`,
+        `${config.src}/**/*.{json,txt,ico,eot,ttf,woff,woff2}`,
         systemjs,
         polyfilljs
     ])
@@ -23,5 +23,6 @@ function copy() {
 gulp.task(copy);
 
 gulp.task('copy:watch', () => {
-    gulp.watch(`${config.src}/*.{json,txt,ico}`, config.watchOpts, copy);
+    gulp.watch(`${config.src}/*.{json,txt,ico,eot,ttf,woff,woff2}`, config.watchOpts)
+    .on('change', copy);
 });

--- a/gulp/tasks/env.js
+++ b/gulp/tasks/env.js
@@ -1,14 +1,23 @@
 var gulp = require('gulp');
 var pi = require('gulp-load-plugins')();
 
-function development() {
+function nodeEnv(env) {
     pi.env({
         vars: {
-            NODE_ENV: 'development'
+            NODE_ENV: env
         }
     });
 
     return Promise.resolve();
 }
 
+function development() {
+    return nodeEnv('development');
+}
+
+function production() {
+    return nodeEnv('production');
+}
+
 gulp.task(development);
+gulp.task(production);

--- a/gulp/tasks/flags.js
+++ b/gulp/tasks/flags.js
@@ -1,0 +1,23 @@
+var gulp = require('gulp');
+var argv = require('yargs').argv;
+var pi = require('gulp-load-plugins')();
+
+function flags() {
+    var env = process.env.NODE_ENV;
+
+    if (argv.production) {
+        env = 'production';
+    } else if (argv.development) {
+        env = 'development';
+    }
+
+    pi.env({
+        vars: {
+            NODE_ENV: env
+        }
+    });
+
+    return Promise.resolve();
+}
+
+gulp.task(flags);

--- a/gulp/tasks/html.js
+++ b/gulp/tasks/html.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp');
 var config = require('../config');
+var bs = require('browser-sync').get(config.name);
 var pi = require('gulp-load-plugins')();
 
 function html() {
@@ -16,5 +17,9 @@ function html() {
 gulp.task(html);
 
 gulp.task('html:watch', () => {
-    gulp.watch(`${config.src}/**/*.html`, config.watchOpts, html);
+    gulp.watch(`${config.src}/**/*.html`, config.watchOpts)
+    .on('change', gulp.series(
+        html,
+        bs.reload
+    ));
 });

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,4 +1,5 @@
 var gulp = require('gulp');
+var argv = require('yargs').argv;
 var config = require('../config');
 var pi = require('gulp-load-plugins')({
     pattern: ['gulp-*', 'gulp.*', 'del']
@@ -8,7 +9,7 @@ function images() {
     return gulp.src(`${config.src}/**/*.{png,jpg,jpeg,gif,svg,mp4}`, {
         since: gulp.lastRun('images')
     })
-    .pipe(pi.if(config.env === 'production', pi.imagemin({
+    .pipe(pi.if(argv.images === 'min', pi.imagemin({
         progressive: true,
         interlaced: true,
         optimizationLevel: 7,
@@ -23,5 +24,6 @@ function images() {
 gulp.task(images);
 
 gulp.task('images:watch', () => {
-    gulp.watch(`${config.src}/**/*.{png,jpg,jpeg,gif,svg,mp4}`, config.watchOpts, images);
+    gulp.watch(`${config.src}/**/*.{png,jpg,jpeg,gif,svg,mp4}`, config.watchOpts)
+    .on('change', images);
 });

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -197,7 +197,8 @@ gulp.task('scripts', gulp.series(
 ));
 
 gulp.task('scripts:watch', () => {
-    gulp.watch(`${config.src}/**/*.js`, config.watchOpts, gulp.series(
+    gulp.watch(`${config.src}/**/*.js`, config.watchOpts)
+    .on('change', gulp.series(
         eslint,
         compileScripts,
         bs.reload

--- a/gulp/tasks/service-worker.js
+++ b/gulp/tasks/service-worker.js
@@ -37,6 +37,9 @@ function precache() {
 
 gulp.task(precache);
 
-gulp.task('precache:watch', () => {
-    gulp.watch(shellFiles.map((uri) => `${config.dest}${uri}`), config.watchOpts, precache);
+gulp.task('scripts:watch', () => {
+    gulp.watch(shellFiles.map((uri) => `${config.dest}${uri}`), config.watchOpts)
+    .on('change', gulp.series(
+        precache
+    ));
 });

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -62,10 +62,8 @@ function compileStyles(src, dest) {
             includeContent: false,
             sourceRoot: './'
         })))
-        .pipe(gulp.dest(dest || config.dest));
-        // BrowserSync currently doesn't support injecting @import'ed CSS files
-        // See: https://github.com/BrowserSync/browser-sync/issues/10
-        // .pipe(bs.stream({match: '**/*.css'}));
+        .pipe(gulp.dest(dest || config.dest))
+        .pipe(bs.stream({match: '**/*.css'}));
 }
 
 function compileAllStyles() {
@@ -104,29 +102,25 @@ gulp.task('styles:watch', () => {
     gulp.watch([
         `${config.src}/**/*.scss`,
         `!${config.src}/styles/{components,mixins,variables}/**/*.scss`
-    ], config.watchOpts, gulp.series(
+    ], config.watchOpts)
+    .on('change', gulp.series(
         scsslint,
-        compileChangedStyles,
-        bs.reload // Only necessary if BS stream isn't piped in above
+        compileChangedStyles
     ));
 });
 
 gulp.task('component-styles:watch', () => {
-    gulp.watch([
-        `${config.src}/styles/components/**/*.scss`
-    ], config.watchOpts, gulp.series(
+    gulp.watch(`${config.src}/styles/components/**/*.scss`, config.watchOpts)
+    .on('change', gulp.series(
         scsslint,
-        compileMainStyle,
-        bs.reload // Only necessary if BS stream isn't piped in above
+        compileMainStyle
     ));
 });
 
 gulp.task('fundamental-styles:watch', () => {
-    gulp.watch([
-        `${config.src}/styles/{mixins,variables}/**/*.scss`
-    ], config.watchOpts, gulp.series(
+    gulp.watch(`${config.src}/styles/{mixins,variables}/**/*.scss`, config.watchOpts)
+    .on('change', gulp.series(
         scsslint,
-        compileAllStyles,
-        bs.reload // Only necessary if BS stream isn't piped in above
+        compileAllStyles
     ));
 });

--- a/gulp/tasks/systemjs-builder.js
+++ b/gulp/tasks/systemjs-builder.js
@@ -2,6 +2,7 @@
 var path = require('path');
 var gulp = require('gulp');
 var config = require('../config');
+var bs = require('browser-sync').get(config.name);
 var Builder = require('systemjs-builder');
 
 function systemjs() {
@@ -33,4 +34,12 @@ gulp.task(systemjs);
 
 gulp.task('systemjs:watch', () => {
     gulp.watch('./jspm_packages/**/*', config.watchOpts, systemjs);
+});
+
+gulp.task('systemjs:watch', () => {
+    gulp.watch('./jspm_packages/**/*', config.watchOpts)
+    .on('change', gulp.series(
+        systemjs,
+        bs.reload
+    ));
 });

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -74,7 +74,8 @@ gulp.task('templates', gulp.parallel(
 ));
 
 gulp.task('templates:watch', () => {
-    gulp.watch(`${config.src}/**/*.part.hbs`, config.watchOpts, gulp.series(
+    gulp.watch(`${config.src}/**/*.part.hbs`, config.watchOpts)
+    .on('change', gulp.series(
         precompilePartials,
         bs.reload
     ));
@@ -82,7 +83,8 @@ gulp.task('templates:watch', () => {
     gulp.watch([
         `${config.src}/**/*.hbs`,
         `!${config.src}/**/*.part.hbs`
-    ], config.watchOpts, gulp.series(
+    ], config.watchOpts)
+    .on('change', gulp.series(
         precompileTemplates,
         bs.reload
     ));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ require('require-dir')('./gulp/tasks', {recurse: true});
 
 gulp.task('default', gulp.series(
     'clean',
+    'flags',
     gulp.parallel(
         'copy',
         'html',
@@ -11,9 +12,7 @@ gulp.task('default', gulp.series(
         'templates',
         'images'
     ),
-    'systemjs',
-    'precache',
-    'minify-scripts'
+    'systemjs'
 ));
 
 gulp.task('dev', gulp.series(
@@ -22,7 +21,12 @@ gulp.task('dev', gulp.series(
     'watch'
 ));
 
-gulp.task('dist', gulp.series('default'));
+gulp.task('dist', gulp.series(
+    'production',
+    'default',
+    'minify-scripts',
+    'precache'
+));
 
 gulp.task('lint', gulp.parallel(
     'scsslint',

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "connect-history-api-fallback": "1.2.0",
     "del": "2.2.0",
     "eslint": "2.8.0",
-    "gulp": "github:gulpjs/gulp#37dffae33396e67bf8fa01a174d0920f1ff1ae6b",
+    "gulp": "github:gulpjs/gulp#4.0",
     "gulp-autoprefixer": "3.1.0",
     "gulp-babel": "6.1.2",
     "gulp-clip-empty-files": "0.1.2",
@@ -55,7 +55,8 @@
     "jspm": "0.16.33",
     "require-dir": "0.3.0",
     "sw-precache": "3.1.1",
-    "systemjs-builder": "0.15.15"
+    "systemjs-builder": "0.15.15",
+    "yargs": "4.6.0"
   },
   "jspm": {
     "directories": {


### PR DESCRIPTION
 - Only minify images with flag `--images=min`
   - MUCH faster dist builds
 - Fix how tasks are watched with gulp 4
 - Support `--production` and `--development` flags
 - Stream CSS changes rather than reloading browser (depends on #309)