### PR TITLE
Implement Community Content Portal Link

### DIFF
--- a/src/app/pages/details/details.hbs
+++ b/src/app/pages/details/details.hbs
@@ -72,6 +72,14 @@
                 </p>
                 <div id="instructor-resources" class="resource"></div>
             </div>
+            <div id="community-resources" class="row">
+                <h3>Community Resources</h3>
+                <p>
+                    Share your own resources or use resources submitted by other
+                    members of the education community for your OpenStax book.
+                </p>
+                <a href="/404" class="btn btn-orange">Unavailable</a>
+            </div>
             <div class="row">
                 <h3>Partner Resources</h3>
                 <p>

--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -176,6 +176,16 @@ export default class Details extends LoadingView {
                     insertResources(resources, 'instructorResources', alternateLink);
                 });
             },
+            showCommunityResources = (text, url) => {
+                let link = this.el.querySelector('#community-resources a');
+
+                if (text) {
+                    link.textContent = text;
+                }
+                if (url) {
+                    link.href = url;
+                }
+            },
             handbookLink = this.el.querySelector('.handbook-link'),
             setHandbookLink = (linkUrl) => {
                 if (linkUrl) {
@@ -329,6 +339,7 @@ export default class Details extends LoadingView {
                         setHandbookLink(detailData.student_handbook_url);
                         handleToc(detailData.table_of_contents);
                         showInstructorResources(detailData.book_faculty_resources);
+                        showCommunityResources(detailData.community_resource_cta, detailData.community_resource_url);
                         insertResources(detailData.book_student_resources, 'studentResources');
                         handleErrataLink(detailData.errata_link, detailData.errata_corrections_link);
                         handlePublishInfo(detailData);


### PR DESCRIPTION
Plug in text and url from CMS, if available. Otherwise, it’s labeled
UNAVAILABLE and links to /404