### PR TITLE
Fix bugs on Impact, K-12, Foundation & Higher-Ed

### DIFF
--- a/src/app/pages/foundation/foundation.scss
+++ b/src/app/pages/foundation/foundation.scss
@@ -46,7 +46,7 @@ $text-black2: rgba(0, 0, 0, 0.7);
     }
 
     .funder {
-        align-items: center;
+        align-items: left;
         background-color: color(neutral-lightest);
         color: $text-black2;
         display: flex;
@@ -57,6 +57,7 @@ $text-black2: rgba(0, 0, 0, 0.7);
         padding: 3rem;
 
         @include desktop {
+            align-items: center;
             flex-flow: row nowrap;
         }
 
@@ -66,10 +67,11 @@ $text-black2: rgba(0, 0, 0, 0.7);
         }
 
         .logo {
-            flex: 0 0 25%;
+            flex: 0 0 auto;
             margin-bottom: 3rem;
 
             @include desktop {
+                flex: 0 0 25%;
                 margin-bottom: 0;
                 margin-right: 3rem;
             }

--- a/src/app/pages/higher-ed/higher-ed.hbs
+++ b/src/app/pages/higher-ed/higher-ed.hbs
@@ -5,13 +5,13 @@
                 <div class="student"></div>
                 <div class="overlay">
                     <div class="text-block">
-                        <h1 class="header">Free textbooks. High quality. No catch.</h1>
-                        <div class="blurb">
+                        <h1 class="header">Free textbooks.<br> High quality.<br> No catch.</h1>
+                        <p class="blurb">
                             Some of the most valuable investments don't have a price tag.
                             Neither do our textbooks. Our free, high-quality textbooks and
                             learning technology give students the tools they need to
                             succeed without having to weigh the cost.
-                        </div>
+                        </p>
                     </div>
                 </div>
             </div>

--- a/src/app/pages/higher-ed/higher-ed.scss
+++ b/src/app/pages/higher-ed/higher-ed.scss
@@ -39,7 +39,7 @@ $hero-break-width: 880px;
         @include collapsed {
             align-items: stretch;
             background: none;
-            height: calc(100vh - 6rem);
+//            height: calc(100vh - 6rem);
             max-height: 53rem;
         }
 

--- a/src/app/pages/impact/impact.hbs
+++ b/src/app/pages/impact/impact.hbs
@@ -8,16 +8,17 @@
                 <div class="overlay">
                     <div class="text-block">
                         <h1 class="header">We measure our success in access.</h1>
-                        <div class="blurb">
+                        <p class="blurb">
                             Since 2012, OpenStax has saved students $66 million and counting by offering free,
                             peer-reviewed textbooks for the highest-enrollment college courses.
                             Meet the schools who’ve adopted OpenStax and some of the students who’ve benefited
                             from free access to the learning materials they need to succeed.
-                        </div>
+                        </p>
                     </div>
                 </div>
             </div>
         </div>
+        {{{strips}}}
         <span class="scrolldown-chevron"><a href="#affiliates"><i class="fa fa-chevron-down"></i></a></span>
 
         <div id="affiliates" class="affiliates">
@@ -41,9 +42,7 @@
                 {{/each}}
             </ul>
 
-            <div class="adopters"><a href="/adopters">See a full list of institutions that have adopted OpenStax</a></div>
+            <div class="adopters"><a href="/adopters">See a full list of institutions that have adopted OpenStax<i></i></a></div>
         </div>
     </main>
-
-    {{{strips}}}
 </div>

--- a/src/app/pages/impact/impact.scss
+++ b/src/app/pages/impact/impact.scss
@@ -32,7 +32,7 @@ $hero-break-width: 880px;
         @include collapsed {
             align-items: stretch;
             background: none;
-            height: calc(100vh - 6rem);
+//            height: calc(100vh - 6rem);
             max-height: 53rem;
         }
 
@@ -190,17 +190,22 @@ $hero-break-width: 880px;
             margin: 0 auto;
             padding: 5rem 0;
             width: 78vw;
+
+            @include phone {
+                width: 100%;
+                padding: 5rem 1.5rem;
+            }
         }
 
         .partners {
             align-items: center;
-            border-bottom: 0.4rem solid rgba(color(neutral-light), 0.30);
-            border-top: 0.4rem solid rgba(color(neutral-light), 0.30);
+            border-bottom: 0.4rem solid rgba(color(neutral-light), 0.10);
+            border-top: 0.4rem solid rgba(color(neutral-light), 0.10);
             display: flex;
             flex-wrap: wrap;
             justify-content: space-between;
             margin: auto;
-            max-width: 100rem;
+            max-width: $boxed-width;
             padding: 1.5rem 0 0;
 
             @media (max-width: $breakpoint-1) {
@@ -208,7 +213,12 @@ $hero-break-width: 880px;
             }
 
             > li {
-                margin: 4rem;
+                padding: 4rem;
+                flex: 1 1 20%;
+
+                @media (max-width: $hero-break-width) {
+                    flex: 1 1 auto;
+                }
 
                 a {
                     transition: All ease-in-out 0.3s;
@@ -226,7 +236,7 @@ $hero-break-width: 880px;
         }
 
         .adopters {
-            padding: 4rem 0 5rem;
+            padding: 4rem 1.5rem 5rem;
 
             a {
                 font-size: 1.4rem;
@@ -234,14 +244,19 @@ $hero-break-width: 880px;
                 position: relative;
                 text-transform: uppercase;
 
-                &::after {
-                    @include triangle(
-                        $direction: right,
-                        $position: top 0.42rem right -1.6rem,
-                        $color: color(cyan),
-                        $size: 0.5rem
-                    );
+                i {
+                    position: relative;
+
+                    &::after {
+                        @include triangle(
+                            $direction: right,
+                            $position: top 0.32rem right -1.6rem,
+                            $color: color(cyan),
+                            $size: 0.5rem
+                        );
+                    }
                 }
+
             }
         }
     }

--- a/src/app/pages/k-12/hero/hero.scss
+++ b/src/app/pages/k-12/hero/hero.scss
@@ -27,8 +27,8 @@ $hero-break-width: 880px;
         @include collapsed {
             align-items: stretch;
             background: none;
-            height: calc(100vh - 6rem);
-            max-height: 53rem;
+//            height: calc(100vh - 6rem);
+            max-height: 48rem;
         }
 
         > div {

--- a/src/styles/components/hero.scss
+++ b/src/styles/components/hero.scss
@@ -14,6 +14,10 @@
         text-align: left;
     }
 
+    @include tablet {
+        text-align: left;
+    }
+
     &.w-cards {
         padding: 1.5rem;
     }


### PR DESCRIPTION
- [x] Added `$boxed-width`  to Impact page logo's container 
- [x] Removed `vh` from all Pages with Hero. It caused the banner to jump in Android.
- [x] Fixed Foundations' page logo overlap in IOS.
- [x] Adjust H1 `line-height` in **hero.sccs**