### PR TITLE
fix how yarn is installed so it is more consistent

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "yarn"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,6 +7,17 @@ set -e
 # Also from https://github.com/Connexions/cnx-rulesets
 
 
+if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
+  >&2 echo "==> Updating Homebrew…"
+  brew update || exit 1
+
+  brew bundle check >/dev/null 2>&1  || {
+    >&2 echo "==> Installing Homebrew dependencies…"
+    brew bundle || exit 1
+  }
+fi
+
+
 # Set up the correct version of node
 if [[ "${CI}" != "true" ]]; then # Skip the nvm stuff if running in Travis
   >&2 echo "==> Setting up node version"
@@ -19,8 +30,29 @@ if [[ "${CI}" != "true" ]]; then # Skip the nvm stuff if running in Travis
     >&2 echo "Using node: $(node --version)"
     >&2 echo "Using npm: $(npm --version)"
   fi
-
 fi
+
+# Install https://yarnpkg.com (package manager)
+if [[ ! $(which yarn) ]]; then
+  # Prompt when on debian
+  if [[ $(which apt-key) ]]; then
+    read -p "Would you like to install yarn (y/N)?" choice
+    echo # Move to a new line
+    if [[ "${choice}" =~ ^[Yy]$ ]]; then
+      >&2 echo "==> Installing yarn. You may be prompted for a password"
+      curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - || exit 1
+      echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list || exit 1
+      sudo apt-get update && sudo apt-get install yarn || exit 1
+    else
+      echo "Yarn is not installed. Exiting"
+      exit 1
+    fi
+  else
+    echo "Not sure how to install yarn automatically. If you are using macOS do you have https://brew.sh installed?"
+    exit 1
+  fi
+fi
+
 
 # Set up the correct version of ruby
 

--- a/script/setup
+++ b/script/setup
@@ -6,15 +6,8 @@ fi
 
 source ./script/bootstrap || exit 1
 
->&2 echo "==> Installing node packages"
-if [[ $(which yarn) ]]; then
-  >&2 echo "Using existing system version of yarn"
-  yarn install || exit 2
-else
-  >&2 echo "Installing yarn locally and then installing packages"
-  npm install yarn
-  $(npm bin)/yarn install || exit 2
-fi
+>&2 echo "==> Installing node packages using https://yarnpkg.com"
+yarn install || exit 2
 
 >&2 echo "==> Installing JSPM packages"
 $(npm bin)/jspm install || exit 3


### PR DESCRIPTION
Refs https://github.com/openstax/napkin-notes/issues/83

If the person running `./script/setup` is a Mac, yarn is installed via Homebrew (no need for sudo).

If Debian, then they are prompted to install it (defaults to *no*).