### PR TITLE
Use "gem list -i bundler" in bootstrap to check if it is installed

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -41,7 +41,7 @@ if [[ "${CI}" != "true" ]]; then
   # Initialize rbenv (if installed)
   [[ -n $(which rbenv) ]] && eval "$(rbenv init -)"
 
-  which bundle >/dev/null 2>&1  || {
+  gem list -i bundler >/dev/null 2>&1  || {
     >&2 echo "==> Installing Ruby Bundler gem…"
     gem install bundler || {
       >&2 echo ''


### PR DESCRIPTION
If we are using rbenv, there is a possibility that `which bundle` might
return the global system `/usr/local/bin/bundle` or
`/var/lib/rundeck/.rbenv/shims/bundle` which does not ensure bundler is
actually installed for the ruby version we are using.

This is the error message we are seeing on bastion:

```
==> Installing gem dependencies…
rbenv: bundle: command not found

The `bundle' command exists in these Ruby versions:
  2.4.2
```

So although `which bundle` works, it is not for the version of ruby we are
using.

The solution we came up with is to check by doing `gem list -i bundler` which
checks whether bundler is installed for the version of ruby we are using.  It
installs bundler if bundler is not installed.