### PR TITLE
Debugging: log message when opening new window

### DIFF
--- a/src/app/router.js
+++ b/src/app/router.js
@@ -120,6 +120,7 @@ class AppRouter extends Router {
                 analytics.record(href);
                 const newWindow = window.open(href, '_blank');
 
+                console.log('The new window is', newWindow);
                 if (newWindow === null) {
                     document.location.href = href;
                 }


### PR DESCRIPTION
Apparently when Firefox “blocks a pop-up” it does not return a null as
the window, which it does when window.open fails. Behavior is different
on dev than on local, so this is a testing PR.