### PR TITLE
fix book cover position on details page

### DIFF
--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -125,11 +125,15 @@
     }
 
     .book-info {
-        justify-content: space-between;
         margin-bottom: 6rem;
 
         @media (min-width: 500px) {
+            justify-content: space-between;
             margin: 6rem auto;
+        }
+
+        @include desktop {
+            justify-content: flex-start;
         }
 
         .cover-wrap {


### PR DESCRIPTION
Book cover would shift position at certain screen widths. Remove
justify-content on desktop screen width to preserve book cover
placement.