### PR TITLE
Stop using query string on details page

### DIFF
--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -104,7 +104,7 @@ export default class Details extends LoadingView {
         this.toggleFixedClass();
         this.attachListenerTo(window, 'scroll', this.toggleFixedClass.bind(this));
 
-        let slug = decodeURIComponent(window.location.search.substr(1)),
+        let slug = window.location.pathname.replace(/.*\//, ''),
             pageModel = new PageModel(),
             insertResources = (resources, regionName, alternateLink) => {
                 for (let res of resources) {
@@ -112,13 +112,8 @@ export default class Details extends LoadingView {
                         this.regions[regionName].append(new Resource(res, alternateLink));
                     }
                 }
-            };
-
-        if (slug === '') {
-            slug = window.location.pathname.replace(/.*\//, '');
-        }
-
-        let showInstructorResources = (resources) => {
+            },
+            showInstructorResources = (resources) => {
                 userModel.fetch().then((userData) => {
                     let userInfo = userData[0],
                         alternateLink = null,

--- a/src/app/pages/home/banners/us-history/us-history.hbs
+++ b/src/app/pages/home/banners/us-history/us-history.hbs
@@ -20,7 +20,7 @@
         <div class="subject-links flyout">
             <ul>
                 <li>
-                    <a class="btn btn-large btn-orange explore-subject" href="/details?us-history">
+                    <a class="btn btn-large btn-orange explore-subject" href="/details/us-history">
                         Explore U.S. History
                     </a>
                 </li>

--- a/src/app/pages/subjects/category-section/book/book.hbs
+++ b/src/app/pages/subjects/category-section/book/book.hbs
@@ -2,6 +2,6 @@
 <div class="details">
     <div class="get-this-title-container"></div>
     <div class="cta">
-        <a href="/details?{{slug}}" class="btn">details &amp; resources</a>
+        <a href="/details/{{slug}}" class="btn">details &amp; resources</a>
     </div>
 </div>

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -16,7 +16,6 @@ const PAGES = [
     'contact',
     'contact-thank-you',
     'details',
-    'details',
     'faculty-confirmation',
     'faculty-verification',
     'finish-profile',


### PR DESCRIPTION
Was accepting details/subject or details?subject
This made email links they want to use not workable