### PR TITLE
Bulk order: Set initial quantity to 25, since min is 25

### DIFF
--- a/src/app/pages/bulk-order/bulk-order.js
+++ b/src/app/pages/bulk-order/bulk-order.js
@@ -23,7 +23,7 @@ class OrderItems extends CMSPageController {
 
         this.model.orderItems = pages.map((p) => ({
             item: p.title,
-            quantity: 0,
+            quantity: 25,
             list: p.amazon_price,
             min: 25,
             validationMessage: (name) => {


### PR DESCRIPTION
Though the field showed quantity of 25 because its min was 25, the actual quantity value was zero, and zero-quantity entries aren't included. Set initial quantity to 25.