### PR TITLE
Fix login link

### DIFF
--- a/src/app/helpers/link.js
+++ b/src/app/helpers/link.js
@@ -1,5 +1,5 @@
 const EXTERNAL = /^((f|ht)tps?:)?\/\//;
-const ABSOLUTE_OPENSTAX = /^https?:\/\/[^/]*openstax.org/;
+const ABSOLUTE_OPENSTAX = /^https?:\/\/openstax.org/;
 const MAILTO = /^mailto:(.+)/;
 const PDF = /.pdf$/;
 const ZIP = /.zip$/;


### PR DESCRIPTION
Only accept /openstax.org as a local domain. Other domains are still external.