### PR TITLE
adds code coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+after_success:
+  # Report coverage to codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
-after_success:
+after_script:
   # Report coverage to codecov
   - bash <(curl -s https://codecov.io/bash)

--- a/gulp/tasks/jspm-builder.js
+++ b/gulp/tasks/jspm-builder.js
@@ -35,7 +35,7 @@ function jspmBuilder() {
 
     return builder.bundle(dependencies, output, {
         minify: (config.env === 'production'),
-        sourceMaps: (config.env !== 'production' ? 'inline' : true)
+        sourceMaps: true
     })
     .catch((err) => {
         /* eslint no-console: 0 */

--- a/gulp/tasks/jspm-builder.js
+++ b/gulp/tasks/jspm-builder.js
@@ -35,7 +35,7 @@ function jspmBuilder() {
 
     return builder.bundle(dependencies, output, {
         minify: (config.env === 'production'),
-        sourceMaps: (config.env !== 'production')
+        sourceMaps: (config.env !== 'production' ? 'inline' : true)
     })
     .catch((err) => {
         /* eslint no-console: 0 */

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -190,7 +190,8 @@ function compileScripts() {
     return gulp.src(`${config.src}/**/*.js`, {
         since: gulp.lastRun('compileScripts')
     })
-    .pipe(pi.sourcemaps.init({loadMaps: true}))
+    // .pipe(pi.sourcemaps.init({loadMaps: true}))
+    .pipe(pi.sourcemaps.init())
     .pipe(pi.replace(/@VERSION@/g, config.version))
     .pipe(pi.replace(/@ENV@/g, config.env))
     .pipe(pi.babel({
@@ -202,11 +203,7 @@ function compileScripts() {
             'transform-object-assign'
         ]
     }))
-    // Use inline sourcemaps for dev mode so code coverage (nyc) find them
-    // according to both:
-    // https://github.com/istanbuljs/nyc#support-for-custom-require-hooks-babel-webpack-etc
-    // https://github.com/avajs/ava/blob/master/docs/recipes/code-coverage.md#configure-babel
-    .pipe(pi.if(config.env !== 'production', pi.sourcemaps.write(), pi.sourcemaps.write('.')))
+    .pipe(pi.sourcemaps.write('.'))
     .pipe(gulp.dest(config.dest));
 }
 

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -190,7 +190,7 @@ function compileScripts() {
     return gulp.src(`${config.src}/**/*.js`, {
         since: gulp.lastRun('compileScripts')
     })
-    .pipe(pi.if(config.env !== 'production', pi.sourcemaps.init()))
+    .pipe(pi.sourcemaps.init({loadMaps: true}))
     .pipe(pi.replace(/@VERSION@/g, config.version))
     .pipe(pi.replace(/@ENV@/g, config.env))
     .pipe(pi.babel({
@@ -202,7 +202,11 @@ function compileScripts() {
             'transform-object-assign'
         ]
     }))
-    .pipe(pi.if(config.env !== 'production', pi.sourcemaps.write('.')))
+    // Use inline sourcemaps for dev mode so code coverage (nyc) find them
+    // according to both:
+    // https://github.com/istanbuljs/nyc#support-for-custom-require-hooks-babel-webpack-etc
+    // https://github.com/avajs/ava/blob/master/docs/recipes/code-coverage.md#configure-babel
+    .pipe(pi.if(config.env !== 'production', pi.sourcemaps.write(), pi.sourcemaps.write('.')))
     .pipe(gulp.dest(config.dest));
 }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "AGPL-3.0",
   "dependencies": {},
   "devDependencies": {
+    "ava": "^0.17.0",
     "babel-eslint": "6.1.2",
     "babel-plugin-transform-async-to-generator": "6.8.0",
     "babel-plugin-transform-class-properties": "6.11.5",
@@ -22,6 +23,7 @@
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-object-assign": "6.8.0",
     "babel-preset-es2015": "6.13.2",
+    "babel-runtime": "^6.20.0",
     "browser-sync": "2.14.0",
     "connect-history-api-fallback": "1.3.0",
     "del": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "gulp dev",
     "prepublish": "jspm install",
     "upgrade": "jspm update",
-    "test": "gulp dev-build && nyc --reporter=lcov --reporter=text-summary --reporter=json ava ./test/src/*/*.js"
+    "test": "gulp dev-build && nyc --reporter=text ava --serial ./test/src/*/*.js && ./script/postprocess-coverage && nyc report --reporter=html --reporter=json --reporter=text"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "gulp dev",
     "prepublish": "jspm install",
     "upgrade": "jspm update",
-    "test": "gulp dev-build && nyc --reporter=lcov --reporter=text-summary --reporter=json ava"
+    "test": "gulp dev-build && nyc --reporter=lcov --reporter=text-summary --reporter=json ava ./test/src/*/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "gulp dev",
     "prepublish": "jspm install",
     "upgrade": "jspm update",
-    "test": "gulp dev-build && nyc --reporter=lcov --reporter=text-lcov --reporter=json ava"
+    "test": "gulp dev-build && nyc --reporter=lcov --reporter=text-summary --reporter=json ava"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "gulp dev",
     "prepublish": "jspm install",
     "upgrade": "jspm update",
-    "test": "gulp test"
+    "test": "gulp dev-build && nyc --reporter=lcov --reporter=text-lcov --reporter=json ava"
   },
   "repository": {
     "type": "git",
@@ -54,6 +54,7 @@
     "jsdom": "9.4.2",
     "jsdom-global": "2.1.0",
     "jspm": "0.17.0-beta.23",
+    "nyc": "^10.0.0",
     "require-dir": "0.3.0",
     "sw-precache": "4.0.0",
     "systemjs-builder": "0.15.29",

--- a/script/postprocess-coverage
+++ b/script/postprocess-coverage
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+'use strict'
+
+// Open .nyc_output/*.json and adjust the path in each JSON file because nyc
+// does not seem to be able to find the source file otherwise.
+//
+// Apparently setting the path to be `src/ANYTHING_GOES_HERE` is sufficient for
+// the source maps to be loaded when generating the coverage report
+
+const fs = require('fs')
+const path = require('path')
+
+const NYC_OUTPUT_PATH = './.nyc_output/'
+
+const files = fs.readdirSync(NYC_OUTPUT_PATH).filter((filename) => {
+  return /\.json$/.test(filename)
+})
+
+const NEW_PATH = path.join(__dirname, '../src/THIS_FILENAME_IS_A_STUB_BUT_THE_PARENT_DIRECTORY_IS_CRUCIAL.js')
+files.forEach(function(filename) {
+  const jsonPath = path.join(NYC_OUTPUT_PATH, filename)
+  const contents = JSON.parse(fs.readFileSync(jsonPath, 'utf8'))
+  Object.keys(contents).forEach((key) => {
+    const val = contents[key]
+    val.path = NEW_PATH
+  })
+  // Write the JSON back out
+  fs.writeFileSync(jsonPath, JSON.stringify(contents))
+})


### PR DESCRIPTION
As part of https://github.com/openstax/napkin-notes/issues/68 this adds code coverage reporting. See the napkin-note Issue for links to other repos being converted.

[Click here for example coverage report](https://codecov.io/gh/openstax/os-webview/src/d4b84d4cd0d122ce0f9383474f28f45ae88271a4/src/app/helpers/link.js)

You can find the coverage link near the "All checks have passed" below. It says "not affected" because there is no data about `/master` yet:

![image](https://cloud.githubusercontent.com/assets/253202/21847828/f8c07a04-d7cb-11e6-91f0-cb64963020c1.png)


# TODO

- Read more of [avajs/ava:./docs/recipes/code-coverage.md](https://github.com/avajs/ava/blob/master/docs/recipes/code-coverage.md)
- include sourcemaps so not just the test is covered
- maybe https://docs.travis-ci.com/user/gui-and-headless-browsers/ would be useful?
- maybe useful notes on JSPM and istanbuljs: https://github.com/systemjs/systemjs/issues/992
- [x] install ava locally instead of in `.travis.yml`