### PR TITLE
Handle blog articles that have not subheading

### DIFF
--- a/src/app/pages/article/article.js
+++ b/src/app/pages/article/article.js
@@ -34,6 +34,8 @@ export default class Article extends LoadingView {
 
                     if (key in data) {
                         el.innerHTML = data[key];
+                    } else {
+                        el.parentNode.removeChild(el);
                     }
                 }
             };

--- a/src/app/pages/blog/pinned-article/pinned-article.hbs
+++ b/src/app/pages/blog/pinned-article/pinned-article.hbs
@@ -1,7 +1,7 @@
 <div class="img"></div>
 <div class="content">
     <h2><a href="/blog/{{articleSlug}}">{{title}}</a></h2>
-    <h3>{{subheading}}</h3>
+    {{#if subheading}}<h3>{{subheading}}</h3>{{/if}}
     <div class="body"></div>
 
     <div class="meta">


### PR DESCRIPTION
If article data does not contain a subheading entry, remove the
corresponding DOM element.