### PR TITLE
Bug fixes for 10/9 release

### DIFF
--- a/src/app/components/popup/popup.html
+++ b/src/app/components/popup/popup.html
@@ -2,7 +2,7 @@
     <div class="overlay" if="model.show">
         <div role="dialog" aria-describedby="popupMessage">
             <p id="popupMessage">{model.message}</p>
-            <button tabindex="1">Got it</button>
+            <button class="dismiss" tabindex="1">Got it</button>
         </div>
     </div>
 </template>

--- a/src/app/components/shell/header/upper-menu/upper-menu.html
+++ b/src/app/components/shell/header/upper-menu/upper-menu.html
@@ -4,7 +4,7 @@
         <li class="nav-menu-item"><a href="/foundation" role="menuitem">Our Supporters</a></li>
         <li if="model.showBlog" class="nav-menu-item"><a href="/blog" role="menuitem">Blog</a></li>
         <li class="nav-menu-item"><a href="/give" role="menuitem">Give</a></li>
-        <li class="nav-menu-item"><a href="/support" role="menuitem">Support</a></li>
+        <li class="nav-menu-item"><a href="/support" role="menuitem">Help</a></li>
     </ul>
     <span class="logo-wrapper">
         <a class="logo rice-logo" href="http://www.rice.edu" role="menuitem">

--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -174,10 +174,7 @@ $special-breakpoint: 54rem;
             }
 
             &.bottom {
-                bottom: 0;
-                position: absolute;
-                top: auto;
-                z-index: 0;
+                top: 7rem;
             }
 
             h2 {

--- a/src/app/pages/subjects/subjects.scss
+++ b/src/app/pages/subjects/subjects.scss
@@ -132,6 +132,8 @@
 
             &.open {
                 @include get-this-is-visible;
+
+                min-width: 23rem;
             }
 
             &::before {
@@ -153,6 +155,8 @@
         .cover:hover .details {
             @include wider-than($tablet-max) {
                 @include get-this-is-visible;
+
+                min-width: 23rem;
             }
         }
     }


### PR DESCRIPTION
Popup dismiss
Change “Support” menu to “Help”
Handle “Get this title” floating menu at the bottom of the page
Make “Get this title” hover menu wider so the button doesn’t hang off