### PR TITLE
Fix TOC numbering on books with units

### DIFF
--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -139,7 +139,12 @@ export default class Details extends LoadingView {
                         }
                     }
                 } else {
-                    this.removeParentEl(this.regions[regionName].el);
+                    const regionEl = this.regions[regionName].el;
+                    const parentEl = this.asEl(regionEl).parentNode;
+                    const linkToIt = `a[href$="#${parentEl.id}"]`;
+
+                    this.removeParentEl(regionEl);
+                    this.removeEl(linkToIt);
                 }
             },
             showInstructorResources = (resources) => {
@@ -197,8 +202,11 @@ export default class Details extends LoadingView {
                 let chapter = continueFromChapter || 0,
                     isUnitLevel = false,
                     endOfUnitChapter = 0,
+                    hasTwoLevelsBelow = (node) => {
+                        return node.contents && node.contents[0].contents;
+                    },
                     handleUnit = (node) => {
-                        if (isUnitLevel || (chapter === 1 && node.title.match(/^Unit/))) {
+                        if (isUnitLevel || (chapter === 1 && hasTwoLevelsBelow(node))) {
                             isUnitLevel = true;
                             delete node.chapter;
                         }

--- a/src/app/pages/subjects/subjects.js
+++ b/src/app/pages/subjects/subjects.js
@@ -48,10 +48,13 @@ export default class Subjects extends LoadingView {
     }
 
     @on('click .filter')
-    filterClick() {
-        let filterSection = this.el.querySelector('.filter');
+    filterClick(e) {
+        const filterSection = this.el.querySelector('.filter');
+        const buttonText = e.target.textContent;
+        const routeTo = buttonText === 'View All' ? '/subjects' : `/subjects/${buttonText}`;
 
         $.scrollTo(filterSection, 30);
+        router.navigate(routeTo, false);
     }
 
     static metaDescription = () => `Our textbooks are openly licensed, peer-reviewed, free,


### PR DESCRIPTION
Also: remove links to removed regions on Details (mostly affects Coming
Soon books, which have no Resources sections)
Also: On Subjects, update Location when filter is selected