### PR TITLE
Hotfix: Scroll to Student Resource

### DIFF
--- a/src/app/pages/details/details-loaded.html
+++ b/src/app/pages/details/details-loaded.html
@@ -105,7 +105,7 @@
                     OpenStax partners provide additional, low-cost resources for your
                     book. See what's offered for this title below and learn more about
                     our <a href="/partners">Partners here</a>.</p>
-                    <div id='partners' class="resource"></div>
+                    <div id='partners' class="resource" skip="true"></div>
                 </div>
             </if>
             <if condition="model.book_student_resources.length">
@@ -115,7 +115,7 @@
                         Take a look at our free student resources that are integrated
                         with your book to help you ace your course.
                     </p>
-                    <div id="student-resources" class="resource"></div>
+                    <div id="student-resources" class="resource" skip="true"></div>
                 </div>
             </if>
         </div>

--- a/src/app/pages/details/details-loaded.js
+++ b/src/app/pages/details/details-loaded.js
@@ -20,12 +20,9 @@ export default class DetailsLoaded extends Controller {
         };
         this.regions = {
             getThisTitle: '.floating-menu .get-this-book',
-            seniorAllAuthors: '[data-id="senior-all-authors"]',
-            allAuthors: '[data-id="nonsenior-all-authors"]',
             instructorResources: '#instructor-resources',
             studentResources: '#student-resources',
             tableOfContents: 'table-of-contents',
-            tocRemover: '.toc-remover',
             partners: '#partners'
         };
         this.model = model;


### PR DESCRIPTION
Add `skip=“true”` to resources regions
Remove unused regions