### PR TITLE
Hide Submit until Role is selected

### DIFF
--- a/src/app/pages/rover-by-openstax/rover-by-openstax.html
+++ b/src/app/pages/rover-by-openstax/rover-by-openstax.html
@@ -56,7 +56,7 @@
                     <input type="hidden" name="lead_source" value="Interest Form">
                     <input type="hidden" name="Interested_in_Rover__c" value="1">
                     <div class="signup-form" skip="true"></div>
-                    <button type="submit">Submit</button>
+                    <button if="model.roleIsSelected" type="submit">Submit</button>
                 </form>
                 <div id="form-response-region" skip="true"></div>
             </div>

--- a/src/app/pages/rover-by-openstax/rover-by-openstax.js
+++ b/src/app/pages/rover-by-openstax/rover-by-openstax.js
@@ -26,6 +26,7 @@ export default class Rover extends CMSPageController {
 
         // State
         this.faqItems = [];
+        this.roleIsSelected = false;
     }
 
     toFaqCards(faqs) {
@@ -76,7 +77,8 @@ export default class Rover extends CMSPageController {
             hideForm: this.hideForm,
             headline4: data.section_4_headline,
             faqCards: this.faqItems, // calculated in onDataLoaded
-            salesforce
+            salesforce,
+            roleIsSelected: this.roleIsSelected
         };
     }
 
@@ -125,7 +127,10 @@ export default class Rover extends CMSPageController {
         const signupFormRegion = new Region(this.el.querySelector('.signup-form'));
         const iframe = document.createElement('iframe');
 
-        this.signupForm = new SignupForm(this.roles);
+        this.signupForm = new SignupForm(this.roles, (role) => {
+            this.roleIsSelected = Boolean(role);
+            this.update();
+        });
         signupFormRegion.attach(this.signupForm);
         iframe.name = iframe.id = 'rover-form-response';
         iframe.width = iframe.height = '0';

--- a/src/app/pages/rover-by-openstax/signup-form/signup-form.js
+++ b/src/app/pages/rover-by-openstax/signup-form/signup-form.js
@@ -6,9 +6,10 @@ import {description as template} from './signup-form.html';
 
 export default class SignupForm extends SalesforceForm {
 
-    init(roles) {
+    init(roles, onChange) {
         this.template = template;
         this.roles = roles;
+        this.onChange = onChange;
         this.regions = {
             selector: '.selector',
             common: '.common-fields',
@@ -92,6 +93,7 @@ export default class SignupForm extends SalesforceForm {
             options: roleOptions
         }, (newValue) => {
             this.selectedRole = newValue;
+            this.onChange(newValue);
             this.update();
         });
 


### PR DESCRIPTION
It is possible to submit the Rover form without selecting a Role (or doing anything else). Hiding the Submit button until a Role is selected ensures that the form is displayed and required fields must be entered.