### PR TITLE
Hotfix: Update Interest Form Copy and Book List

### DIFF
--- a/src/app/helpers/book-titles.js
+++ b/src/app/helpers/book-titles.js
@@ -16,6 +16,7 @@ export let published = [
     'Biology',
     'Calculus',
     'Chemistry',
+    'Chemistry: Atoms First',
     'College Algebra',
     {
         text: 'College Physics',

--- a/src/app/pages/interest/interest.hbs
+++ b/src/app/pages/interest/interest.hbs
@@ -1,10 +1,9 @@
 <div class="text-content subhead">
-<h1>OpenStax College Interest Form</h1>
+<h1>Interested in learning more about OpenStax?</h1>
     <p>
-        Thank you for your interest in OpenStax College textbooks! Please complete the form below so that we may provide
-        you with the information you need to start saving your students thousands of dollars each semester.
+        Fill out the form below, and we’ll send you more information about giving your students access to peer-reviewed college textbooks, free of cost.
     </p>
-    <p>Have you already adopted an OpenStax College textbook? <a href="/adoption">Let us know!</a></p>
+    <p>Have you already adopted an OpenStax textbook? <a href="/adoption">Let us know!</a></p>
 </div>
 
 <form accept-charset="UTF-8" action="https://www.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8"


### PR DESCRIPTION
Use new copy to remove deprecated `OpenStax College` branding, and add the book `Chemistry: Atoms First`.