### PR TITLE
Enable Google Analytics for non-production

### DIFF
--- a/src/app/helpers/analytics.js
+++ b/src/app/helpers/analytics.js
@@ -56,11 +56,7 @@ class Analytics {
             location: window.location.href
         };
 
-        if (linkHelper.isProduction()) {
-            this.sendEvent(eventPacket);
-        } else {
-            console.debug('[Non production] Send to analytics:', eventPacket);
-        }
+        this.sendEvent(eventPacket);
     }
 
     sendUrlEvent(category, href, action = 'download') {
@@ -202,13 +198,17 @@ class Analytics {
         if (typeof window.ga !== 'function') {
             window.GoogleAnalyticsObject = 'ga';
             window.ga = {
-                q: [['create', settings.analyticsID, 'auto'],
-                    ['create', settings.analyticsID2, 'auto', {name: 'ga2'}]],
+                q: [['create', settings.analyticsID, 'auto']],
                 l: Date.now()
             };
+            if (settings.analyticsID2) {
+                window.ga.q.push(['create', settings.analyticsID2, 'auto', {name: 'ga2'}]);
+            }
         } else {
             window.ga('create', settings.analyticsID, 'auto');
-            window.ga('create', settings.analyticsID2, 'auto', {name: 'ga2'});
+            if (settings.analyticsID2) {
+                window.ga('create', settings.analyticsID2, 'auto', {name: 'ga2'});
+            }
         }
 
         accountsModel.load().then((accountResponse) => {

--- a/src/settings-example.js
+++ b/src/settings-example.js
@@ -1,7 +1,6 @@
 const settings = {
     accountHref: 'https://accounts-dev.openstax.org',
-    analyticsID: 'UA-73668038-1',
-    analyticsID2: 'UA-73668038-2',
+    analyticsID: 'UA-73668038-3',
     apiOrigin: 'https://oscms-dev.openstax.org',
     buildVersion: '2.6.0',
     tagManagerID: 'GTM-W6N7PB',


### PR DESCRIPTION
Devops will need to update `settings.js` on dev and qa to use the new analyticsID values from the Trello cards and remove analyticsID2.