### PR TITLE
Fix request for nonexistent math.svg

### DIFF
--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -129,7 +129,9 @@ $tablet-book-size: 16.5rem;
     .book,
     .second-book {
         background-color: $book-color;
-        background-image: url('/images/subjects/#{$subject}.svg');
+        @if $subject != 'math' {
+            background-image: url('/images/subjects/#{$subject}.svg');
+        }
         background-position: top left;
         height: calc(30vw + 15rem);
         left: 0;


### PR DESCRIPTION
The generic css for the banners sets background image for .book and
.second-book to be ${subject}.svg. There is no math.svg. Although the
css overrides that generic css, we are still getting requests. I have
put in an if-directive to prevent the setting of the background image
in the generic css when subject is math.