### PR TITLE
Hotfix: Make Faculty Verification use Salesforce data correctly

### DIFF
--- a/src/app/pages/faculty-verification/faculty-verification.html
+++ b/src/app/pages/faculty-verification/faculty-verification.html
@@ -11,91 +11,104 @@
         <p if="model.pendingVerification">
             You already have a verification request pending.
         </p>
+        <p if="model.alreadyVerified">
+            Your account is already verified.
+        </p>
     </div>
     <iframe name="form-response" id="form-response" src="" width="0" height="0"></iframe>
-    <form accept-charset="UTF-8" class="form" if="!model.pendingVerification"
-     target="form-response"
-     action="https://www.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="post">
-        <div class="text-content">
-            <div>
-                <input name="utf8" type="hidden" value="✓">
-                <input type="hidden" name="oid" value="00DU0000000Kwch">
-                <input type="hidden" name="lead_source" value="OSC Faculty">
-                <input type="hidden" name="user_id" value="{model.userId}">
-                <input type="hidden" name="OS_Accounts_ID__c" value="{model.accountId}">
-            </div>
-
-            <div class="labeled-inputs row top-of-form">
-                <div class="col">
-                    <label>
-                        First name <span class="invalid-message">{model.validationMessage('first_name')}</span>
-                        <input name="first_name" type="text" required>
-                    </label>
-                    <label>
-                        Last name <span class="invalid-message">{model.validationMessage('last_name')}</span>
-                        <input name="last_name" type="text" required>
-                    </label>
-                    <label>
-                        OpenStax Account Email <span class="invalid-message">{model.validationMessage('email')}</span>
-                        <input name="email" type="email" required>
-                    </label>
-                </div>
-
-                <div class="col">
-                    <label>
-                        School <span class="invalid-message">{model.validationMessage('company')}</span>
-                        <input name="company" type="text" required>
-                    </label>
-                    <label>
-                        Phone <span class="invalid-message">{model.validationMessage('phone')}</span>
-                        <input name="phone" type="text" required>
-                    </label>
-                </div>
-            </div>
+    <if condition="!model.userId">
+        <div class="boxed">
+            <if condition="model.problemMessage">
+                {model.problemMessage}
+            <else>
+                Checking your account status...
+            </if>
         </div>
-
-        <div class="wrapper">
-            <img class="strips" src="/images/components/strips.svg" height="10" alt="" role="presentation">
-            <div class="text-content labeled-inputs row book-info">
-                <div class="col">
-                    <label>
-                        College website URL <span class="invalid-message">{model.validationMessage('website')}</span>
-                        <input name="website" type="text" required>
-                    </label>
-                    <label>
-                        Official institutional email address <span class="invalid-message">{model.validationMessage('00NU0000005oVQV')}</span>
-                        <input name="00NU0000005oVQV" pattern="[^@]+@([^@\.]+\.)+[^@\.]+" type="email" required>
-                        <div class="validation-message">
-                            Please enter your official school/organizational email address
-                            to help us verify your position with your school.
-                        </div>
-                        <small>A verification email will be sent to this address</small>
-                    </label>
-                    <label>
-                        Are you already using OpenStax in your courses? <span class="invalid-message">{model.validationMessage('00NU00000055spw')}</span>
-                        <div skip="true"></div>
-                        <select name="00NU00000055spw" required>
-                            <option each="opt in model.adoptionOptions" value="{opt.value}">{opt.qtext || opt.text}</option>
-                        </select>
-                    </label>
+    <elseif condition="!model.alreadyVerified">
+        <form accept-charset="UTF-8" class="form" if="!model.pendingVerification"
+         target="form-response"
+         action="https://www.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="post">
+            <div class="text-content">
+                <div>
+                    <input name="utf8" type="hidden" value="✓">
+                    <input type="hidden" name="oid" value="00DU0000000Kwch">
+                    <input type="hidden" name="lead_source" value="OSC Faculty">
+                    <input type="hidden" name="user_id" value="{model.userId}">
+                    <input type="hidden" name="OS_Accounts_ID__c" value="{model.accountId}">
                 </div>
 
