### PR TITLE
Merge 1002 to master

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -42,7 +42,7 @@ function scsslint() {
 
 function compileStyles(src, dest) {
     return src
-        .pipe(pi.if(config.env !== 'production', pi.sourcemaps.init()))
+        .pipe(pi.sourcemaps.init())
         .pipe(pi.sass({
             includePaths: [
                 './styles',
@@ -58,10 +58,10 @@ function compileStyles(src, dest) {
                 keyframes: false
             }
         })))
-        .pipe(pi.if(config.env !== 'production', pi.sourcemaps.write('.', {
+        .pipe(pi.sourcemaps.write('.', {
             includeContent: false,
             sourceRoot: './'
-        })))
+        }))
         .pipe(gulp.dest(dest || config.dest))
         .pipe(bs.stream({match: '**/*.css'}));
 }

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -3,15 +3,13 @@ const config = require('../config');
 const pi = require('gulp-load-plugins')({
     pattern: ['gulp-*', 'gulp.*', 'del']
 });
+const webpack = require('./webpack');
 
 function templates() {
     return gulp.src(`${config.src}/app/**/*.html`, {
         since: gulp.lastRun('templates')
     })
-    .pipe(pi.if(config.env !== 'production', pi.sourcemaps.init()))
-    .pipe(pi.rename((uri) => {
-        uri.extname = '.html.js';
-    }))
+    .pipe(pi.sourcemaps.init())
     .pipe(pi.htmlmin({
         collapseWhitespace: true
     }))
@@ -22,7 +20,10 @@ function templates() {
         compact: false,
         presets: ['es2015']
     }))
-    .pipe(pi.if(config.env !== 'production', pi.sourcemaps.write('.')))
+    .pipe(pi.rename((uri) => {
+        uri.extname = '.html.js';
+    }))
+    .pipe(pi.sourcemaps.write('.'))
     .pipe(gulp.dest(`${config.dest}/app`));
 }
 
@@ -32,6 +33,7 @@ gulp.task('templates:watch', () => {
     gulp.watch(`${config.src}/**/*.html`, config.watchOpts)
     .on('change', gulp.series(
         templates,
+        'webpack',
         'reload-browser'
     ));
 });

--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -1,0 +1,47 @@
+const gulp = require('gulp');
+const config = require('../config');
+const pi = require('gulp-load-plugins')();
+const path = require('path');
+const webpackStream = require('webpack-stream');
+const webpack2 = require('webpack');
+
+function webpack() {
+    return gulp.src([
+        `${config.dest}/app/main.js`
+    ])
+    .pipe(webpackStream({
+        // watch: true, // This causes gulp to freeze and not serve
+        output: {
+            path: path.resolve(config.dest),
+            filename: "bundle.js",
+            publicPath: "/", // for where to request chunks when the SinglePageApp changes the URL
+            chunkFilename: "chunk-[chunkhash].js"
+        },
+        externals: {
+            settings: 'SETTINGS'
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.css$/,
+                    loader: 'ignore-loader'
+                }
+            ]
+        },
+        plugins: [
+            new webpack2.optimize.UglifyJsPlugin(),
+            new webpack2.optimize.MinChunkSizePlugin({minChunkSize: 16000})
+        ],
+        resolve: {
+            alias: {
+                "settings": path.resolve(config.dest, "settings.js"),
+                "~": path.resolve(config.dest, "app/"),
+            }
+        },
+        devtool: "source-map"
+    }))
+    .pipe(pi.sourcemaps.write('.'))
+    .pipe(gulp.dest(config.dest));
+}
+
+gulp.task(webpack);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,9 +13,8 @@ gulp.task('default', gulp.series(
         'scripts',
         'templates',
         'images'
-    // ),
-    )
-    // 'jspm-builder'
+    ),
+    'webpack'
 ));
 
 gulp.task('dev-build', gulp.series(
@@ -30,6 +29,7 @@ gulp.task('dist-build', gulp.series(
 
 gulp.task('dev', gulp.series(
     'dev-build',
+    'copySettings',
     'watch'
 ));
 
@@ -37,7 +37,6 @@ gulp.task('dist', gulp.series(
     'production',
     'default',
     'precache',
-    'minify-scripts',
     'humans'
 ));
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "http-server": "^0.10.0",
+    "ignore-loader": "^0.1.2",
     "rollup": "^0.50.0",
     "rollup-plugin-commonjs": "^8.2.3",
     "rollup-plugin-node-resolve": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4149,6 +4149,10 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+ignore-loader@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
+
 ignore@^3.3.3:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"


### PR DESCRIPTION
Changes were reviewed and approved by Phil, but merged into a different branch; it needs to be merged to master now.

Drop sourcemaps, as they do not seem to be used
Remove redundant webpack step and config
Copy settings-example.js for dev
* Stop webpack warnings
* Separate webpack task so both scripts and templates can use it
Reload browser works for html updates as well as script updates
* Use webpack to minify code
Drop sourcemaps, as they do not seem to be used
Remove redundant webpack step and config
Copy settings-example.js for dev
Use global SETTINGS variable
Remove dead build scripts, keep fiddling with settings
* Add source map calls back in