### PR TITLE
Upgrade to Font Awesome 4.6.1

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@
         <link type="image/png" rel="icon" href="/images/icons/favicon-64x64.png" sizes="64x64">
 
         <link href='https://fonts.googleapis.com/css?family=Permanent+Marker' rel='stylesheet' type='text/css'>
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
         <link rel="stylesheet" href="/styles/main.css">
 
         <script src="https://cdn.rawgit.com/eligrey/classList.js/e87db36a95b2381a8c3ed44582a3926185cede70/classList.min.js"></script>


### PR DESCRIPTION
Fixes a warning about improper CSS in Safari and iOS due to IE8 hacks in Font Awesome.