### PR TITLE
always use yarn

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -8,9 +8,12 @@ source ./script/bootstrap || exit 1
 
 >&2 echo "==> Installing node packages"
 if [[ $(which yarn) ]]; then
+  >&2 echo "Using existing system version of yarn"
   yarn install || exit 2
 else
-  npm install || exit 2
+  >&2 echo "Installing yarn locally and then installing packages"
+  npm install yarn
+  $(npm bin)/yarn install || exit 2
 fi
 
 >&2 echo "==> Installing JSPM packages"


### PR DESCRIPTION
This is because deployment servers did not have yarn installed globally.

You can test this by doing: 

```
# Uninstall yarn. Depending on how you installed it, the uninstall is different:
brew uninstall yarn
npm uninstall -g yarn

./script/setup && ./script/test
```