### PR TITLE
Fix Contact Us Comments box

### DIFF
--- a/src/styles/components/forms.scss
+++ b/src/styles/components/forms.scss
@@ -154,8 +154,9 @@ form {
         border: 0.1rem solid rgba(color(gray) , 0.2);
         color: color(neutral-dark);
         display: inline-block;
+        font-family: inherit;
         font-size: 1.6rem;
-        font-weight: 600;
+        font-weight: 500;
         height: 4.8rem;
         padding: 0.84rem;
         width: 100%;
@@ -174,6 +175,7 @@ form {
     textarea {
         height: 21.42rem;
         white-space: normal;
+        overflow-y: auto;
     }
 
     .select-instructions {


### PR DESCRIPTION
Allow word wrapping and scroll bar for texture
Also make it use our default font and not so bold in the fields.