### PR TITLE
Detach events properly

### DIFF
--- a/src/app/helpers/backbone/view.js
+++ b/src/app/helpers/backbone/view.js
@@ -158,7 +158,7 @@ class BaseView extends Backbone.View {
             for (let i = 0, len = this._domEvents.length; i < len; i++) {
                 let item = this._domEvents[i];
 
-                item.el.removeEventListener(item.eventName, item.handler);
+                item.el.removeEventListener(item.eventName, item.listener);
             }
 
             this._domEvents.length = 0;


### PR DESCRIPTION
Events were not being detached ever because they were being saved on `listener` but passing the value from `handler` to remove them.