### PR TITLE
Improve resizing of blocks

### DIFF
--- a/src/app/pages/about-us/about-us.scss
+++ b/src/app/pages/about-us/about-us.scss
@@ -280,11 +280,11 @@
             padding: 3rem 0;
             margin-top: 3rem;
             opacity: 1;
-            width: calc(100vw - 4rem);
+            width: calc(100vw - 3rem);
             overflow: visible;
             position: absolute;
             bottom: auto;
-            left: -113%;
+            left: -109%;
             top: 18rem;
             right: auto;
             display: flex;
@@ -488,48 +488,26 @@
 
     .strategic-advisors {
         .headshot {
-            flex: 0 0 49%;
+            flex: 0 0 100%;
 
-            @media (max-width: 400px) {
-                flex: 0 0 100%;
-            }
-
-            @include phone {
-                width: 50%;
+            @media (min-width: 400px) {
+                flex-basis: 48%;
             }
 
             @include tablet {
-                flex: 0 0 30%;
-                margin-right: 1rem;
+                flex-basis: 31.5%;
             }
 
             @include desktop {
-                width: 17.5rem;
-                flex: 0 0 auto;
+                flex-basis: 23.5%;
             }
 
-            &:nth-child(odd) {
-                .picture-area {
-                    @include phone {
-                        margin-right: 1.25rem;
-                    }
-
-                    @media (max-width: 400px) {
-                        margin-right: 0;
-                    }
-                }
+            @media (min-width: 955px) {
+                flex-basis: 18.5%;
             }
 
-            &:nth-child(even) {
-                .picture-area {
-                    @include phone {
-                        margin-left: 1.25rem;
-                    }
-
-                    @media (max-width: 400px) {
-                        margin-left: 0;
-                    }
-                }
+            @media (min-width: 1140px) {
+                flex-basis: 15%;
             }
 
             .remover {
@@ -595,7 +573,7 @@
     .strategic-advisors .headshot.tapped .details {
         @include tablet {
             top: auto;
-            bottom: 26rem;
+            bottom: 100%;
 
             &::before {
                 border-color: color(neutral-lightest) transparent transparent;

--- a/src/app/pages/about-us/about-us.scss
+++ b/src/app/pages/about-us/about-us.scss
@@ -69,10 +69,7 @@
         display: flex;
         flex-flow: row wrap;
         position: relative;
-
-        @include tablet {
-            justify-content: space-between;
-        }
+        justify-content: space-between;
 
         .headshot {
             cursor: pointer;
@@ -335,46 +332,28 @@
     .our-team .headshot {
         display: flex;
         flex-flow: column nowrap;
-        flex: 0 0 50%;
+        flex: 0 0 100%;
+        justify-content: space-between;
         height: 25rem;
-        width: 100%;
 
-        @media (max-width: 400px) {
-            flex: 0 0 100%;
+        @media (min-width: 400px) {
+            flex-basis: 48%;
         }
 
         @include tablet {
-            flex: 0 0 30%;
-            margin-right: 1rem;
+            flex-basis: 31.5%;
         }
 
         @include desktop {
-            width: 17.5rem;
-            flex: 0 0 auto;
+            flex-basis: 23.5%;
         }
 
-        &:nth-child(odd) {
-            .picture-area {
-                @include phone {
-                    margin-right: 1.25rem;
-                }
-
-                @media (max-width: 400px) {
-                    margin-right: 0;
-                }
-            }
+        @media (min-width: 955px) {
+            flex-basis: 18.5%;
         }
 
-        &:nth-child(even) {
-            .picture-area {
-                @include phone {
-                    margin-left: 1.25rem;
-                }
-
-                @media (max-width: 400px) {
-                    margin-left: 0;
-                }
-            }
+        @media (min-width: 1140px) {
+            flex-basis: 15%;
         }
 
         &.hidden {

--- a/src/app/pages/about-us/headshot/headshot.js
+++ b/src/app/pages/about-us/headshot/headshot.js
@@ -28,7 +28,7 @@ export default class Headshot extends BaseView {
     }
 
     isNarrowScreen() {
-        return window.innerWidth < 500;
+        return window.innerWidth <= 500;
     }
 
     @on('click')

--- a/src/app/pages/subjects/subjects.hbs
+++ b/src/app/pages/subjects/subjects.hbs
@@ -6,7 +6,7 @@
         <div class="filter">
             <div class="filter-buttons"></div>
         </div>
-        <div class="container"></div>
+        <div class="container row-container"></div>
         <div class="feature-block">
             <div class="container">
                 <h2>About Our Textbooks</h2>

--- a/src/app/pages/subjects/subjects.hbs
+++ b/src/app/pages/subjects/subjects.hbs
@@ -6,7 +6,7 @@
         <div class="filter">
             <div class="filter-buttons"></div>
         </div>
-        <div class="container row-container"></div>
+        <div class="container"></div>
         <div class="feature-block">
             <div class="container">
                 <h2>About Our Textbooks</h2>

--- a/src/app/pages/subjects/subjects.scss
+++ b/src/app/pages/subjects/subjects.scss
@@ -14,6 +14,14 @@
         @include phone {
             display: block;
         }
+
+        @media (min-width: $boxed-width) {
+            padding: 0;
+
+            &.row-container {
+                max-width: calc(#{$boxed-width} + 3rem);
+            }
+        }
     }
 
     .container[data-manager="page-description"] {
@@ -21,6 +29,11 @@
 
         @include desktop {
             text-align: center;
+        }
+
+        @media (min-width: $boxed-width) {
+            padding-left: 0;
+            padding-right: 0;
         }
 
         h2 {
@@ -115,32 +128,31 @@
         .row {
             display: flex;
             flex-flow: row wrap;
-            justify-content: space-around;
+            justify-content: flex-start;
             margin: 0 -1rem;
-            width: 100%;
-
-            @include tablet {
-                justify-content: space-between;
-            }
-
-            @include desktop {
-                justify-content: flex-start;
-            }
+            width: calc(100% + 2rem);
         }
 
         .cover {
-            width: 21rem;
-            margin: 1rem;
-            flex: 1 100%;
-            position: relative;
             cursor: pointer;
+            flex: 0 100%;
+            margin: 1rem;
+            position: relative;
 
-            @include tablet {
-                flex: 0 45%;
+            @media (min-width: $boxed-width - 660) {
+                flex-basis: calc(50% - 2rem);
             }
 
-            @include desktop {
-                flex: 0 auto;
+            @media (min-width: $boxed-width - 440) {
+                flex-basis: calc(33.3% - 2rem);
+            }
+
+            @media (min-width: $boxed-width - 220) {
+                flex-basis: calc(25% - 2rem);
+            }
+
+            @media (min-width: $boxed-width) {
+                flex-basis: calc(20% - 2rem);
             }
 
             &.coming-soon::before {
@@ -173,6 +185,14 @@
                 left: 50%;
                 margin-left: -2rem;
                 position: absolute;
+            }
+
+            .remover {
+                @include absolute(top 1.84rem right -0.8rem);
+
+                > i {
+                    color: color(neutral-dark);
+                }
             }
 
             .cta > .btn {

--- a/src/app/pages/subjects/subjects.scss
+++ b/src/app/pages/subjects/subjects.scss
@@ -14,14 +14,6 @@
         @include phone {
             display: block;
         }
-
-        @media (min-width: $boxed-width) {
-            padding: 0;
-
-            &.row-container {
-                max-width: calc(#{$boxed-width} + 3rem);
-            }
-        }
     }
 
     .container[data-manager="page-description"] {
@@ -29,11 +21,6 @@
 
         @include desktop {
             text-align: center;
-        }
-
-        @media (min-width: $boxed-width) {
-            padding-left: 0;
-            padding-right: 0;
         }
 
         h2 {
@@ -44,6 +31,12 @@
 
         p {
             font-size: 1.8rem;
+
+            @include desktop {
+                width: 80%;
+                margin-left: auto;
+                margin-right: auto;
+            }
         }
     }
 
@@ -169,8 +162,8 @@
             height: 0;
             overflow: hidden;
             position: absolute;
-            top: 98%;
-            left: -10%;
+            top: 95%;
+            left: -5%;
             background: color(neutral-lightest);
             transform: translate3d(0, -1rem, 0);
             opacity: 0;
@@ -187,19 +180,12 @@
                 position: absolute;
             }
 
-            .remover {
-                @include absolute(top 1.84rem right -0.8rem);
-
-                > i {
-                    color: color(neutral-dark);
-                }
-            }
-
             .cta > .btn {
                 width: 100%;
                 font-variant: normal;
                 padding: 1.5rem;
                 text-transform: uppercase;
+                font-weight: 400;
             }
 
             .cta > .btn:hover,
@@ -212,7 +198,7 @@
         .cover:hover .details {
             @include desktop {
                 overflow: initial;
-                width: 120%;
+                width: 110%;
                 height: auto;
                 opacity: 1;
                 transform: translate3d(0, 0, 0);


### PR DESCRIPTION
Make Book covers on Subjects page and color blocks on About Us resize
to keep limited between-block margins, and span the width of the screen
(up to 1200)