### PR TITLE
Fix quote boxes to pull from CMS

### DIFF
--- a/src/app/components/bucket/bucket.hbs
+++ b/src/app/components/bucket/bucket.hbs
@@ -1,6 +1,8 @@
 {{#if hasImage}}<div class="image"></div>{{/if}}
 <div class="quote">
-    <span class="title">{{titleText}}</span>
-    <span class="blurb">{{{blurbHtml}}}</span>
+    <div>
+        <span class="title">{{titleText}}</span>
+        <span class="blurb">{{{blurbHtml}}}</span>
+    </div>
     <a class="btn {{btnClass}}" href="{{linkUrl}}">{{linkText}}</a>
 </div>

--- a/src/app/components/buckets/buckets.js
+++ b/src/app/components/buckets/buckets.js
@@ -3,6 +3,9 @@ import {props} from '~/helpers/backbone/decorators';
 import {template} from './buckets.hbs';
 import Bucket from '../bucket/bucket';
 
+const bucketClasses = ['our-impact', 'partners'];
+const buttonClasses = ['btn-cyan', 'btn-gold'];
+
 @props({
     template: template,
     css: '/app/components/buckets/buckets.css',
@@ -11,42 +14,53 @@ import Bucket from '../bucket/bucket';
     }
 })
 export default class Buckets extends BaseView {
+    constructor(data) {
+        super();
+        if (data) {
+            this.data = data.map((item, index) => ({
+                orientation: 'left',
+                bucketClass: bucketClasses[index],
+                hasImage: false,
+                titleText: item.heading,
+                blurbHtml: item.description,
+                btnClass: buttonClasses[index],
+                linkUrl: item.link,
+                linkText: item.cta
+            }));
+        } else {
+            this.data = [
+                {
+                    orientation: 'left',
+                    bucketClass: 'our-impact',
+                    hasImage: true,
+                    titleText: 'Our Impact',
+                    blurbHtml: `Prof. Wolchonok has saved students $15,000
+                    and opened doors for them to pursue health science careers
+                    by adopting our free Anatomy and Physiology book. `,
+                    btnClass: 'btn-cyan',
+                    linkUrl: '/impact',
+                    linkText: 'See Our Impact'
+                },
+                {
+                    orientation: 'full',
+                    bucketClass: 'partners',
+                    hasImage: false,
+                    titleText: 'OpenStax Partners',
+                    blurbHtml: `OpenStax partners have united with us to increase access
+                    to high-quality learning materials. Their low-cost tools integrate
+                    seamlessly with OpenStax books.`,
+                    btnClass: 'btn-gold',
+                    linkUrl: '/partners',
+                    linkText: 'View Partners'
+                }
+            ];
+        }
+    }
+
+
     onRender() {
-        // this.regions.buckets.append(new Bucket({
-        //     orientation: 'right',
-        //     bucketClass: 'give',
-        //     hasImage: true,
-        //     titleText: 'Give',
-        //     blurbHtml: `Joshua is working to support himself while going
-        //     to college on the GI Bill. Your donations helped create the
-        //     free textbook he is using to complete his college degree.`,
-        //     btnClass: 'btn-yellow',
-        //     linkUrl: '/give',
-        //     linkText: 'Give Today'
-        // }));
-        this.regions.buckets.append(new Bucket({
-            orientation: 'left',
-            bucketClass: 'our-impact',
-            hasImage: true,
-            titleText: 'Our Impact',
-            blurbHtml: `Prof. Wolchonok has saved students $15,000
-            and opened doors for them to pursue health science careers
-            by adopting our free Anatomy and Physiology book. `,
-            btnClass: 'btn-cyan',
-            linkUrl: '/impact',
-            linkText: 'See Our Impact'
-        }));
-        this.regions.buckets.append(new Bucket({
-            orientation: 'full',
-            bucketClass: 'partners',
-            hasImage: false,
-            titleText: 'OpenStax Partners',
-            blurbHtml: `OpenStax partners have united with us to increase access
-            to high-quality learning materials. Their low-cost tools integrate
-            seamlessly with OpenStax books.`,
-            btnClass: 'btn-gold',
-            linkUrl: '/partners',
-            linkText: 'View Partners'
-        }));
+        for (let bucketData of this.data) {
+            this.regions.buckets.append(new Bucket(bucketData));
+        }
     }
 }

--- a/src/app/components/buckets/buckets.scss
+++ b/src/app/components/buckets/buckets.scss
@@ -11,7 +11,6 @@
     .bucket {
         color: color(neutral-lightest);
         max-width: 100%;
-        min-height: 30rem;
 
         @include collapsed {
             flex-direction: column;
@@ -19,41 +18,6 @@
 
         &:last-child {
             margin-bottom: 0;
-        }
-
-        &.give {
-            background-color: color(green);
-
-            > .image {
-                background-image: url('/images/home/buckets/give.jpg');
-                background-position: center center;
-                background-repeat: no-repeat;
-                background-size: cover;
-            }
-
-            > .quote {
-                &::before {
-                    @include triangle(
-                        $direction: left,
-                        $position: top 27% left -2.4rem,
-                        $color: color(green),
-                        $size: 2.4rem
-                    );
-
-                    @include collapsed {
-                        @include triangle(
-                            $direction: top,
-                            $position: top -2.4rem right 5rem left auto,
-                            $color: color(green),
-                            $size: 2.4rem
-                        );
-                    }
-                }
-
-                .title {
-                    color: color(yellow);
-                }
-            }
         }
 
         &.our-impact {
@@ -64,6 +28,7 @@
                 background-position: center center;
                 background-repeat: no-repeat;
                 background-size: cover;
+                min-height: 30rem;
             }
 
             > .quote {
@@ -96,6 +61,32 @@
             background-image: url('/images/home/buckets/partners.jpg');
             background-repeat: no-repeat;
             background-size: cover;
+        }
+
+        .quote {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+
+            @include collapsed {
+                min-height: 30rem;
+            }
+
+            > div {
+                max-width: 100%;
+            }
+        }
+
+        &.left .quote {
+            align-items: flex-start;
+        }
+
+        &.full .quote {
+            align-items: center;
+
+            @include collapsed {
+                align-items: flex-start;
+            }
         }
 
     }

--- a/src/app/components/quotes/quotes.scss
+++ b/src/app/components/quotes/quotes.scss
@@ -88,7 +88,7 @@ $phone-up: #{breakpoints(phone) + 1};
                 order: 1;
                 background-position: 62%;
                 background-repeat: no-repeat;
-                background-size: contain;
+                background-size: cover;
             }
 
             > .quote {

--- a/src/app/components/shell/header/header.hbs
+++ b/src/app/components/shell/header/header.hbs
@@ -6,8 +6,8 @@
     <nav class="meta-nav">
         <div class="container">
             <ul class="nav-menu meta-menu no-bullets" role="menu" aria-label="Meta navigation menu">
-                <li class="nav-menu-item"><a href="/blog" role="menuitem">Blog</a></li>
                 <li class="nav-menu-item"><a href="/about-us" role="menuitem">About Us</a></li>
+                <li class="nav-menu-item"><a href="/blog" role="menuitem">Blog</a></li>
                 <li class="nav-menu-item"><a href="/contact" role="menuitem">Contact</a></li>
                 <li class="nav-menu-item login"><a href="{{login}}" data-local="true" role="menuitem">Login<svg width="0" class="chevron" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 30"><title>arrow</title><path d="M12,1L26,16,12,31,8,27,18,16,8,5Z" transform="translate(-8 -1)"/></svg></a>
                     <ul class="dropdown-menu" role="menu" aria-expanded="false" aria-label="User Menu">

--- a/src/app/pages/about-us/about-us.hbs
+++ b/src/app/pages/about-us/about-us.hbs
@@ -10,7 +10,7 @@
                 textbook was published in 2012 and has since scaled to more than 20 books used by
                 hundreds of thousands of students across the globe. Our adaptive learning
                 technology, designed to improve learning outcomes through personalized
-                educational paths, are currently being piloted for K-12 and college.
+                educational paths, is currently being piloted for K-12 and college.
                 The OpenStax mission is made possible through the generous support of
                 philanthropic foundations. Through these partnerships and our alliance
                 with other educational resource companies, OpenStax is breaking down the

--- a/src/app/pages/details/author/author.hbs
+++ b/src/app/pages/details/author/author.hbs
@@ -1,1 +1,1 @@
-<div class="top-author">{{name}}, {{university}}</div>
+<div class="top-author">{{name}}{{#if university}}, {{university}}{{/if}}</div>

--- a/src/app/pages/higher-ed/higher-ed.scss
+++ b/src/app/pages/higher-ed/higher-ed.scss
@@ -299,7 +299,6 @@ $hero-break-width: 880px;
                 background-position: 0 0;
                 margin-bottom: 0;
                 margin-right: 3rem;
-                text-align: center;
 
                 @include collapsed {
                     margin-bottom: 3rem;

--- a/src/app/pages/home/home.js
+++ b/src/app/pages/home/home.js
@@ -75,7 +75,7 @@ export default class Home extends LoadingView {
         this.regions.quotes.show(new Quotes([
             {
                 orientation: 'right',
-                hasImage: true,
+                imageUrl: '/images/home/quotes/quote-right.jpg',
                 quoteHtml: `Concept Coach is our free new tool that helps college
                 students understand and retain what they’ve read. We’re recruiting
                 faculty for our Fall 2016 pilot!`,


### PR DESCRIPTION
On home page, continue to use default images/data
On Higher Ed, pass data from CMS to Buckets, and display it properly
Fixed bucket display issues on IE11