### PR TITLE
Add optional special None behavior to multi-select

### DIFF
--- a/src/app/components/select/select.html
+++ b/src/app/components/select/select.html
@@ -8,7 +8,7 @@
                 </li>
             <else>
                 <li>
-                    <span class="label none">None</span>
+                    <span class="label none">{model.noneMessage}</span>
                 </li>
             </if>
         </ul>

--- a/src/app/components/select/select.js
+++ b/src/app/components/select/select.js
@@ -93,6 +93,11 @@ export default class Select extends Controller {
         this.model.selected = Select[CONVERT_OPTIONS](this.select.querySelectorAll('option[selected]'));
         this.model.options = Select[CONVERT_OPTIONS](this.select.options);
         this.updateSelectElement();
+        if (this.select.required) {
+            this.model.noneMessage = 'Please select...';
+        } else {
+            this.model.noneMessage = 'None';
+        }
     }
 
     closeDropdown() {
@@ -170,11 +175,20 @@ export default class Select extends Controller {
             e.stopPropagation();
         }
 
+        if ('requireNone' in this.select.dataset) {
+            if (value === '') {
+                this.model.selected.clear();
+            } else {
+                this.model.selected.delete('');
+            }
+        }
+
         if (this.model.selected.has(value)) {
             this.model.selected.delete(value);
         } else {
             this.model.selected.set(value, text);
         }
+
 
         this.update();
         this.updateSelectElement();

--- a/src/app/pages/adoption/adoption.html
+++ b/src/app/pages/adoption/adoption.html
@@ -130,7 +130,8 @@
                         <span class="select-instructions">You may select more than one.</span>
                         <span class="invalid-message">{model.validationMessage('00NU00000055spm')}</span>
                         <div skip="true"></div>
-                        <select multiple name="00NU00000055spm">
+                        <select multiple name="00NU00000055spm" data-require-none required>
+                            <option value="">None</option>
                             <option value="Online homework partners">Online homework partners</option>
                             <option value="Adaptive courseware partners">Adaptive courseware partners</option>
                             <option value="Customization tool partners">Customization tool partners</option>


### PR DESCRIPTION
Required multiselect prompt is now “Please select…”
if select has `data-require-none`, and a None item with value “”, the
None item clears other items, and other items clear None