### PR TITLE
Cache page data

### DIFF
--- a/src/app/controllers/cms.js
+++ b/src/app/controllers/cms.js
@@ -1,4 +1,5 @@
 import settings from 'settings';
+import jsonDataCache from '~/helpers/json-data-cache';
 import {Controller} from 'superb';
 
 const TRANSFORM_DATA = Symbol();
@@ -13,8 +14,7 @@ class CMSPageController extends Controller {
             /* eslint arrow-parens: 0 */ // Fix eslint bug with async arrow functions
             (async () => {
                 try {
-                    const response = await fetch(`${settings.apiOrigin}/api/${this.slug}`);
-                    const data = await response.json();
+                    const data = await jsonDataCache.load(`${settings.apiOrigin}/api/${this.slug}`);
 
                     this.pageData = this.preserveWrapping ? data : CMSPageController[TRANSFORM_DATA](data);
 
@@ -26,6 +26,10 @@ class CMSPageController extends Controller {
                 }
             })();
         }
+    }
+
+    onDataError(e) {
+        console.warn(e);
     }
 
     [LOAD_IMAGES](data) {

--- a/src/app/helpers/json-data-cache.js
+++ b/src/app/helpers/json-data-cache.js
@@ -1,0 +1,44 @@
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+
+class JsonDataCache {
+
+    constructor(url) {
+        this.url = url;
+        this.timeout = DEFAULT_TIMEOUT_MS;
+    }
+
+    load() {
+        if (!this.promise) {
+            this.promise = new Promise((resolve, reject) =>
+                fetch(this.url)
+                .then((response) =>
+                    response.ok ? resolve(response.json()) : reject(response)
+                )
+                .catch((e) => reject(e))
+            );
+            clearTimeout(this.scheduledCleanup);
+            this.scheduledCleanup = setTimeout(() => {
+                this.promise = null;
+            }, this.timeout);
+        }
+        return this.promise;
+    }
+
+}
+
+class JsonDataCacheManager {
+
+    constructor() {
+        this.models = {};
+    }
+
+    load(url) {
+        if (!(url in this.models)) {
+            this.models[url] = new JsonDataCache(url);
+        }
+        return this.models[url].load();
+    }
+
+}
+
+export default new JsonDataCacheManager();


### PR DESCRIPTION
CMS page data is cached so returning to the page does not require another fetch.
Cached data self-purges in 15 minutes.