### PR TITLE
update recordo so it does not inject buttons all the time

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       "backbone.nativeajax": "github:akre54/Backbone.NativeAjax@^0.4.3",
       "backbone.nativeview": "github:akre54/Backbone.NativeView@^0.3.3",
       "handlebars": "github:components/handlebars.js@^4.0.5",
-      "recordo": "npm:recordo@0.0.5",
+      "recordo": "npm:recordo@0.0.6",
       "underscore": "npm:underscore@^1.8.3"
     },
     "devDependencies": {

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -33,7 +33,7 @@ System.config({
     "backbone.nativeview": "github:akre54/Backbone.NativeView@0.3.3",
     "core-js": "npm:core-js@1.2.6",
     "handlebars": "github:components/handlebars.js@4.0.5",
-    "recordo": "npm:recordo@0.0.5",
+    "recordo": "npm:recordo@0.0.6",
     "underscore": "npm:underscore@1.8.3",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
@@ -104,7 +104,7 @@ System.config({
     "npm:process@0.11.2": {
       "assert": "github:jspm/nodelibs-assert@0.1.0"
     },
-    "npm:recordo@0.0.5": {
+    "npm:recordo@0.0.6": {
       "clipboard": "npm:clipboard@1.5.12",
       "good-listener": "npm:good-listener@1.1.7",
       "lodash": "npm:lodash@3.10.1",


### PR DESCRIPTION
Relevant code: https://github.com/philschatz/recordo.js/commit/fcc77bb0a0d46e786f82ca57c20070516e197360

The website was always adding 3 buttons to the bottom of the page, even when debugging was not enabled. Now, debugging is only enabled when `?collect=true` is added to the URL.

# Questions

- Does updating a package version _really_ require changing it in 3 places? /cc @dak 

# Before

![image](https://cloud.githubusercontent.com/assets/253202/16394770/df89a3ea-3c84-11e6-8abc-d85af5a47fbf.png)
