### PR TITLE
Load images using old API

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -196,8 +196,9 @@ function compileScripts() {
     .pipe(pi.babel({
         presets: ['es2015'],
         plugins: [
-            'transform-decorators-legacy',
+            'transform-async-to-generator',
             'transform-class-properties',
+            'transform-decorators-legacy',
             'transform-object-assign'
         ]
     }))

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {},
   "devDependencies": {
     "babel-eslint": "6.1.2",
+    "babel-plugin-transform-async-to-generator": "6.8.0",
     "babel-plugin-transform-class-properties": "6.11.5",
     "babel-plugin-transform-decorators": "6.13.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/src/app/components/quotes/quote/quote.html
+++ b/src/app/components/quotes/quote/quote.html
@@ -1,6 +1,6 @@
 <template args="model">
     <if condition="model.image.image">
-        <div class="image" style="background-image: url({model.image}){model.height ? `; height: ${model.height}px` : ''}">
+        <div class="image" style="background-image: url({model.image.image}){model.height ? `; height: ${model.height}px` : ''}">
         </div>
     </if>
     <div class="quote {model.colorScheme ? model.colorScheme : ''}">


### PR DESCRIPTION
API was unable to be updated to include image urls for this release, so we've had to fallback to loading images with additional roundtrip requests.

CMSPageController will automatically traverse the JSON and find any `image` property with a number and create a separate call to fetch the image's url and insert it in place of the number.

`onDataLoaded` will not be called until all images have loaded, to avoid any potential issues that may exist with calling it multiple times.