### PR TITLE
cache node packages in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ before_install:
   - rvm install 2.3.1
   - gem install scss_lint
 sudo: false
+
+# Cache the 3rd-party packages. From https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn
+cache:
+  yarn: true
+  directories:
+    - node_modules
+    
 notifications:
   email: false
 env:


### PR DESCRIPTION
This should speed up tests because the packages should only need to be installed when package versions change (in `yarn.lock`)

See https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn