### PR TITLE
Include hashclicks in history

### DIFF
--- a/src/app/components/shell/shell.js
+++ b/src/app/components/shell/shell.js
@@ -31,29 +31,29 @@ class AppView extends BaseView {
 
         // Lazy-load the page
         System.import(`~/pages/${pageName}/${pageName}`).then((m) => {
-            let Page = m.default;
+            let Page = m.default,
+                view = new Page(options),
+                hash = window.location.hash,
+                scrollToDestination = () => {
+                    let destination = document.getElementById(hash.substr(1));
+
+                    if (destination) {
+                        $.scrollTo(destination);
+                    }
+                };
 
             this.regions.header.show(header);
-            this.regions.main.show(new Page(options));
+            this.regions.main.show(view);
             this.regions.footer.show(footer);
             headTitle.textContent = `${pageName[0].toUpperCase()}${pageName.slice(1)} - OpenStax`;
             zendesk();
 
-            let hash = window.location.hash;
-
             if (hash) {
-                let attempts = 0,
-                    i = setInterval(() => {
-                        let destination = document.getElementById(hash.substr(1));
-
-                        if (destination) {
-                            $.scrollTo(destination);
-                        }
-                        ++attempts;
-                        if (attempts > 6) {
-                            clearInterval(i);
-                        }
-                    }, 200);
+                if ('isLoaded' in view) {
+                    view.isLoaded.then(scrollToDestination);
+                } else {
+                    scrollToDestination();
+                }
             } else {
                 window.scrollTo(0, 0);
             }

--- a/src/app/helpers/$.js
+++ b/src/app/helpers/$.js
@@ -17,21 +17,16 @@ $.isTouchDevice = () => (
  );
 
 const tick = 1000 / 40,
-    defaultStep = 200,
     spaceForMenu = 59,
-    maxTicks = 20;
+    targetStep = 200,
+    targetTicks = 20;
 
-$.scrollTo = (el, customStep, offset = 0) => {
+$.scrollTo = (el, offset = 0) => {
     let rect = el.getBoundingClientRect(),
         offsetTop = rect.top - spaceForMenu - offset,
         direction = Math.sign(offsetTop),
         magnitude = Math.abs(offsetTop),
-        chosenStep = customStep || defaultStep,
-        tickCount = magnitude / chosenStep;
-
-    if (tickCount > maxTicks) {
-        chosenStep = magnitude / maxTicks;
-    }
+        chosenStep = (targetStep + magnitude / targetTicks) / 2;
 
     let i = setInterval(() => {
         let step = (magnitude > chosenStep) ? chosenStep : magnitude,
@@ -95,14 +90,16 @@ $.applyScrollFix = (view) => {
     });
 };
 
-$.hashTarget = (event) => {
-    let node = event.target;
+$.hashClick = (event, options = {doHistory: true}) => {
+    let node = event.currentTarget,
+        destUrl = `${node.pathname}${node.hash}`,
+        targetEl = document.getElementById(node.hash.substr(1));
 
-    while (node.tagName !== 'A') {
-        node = node.parentNode;
+    $.scrollTo(targetEl);
+    if (options.doHistory) {
+        history.pushState({}, '', destUrl);
     }
-
-    return document.getElementById(node.hash.substr(1));
+    event.preventDefault();
 };
 
 export default $;

--- a/src/app/helpers/backbone/loading-view.js
+++ b/src/app/helpers/backbone/loading-view.js
@@ -46,12 +46,16 @@ class LoadingView extends BaseView {
         this.otherPromises = [];
         this.subviewPromises = [];
         this.loadingSection = new LoadingSection();
+        this.isLoaded = new Promise((resolve) => {
+            this.resolveLoaded = resolve;
+        });
     }
 
     onLoaded() {
         document.getElementById('header').classList.remove('hidden');
         document.getElementById('footer').classList.remove('hidden');
         this.loadingSection.remove();
+        this.resolveLoaded();
     }
 
     onRender() {

--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -50,8 +50,7 @@ function dataToTemplateHelper(data) {
 export default class Details extends LoadingView {
     @on('click a[href^="#"]')
     hashClick(e) {
-        $.scrollTo($.hashTarget(e));
-        e.preventDefault();
+        $.hashClick(e);
     }
 
     @on('click .table-of-contents-link')

--- a/src/app/pages/higher-ed/higher-ed.js
+++ b/src/app/pages/higher-ed/higher-ed.js
@@ -26,8 +26,7 @@ export default class HigherEd extends BaseView {
 
     @on('click a[href^="#"]')
     hashClick(e) {
-        $.scrollTo($.hashTarget(e));
-        e.preventDefault();
+        $.hashClick(e, {doHistory: false});
     }
 
     onRender() {

--- a/src/app/pages/home/home.js
+++ b/src/app/pages/home/home.js
@@ -43,8 +43,7 @@ export default class Home extends LoadingView {
 
     @on('click a[href^="#"]')
     hashClick(e) {
-        $.scrollTo($.hashTarget(e));
-        e.preventDefault();
+        $.hashClick(e, {doHistory: false});
     }
 
     parallaxBanner() {

--- a/src/app/pages/impact/impact.js
+++ b/src/app/pages/impact/impact.js
@@ -78,8 +78,7 @@ export default class Impact extends LoadingView {
 
     @on('click a[href^="#"]')
     hashClick(e) {
-        $.scrollTo($.hashTarget(e));
-        e.preventDefault();
+        $.hashClick(e, {doHistory: false});
     }
 
     onLoaded() {

--- a/src/app/pages/k-12/k-12.js
+++ b/src/app/pages/k-12/k-12.js
@@ -24,8 +24,7 @@ export default class K12 extends BaseView {
 
     @on('click a[href^="#"]')
     hashClick(e) {
-        $.scrollTo($.hashTarget(e));
-        e.preventDefault();
+        $.hashClick(e, {doHistory: false});
     }
 
     onRender() {

--- a/src/app/pages/partners/icon/icon.js
+++ b/src/app/pages/partners/icon/icon.js
@@ -9,9 +9,7 @@ import {template} from './icon.hbs';
 export default class Icon extends BaseView {
     @on('click [href^="#"]')
     goToBlurb(e) {
-        $.scrollTo($.hashTarget(e));
-        e.preventDefault();
-        e.stopPropagation();
+        $.hashClick(e, {doHistory: false});
     }
 
     setVisibility() {

--- a/src/app/pages/partners/partners.js
+++ b/src/app/pages/partners/partners.js
@@ -77,7 +77,7 @@ export default class Partners extends LoadingView {
     filterClick() {
         let filterSection = this.el.querySelector('.filter');
 
-        $.scrollTo(filterSection, 60, 30);
+        $.scrollTo(filterSection, 30);
     }
 
     updateSelectedFilterFromPath() {

--- a/src/app/pages/subjects/subjects.js
+++ b/src/app/pages/subjects/subjects.js
@@ -51,7 +51,7 @@ export default class Subjects extends LoadingView {
     filterClick() {
         let filterSection = this.el.querySelector('.filter');
 
-        $.scrollTo(filterSection, 60, 30);
+        $.scrollTo(filterSection, 30);
     }
 
     updateSelectedFilterFromPath() {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -83,7 +83,7 @@ sup {
     }
 
     i {
-        text-shadow: 0 0.2rem 0.2rem rgba(color(neutral-dark), 0.1);
+        text-shadow: 0 0.2rem 0.2rem rgba(color(neutral-dark), 0.25);
         color: color(neutral-lightest);
         padding: 0 2rem 0.4rem;
     }


### PR DESCRIPTION
On Details page only, clicking down-page link modifies history (and location) with hash
Also fixed scroll-to-hash for newly loaded pages