### PR TITLE
Fix errata submission for Edge

### DIFF
--- a/src/app/pages/errata/form/form.js
+++ b/src/app/pages/errata/form/form.js
@@ -109,16 +109,16 @@ export default class Form extends Controller {
         this.model.submitted = true;
         this.update();
         const formEl = this.el.querySelector('form');
-        const form = new FormData(formEl);
 
-        // Safari cannot handle empty files
+        // Safari cannot handle empty files; Edge cannot manipulate FormData
         ['file_1', 'file_2'].forEach((name) => {
-            const fd = form.get(name);
+            const el = formEl.querySelector(`[name="${name}"]`);
 
-            if (fd && fd.name === '') {
-                form.delete(name);
+            if (el && el.value === '') {
+                el.parentNode.removeChild(el);
             }
         });
+        const form = new FormData(formEl);
 
         // Programmatically post the form
         fetch(this.model.postEndpoint, {

--- a/src/app/pages/faq/faq.html
+++ b/src/app/pages/faq/faq.html
@@ -2,7 +2,7 @@
     <div if="model.heading" class="hero">
         <div class="boxed">
             <h1>{model.heading}</h1>
-            <p data-html="subhead"></p>
+            <div class="text-content" data-html="subhead"></div>
         </div>
     </div>
     <img class="strips" src="/images/components/strips.svg" height="10" alt="" role="presentation">


### PR DESCRIPTION
I cannot test locally in Edge. The problem was that I was using an unsupported feature to clean up the form data for Safari. I used a different approach and tested that Safari still works. Will have to verify that it works in Edge on Dev. 