### PR TITLE
Fix finish-profile submit button overlap problem

### DIFF
--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -264,7 +264,7 @@ export default class Details extends LoadingView {
                             this.regions.allAuthors.append(new Author(author));
                         }
                         this.el.querySelector('.book-cover').src = th.coverUrl;
-                        this.el.querySelector('.book-info .title').textContent = th.title;
+                        this.el.querySelector('.book-info .title').innerHTML = th.title;
                         this.el.querySelector('.book-info .blurb').innerHTML = th.description;
                         handleEndorsement(th);
                         this.gtt = new GetThisTitle(detailData);

--- a/src/app/pages/finish-profile/finish-profile.scss
+++ b/src/app/pages/finish-profile/finish-profile.scss
@@ -51,10 +51,9 @@
 
         &.faculty .cta {
             @media (min-width: 481px) {
-                margin-top: -10rem;
-                padding-bottom: 8rem;
+                float: right;
+                top: -10rem;
                 position: relative;
-                z-index: -1;
             }
         }
     }


### PR DESCRIPTION
Float it instead of having a full-width div
Also: modify details title to accept HTML so `<sup>` can be used with
AP books