-                <div class="col">
-                    <label>
-                        Number of students this semester <span class="invalid-message">{model.validationMessage('00NU00000052VId')}</span>
-                        <input name="00NU00000052VId" type="number" min="1" required>
-                    </label>
-                    <label>Your OpenStax book: <span class="invalid-message">{model.validationMessage('00NU00000053nzR')}</span>
-                        <div skip="true"></div>
-                        <select name="00NU00000053nzR" required>
-                            <option each="title in model.titles" value="{title.value}">{title.text}</option>
-                        </select>
-                    </label>
-                    <div class="cta">
-                        <input type="submit" value="Submit" role="button" class="btn">
+                <div class="labeled-inputs row top-of-form">
+                    <div class="col">
+                        <label>
+                            First name <span class="invalid-message">{model.validationMessage('first_name')}</span>
+                            <input name="first_name" type="text" value="{model.firstName}" required>
+                        </label>
+                        <label>
+                            Last name <span class="invalid-message">{model.validationMessage('last_name')}</span>
+                            <input name="last_name" type="text" value="{model.lastName}" required>
+                        </label>
+                        <label>
+                            OpenStax Account Email <span class="invalid-message">{model.validationMessage('email')}</span>
+                            <input name="email" type="email" required>
+                        </label>
+                    </div>
+
+                    <div class="col">
+                        <label>
+                            School <span class="invalid-message">{model.validationMessage('company')}</span>
+                            <input name="company" type="text" required>
+                        </label>
+                        <label>
+                            Phone <span class="invalid-message">{model.validationMessage('phone')}</span>
+                            <input name="phone" type="text" required>
+                        </label>
                     </div>
                 </div>
             </div>
-        </div>
-    </form>
+
+            <div class="wrapper">
+                <img class="strips" src="/images/components/strips.svg" height="10" alt="" role="presentation">
+                <div class="text-content labeled-inputs row book-info">
+                    <div class="col">
+                        <label>
+                            College website URL <span class="invalid-message">{model.validationMessage('website')}</span>
+                            <input name="website" type="text" required>
+                        </label>
+                        <label>
+                            Official institutional email address <span class="invalid-message">{model.validationMessage('00NU0000005oVQV')}</span>
+                            <input name="00NU0000005oVQV" pattern="[^@]+@([^@\.]+\.)+[^@\.]+" type="email" required>
+                            <div class="validation-message">
+                                Please enter your official school/organizational email address
+                                to help us verify your position with your school.
+                            </div>
+                            <small>A verification email will be sent to this address</small>
+                        </label>
+                        <label>
+                            Are you already using OpenStax in your courses? <span class="invalid-message">{model.validationMessage('00NU00000055spw')}</span>
+                            <div skip="true"></div>
+                            <select name="00NU00000055spw" required>
+                                <option each="opt in model.adoptionOptions" value="{opt.value}">{opt.qtext || opt.text}</option>
+                            </select>
+                        </label>
+                    </div>
+
+                    <div class="col">
+                        <label>
+                            Number of students this semester <span class="invalid-message">{model.validationMessage('00NU00000052VId')}</span>
+                            <input name="00NU00000052VId" type="number" min="1" required>
+                        </label>
+                        <label>Your OpenStax book: <span class="invalid-message">{model.validationMessage('00NU00000053nzR')}</span>
+                            <div skip="true"></div>
+                            <select name="00NU00000053nzR" required>
+                                <option each="title in model.titles" value="{title.value}">{title.text}</option>
+                            </select>
+                        </label>
+                        <div class="cta">
+                            <input type="submit" value="Submit" role="button" class="btn">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </if>
 </template>

--- a/src/app/pages/faculty-verification/faculty-verification.js
+++ b/src/app/pages/faculty-verification/faculty-verification.js
@@ -41,7 +41,6 @@ export default class FacultyVerificationForm extends SalesforceForm {
 
     onLoaded() {
         document.title = 'Instructor Verification - OpenStax';
-        selectHandler.setup(this);
         sfUserModel.load().then((user) => {
             if (user.username) {
                 this.model.firstName = user.first_name;
@@ -49,6 +48,7 @@ export default class FacultyVerificationForm extends SalesforceForm {
                 this.model.userId = user.username;
                 this.model.accountId = user.accounts_id;
                 this.model.pendingVerification = user.pending_verification;
+                this.model.alreadyVerified = user.groups.includes('Faculty');
 
                 if (user.accounts_id === null) {
                     this.model.problemMessage = 'Could not load user information';
@@ -57,6 +57,7 @@ export default class FacultyVerificationForm extends SalesforceForm {
                 }
 
                 this.update();
+                selectHandler.setup(this);
             } else {
                 const loginLink = document.querySelector('.nav-menu-item.login > a');
 


### PR DESCRIPTION
Make page wait for SalesForce data before displaying form
Do not display form if verification is pending or completed