### PR TITLE
Fix adoption links

### DIFF
--- a/src/app/pages/details/let-us-know/let-us-know.html
+++ b/src/app/pages/details/let-us-know/let-us-know.html
@@ -2,10 +2,10 @@
     <a class="book-icon" href="/interest?{encodeURIComponent(model.title)}">
         <span class="fa fa-user-plus"></span>
     </a>
-    <a class="text" href="/interest?{encodeURIComponent(model.title)}">
+    <a class="text" href="/adoption?{encodeURIComponent(model.title)}">
     Sign up to<br>learn more
     </a>
-    <a class="link" href="/interest?{encodeURIComponent(model.title)}">
+    <a class="link" href="/adoption?{encodeURIComponent(model.title)}">
         Using this book? Let us know.
     </a>
 </div>


### PR DESCRIPTION
In “Let Us Know”, they were set to interest instead of adoption.