### PR TITLE
Set login/logout links in template

### DIFF
--- a/src/app/components/shell/header/header.hbs
+++ b/src/app/components/shell/header/header.hbs
@@ -8,11 +8,11 @@
             <ul class="nav-menu meta-menu no-bullets" role="menu" aria-label="Meta navigation menu">
                 <li class="nav-menu-item"><a href="/about-us" role="menuitem">About Us</a></li>
                 <li class="nav-menu-item"><a href="/contact" role="menuitem">Contact</a></li>
-                <li class="nav-menu-item login"><a href="#" role="menuitem">Login<svg width="0" class="chevron" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 30"><title>arrow</title><path d="M12,1L26,16,12,31,8,27,18,16,8,5Z" transform="translate(-8 -1)"/></svg></a>
+                <li class="nav-menu-item login"><a href="{{login}}" data-local="true" role="menuitem">Login<svg width="0" class="chevron" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 30"><title>arrow</title><path d="M12,1L26,16,12,31,8,27,18,16,8,5Z" transform="translate(-8 -1)"/></svg></a>
                     <ul class="dropdown-menu" role="menu" aria-expanded="false" aria-label="User Menu">
                         <li role="presentation"><a data-href-setting="account-href" role="menuitem" tabindex="-1">Account Profile</a></li>
                         <li role="presentation" class="non-faculty"><a href="/faculty-verification" role="menuitem" tabindex="-1">Request instructor access</a></li>
-                        <li role="presentation" class="logout"><a href="#" role="menuitem" tabindex="-1">Logout</a></li>
+                        <li role="presentation" class="logout"><a href="{{logout}}" data-local="true" role="menuitem" tabindex="-1">Logout</a></li>
                     </ul>
                 </li>
             </ul>

--- a/src/app/components/shell/header/header.js
+++ b/src/app/components/shell/header/header.js
@@ -19,10 +19,17 @@ class Header extends BaseView {
 
         this.meta = {};
 
-        this.templateHelpers = {
-            visible: () => this.meta.visible,
-            fixed: () => this.meta.fixed,
-            transparent: () => this.meta.transparent
+        this.templateHelpers = () => {
+            let accounts = `${settings.apiOrigin}/accounts`;
+            let currentPage = Backbone.history.location.href;
+
+            return {
+                visible: () => this.meta.visible,
+                fixed: () => this.meta.fixed,
+                transparent: () => this.meta.transparent,
+                login: `${accounts}/login/openstax/?next=${currentPage}`,
+                logout: `${accounts}/logout/?next=${currentPage}`
+            };
         };
     }
 
@@ -221,30 +228,6 @@ class Header extends BaseView {
         }
     }
 
-    appendURL() {
-        let loginEl = this.el.querySelector('.login>a');
-        let loginLink = `${settings.apiOrigin}/accounts/login/openstax/?next=`;
-        let loginHref = loginLink + Backbone.history.location.href;
-
-        loginEl.href = loginHref;
-
-        let logoutEl = this.el.querySelector('.logout>a');
-        let logoutLink = `${settings.apiOrigin}/accounts/logout/?next=`;
-        let logoutHref = logoutLink + Backbone.history.location.href;
-
-        logoutEl.href = logoutHref;
-    }
-
-    openLinkSameWindow(e) {
-        e.preventDefault(e);
-        window.open(e.target, '_self');
-    }
-
-    @on('click .logout a')
-    appendLogoutURL(e) {
-        this.openLinkSameWindow(e);
-    }
-
     @on('keydown .expand')
     onKeydownToggleFullScreenNav(e) {
         if (document.activeElement === e.currentTarget && (e.keyCode === 13 || e.keyCode === 32)) {
@@ -372,11 +355,9 @@ class Header extends BaseView {
                 this.attachListenerTo(loginItem, 'click', this.flyOutMenu.bind(this));
             } else {
                 loginItem.firstChild.textContent = 'Login';
-                this.attachListenerTo(loginItem, 'click', this.openLinkSameWindow.bind(this));
             }
         });
         this.updateHeaderStyle();
-        this.appendURL();
         this.el.querySelector('[data-href-setting="account-href"]').href = settings.accountHref;
         this.attachListenerTo(document, 'click', this.resetHeader.bind(this), true);
         this.attachListenerTo(window, 'scroll', () =>


### PR DESCRIPTION
This allows some unnecessary event handlers to be removed, cleans up the template code, and fixes clicking the login/logout links in Edge.