### PR TITLE
force fonts to use secure connection

### DIFF
--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,5 +1,5 @@
 
-@import url("//fast.fonts.net/t/1.css?apiType=css&projectid=437b6557-ce99-4f35-97ff-64a93247731f");
+@import url("https://fast.fonts.net/t/1.css?apiType=css&projectid=437b6557-ce99-4f35-97ff-64a93247731f");
 @font-face{
 font-family:"Neue Helvetica W01_n1";
 src:url("fonts/c0c7b087-4dbd-4c75-8acc-8f4444b2ee1d.eot?#iefix") format("eot")


### PR DESCRIPTION
change fonts.com import link from `//` to `https://`