### PR TITLE
Fix footer page not changing

### DIFF
--- a/src/app/pages/footer-page/footer-page.js
+++ b/src/app/pages/footer-page/footer-page.js
@@ -8,11 +8,16 @@ const spec = {
     view: {
         classes: ['footer-page', 'page']
     },
-    slug: `pages${window.location.pathname}`
+    slug: 'set in init'
 };
 const BaseClass = componentType(spec, canonicalLinkMixin, loaderMixin);
 
 export default class FooterPage extends BaseClass {
+
+    init(...args) {
+        super.init(...args);
+        this.slug = `pages${window.location.pathname}`;
+    }
 
     onDataLoaded() {
         document.title = this.pageData.title;


### PR DESCRIPTION
The footer page slug was being set once for the session rather than once per page creation.