### PR TITLE
Remove partnership link from Impact page

### DIFF
--- a/src/app/pages/impact/impact.hbs
+++ b/src/app/pages/impact/impact.hbs
@@ -30,6 +30,7 @@
                     to give students access to the learning materials they need to succeed.
                 </p>
                 <div class="cta">
+                    {{!
                     Interested in driving student success on your campus with open resources?
                     Access our Institutional Partnership Program application to learn more.
                     Applications are due June 15, and the program begins July 15.
@@ -37,6 +38,8 @@
                     <a class="btn" href="https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/Institutional_Partnership_Program_Application.pdf">
                         Get the application
                     </a>
+                    }}
+                    <a class="btn" href='/contact?subject=College/University%20Partnerships'>Contact us to learn more</a>
                 </div>
             </div>
 


### PR DESCRIPTION
Remove text inviting them to Institutional Partnership Program
Replace Get the application button with “Contact us to learn more”
button that takes them to /contact with “College/University
Partnerships” selected.