### PR TITLE
Log out should be two words

### DIFF
--- a/src/app/components/shell/header/main-menu/main-menu.js
+++ b/src/app/components/shell/header/main-menu/main-menu.js
@@ -99,7 +99,7 @@ export default class MainMenu extends Controller {
                 {url: this.model.facultyAccessLink, label: 'Request instructor access'},
                 {
                     url: this.model.logout,
-                    label: 'Logout',
+                    label: 'Log out',
                     isLocal: true
                 }
             ];


### PR DESCRIPTION
Log out should be two words.  Accounts and Tutor have "Log out", too.