### PR TITLE
fix form field alignment on faculty-verification page

### DIFF
--- a/src/app/pages/faculty-verification/faculty-verification.hbs
+++ b/src/app/pages/faculty-verification/faculty-verification.hbs
@@ -64,6 +64,11 @@
                     <input name="00NU0000005oVQV" pattern="[^@]+@([^@\.]+\.)+[^@\.]+" type="text" required />
                     <small>A verification email will be sent to this address</small>
                 </label>
+                <label>
+                    <span>Are you already using OpenStax in your courses?</span>
+                    <select name="00NU00000055spw">
+                    </select>
+                </label>
             </div>
 
             <div class="col">
@@ -81,11 +86,6 @@
                                 <option value="{{this}}">{{this}}</option>
                             {{/if}}
                         {{/each}}
-                    </select>
-                </label>
-                <label>
-                    <span>Are you already using OpenStax in your courses?</span>
-                    <select name="00NU00000055spw">
                     </select>
                 </label>
                 <div class="cta">


### PR DESCRIPTION
Last form field was added to the right column, I moved it to the left column to match the alignment of the fields on the rest of the website.