### PR TITLE
Improve errata form load time

### DIFF
--- a/src/app/helpers/analytics.js
+++ b/src/app/helpers/analytics.js
@@ -132,11 +132,6 @@ class Analytics {
                     this.sourceByUrl[resource.link_document_url] = `${item.title} ${marker}`;
                 }
             }
-        }
-    }
-
-    addPartnersToLookupTable(partnerItems) {
-        for (const item of partnerItems) {
             for (const ally of item.book_allies) {
                 const url = ally.book_link_url;
 
@@ -183,26 +178,10 @@ class Analytics {
         })();
     }
 
-    fetchPartners() {
-        /* eslint arrow-parens: 0 */
-        (async () => {
-            try {
-                const response = await fetch(`${settings.apiOrigin}/api/v2/pages/?type=books.Book&fields`+
-                  '=title,book_allies');
-                const data = await response.json();
-
-                this.addPartnersToLookupTable(data.items);
-            } catch (e) {
-                console.log(e);
-            }
-        })();
-    }
-
     [SETUP_GA]() {
         this.data = {};
         this.sourceByUrl = {};
         this.fetchBooks();
-        this.fetchPartners();
         if (typeof window.ga !== 'function') {
             window.GoogleAnalyticsObject = 'ga';
             window.ga = {

--- a/src/app/models/usermodel.js
+++ b/src/app/models/usermodel.js
@@ -5,20 +5,20 @@ const sfUserUrl = `${settings.apiOrigin}/api/user_salesforce`;
 const docUrlBase = `${settings.apiOrigin}/api/documents`;
 
 const LOADED = Symbol();
+const LOADED_TIME = Symbol();
+const CACHE_FOR_MS = 15000;
 
 class UserModel {
 
     constructor(url) {
         this.url = url;
+        this[LOADED_TIME] = 0;
     }
 
-    load(qs = {}) {
-        const query = Object.keys(qs)
-        .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(qs[k])}`)
-        .join('&');
-        const url = this.url + (query.length ? `?${query}` : '');
-
-        this[LOADED] = fetch(url, {credentials: 'include'}).then((response) => response.json());
+    load() {
+        if (Date.now() > this[LOADED_TIME] + CACHE_FOR_MS) {
+            this[LOADED] = fetch(this.url, {credentials: 'include'}).then((response) => response.json());
+        }
         return this[LOADED];
     }
 


### PR DESCRIPTION
Make supermodel cache results for 15 seconds
In analytics, use the book fetch to add partner information to the
lookup tables, reducing a second fetch of book data