### PR TITLE
Only include "live" books in Salesforce book list

### DIFF
--- a/src/app/controllers/salesforce-form.js
+++ b/src/app/controllers/salesforce-form.js
@@ -18,7 +18,7 @@ class SalesforceForm extends CMSPageController {
                 const seen = abbrev in seenTitles;
 
                 seenTitles[abbrev] = true;
-                return abbrev && !seen;
+                return abbrev && !seen && book.book_state === 'live';
             })
             .map((book) => ({
                 text: book.salesforce_name,


### PR DESCRIPTION
Adoption and interest form show covers for old books because the Salesforce book list does not distinguish between editions and uses the data from the first entry for (say) Biology that comes from the CMS. Filter out entries whose `book_state` is not "live" to avoid using obsolete information.