### PR TITLE
fix instructor resources alignment

### DIFF
--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -103,7 +103,7 @@
         }
 
         @include desktop {
-            flex-flow: row nowrap;
+            flex-flow: row wrap;
         }
     }
 


### PR DESCRIPTION
change flex-wrap from nowrap back to wrap to fix
instructor resources alignment on details page