### PR TITLE
Fix: pages that don't use the loader animation stay hidden

### DIFF
--- a/src/app/components/shell/shell.js
+++ b/src/app/components/shell/shell.js
@@ -17,11 +17,21 @@ class Shell extends Controller {
 
         this.header = header;
         this.footer = footer;
+        // Wait for main to receive some content before attaching header and footer
+        this.mainObserver = new MutationObserver((observations) => {
+            // If the page doesn't use the page loader, prevent the page
+            // loader from running later by adding the page-loaded class
+            if (!document.body.classList.contains('page-loading')) {
+                document.body.classList.add('page-loaded');
+            }
+            this.regions.header.attach(header);
+            this.regions.footer.attach(footer);
+            this.mainObserver.disconnect();
+        });
     }
 
     onLoaded() {
-        this.regions.header.attach(header);
-        this.regions.footer.attach(footer);
+        this.mainObserver.observe(document.getElementById('main'), {childList: true});
 
         // Start recordo
         initialize({ignoreAjaxResponse: true});

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -2,7 +2,6 @@ import 'babel-polyfill';
 import 'fetch';
 import $ from '~/helpers/$';
 import router from '~/router';
-import shell from '~/components/shell/shell';
 
 // NOTE: precaching is disabled. uglify will remove this code block since it's unreachable
 if (false && '@ENV@' === 'production' && 'serviceWorker' in navigator) {
@@ -41,7 +40,6 @@ if (false && '@ENV@' === 'production' && 'serviceWorker' in navigator) {
 class App {
 
     constructor() {
-        this.shell = shell;
         router.start();
 
         if (!$.isSupported()) {

--- a/src/index.html
+++ b/src/index.html
@@ -86,12 +86,6 @@
             }
         </script>
         <script async src="https://cdn.optimizely.com/js/7893320024.js"></script>
-        <style type="text/css">
-          .os-loader {opacity: 0;width: 0;height: 0;}
-           #header,
-           #main,
-           #footer {opacity: 0;}
-        </style>
     </head>
     <body>
         <noscript>


### PR DESCRIPTION
Remove page-hiding css from index.html
Wait for #main to get content before attaching header and footer
Determine whether page-loader is being used; if not, add page-loaded
class to prevent its running later