### PR TITLE
Fix: Form Header

### DIFF
--- a/src/app/components/form-header/form-header.js
+++ b/src/app/components/form-header/form-header.js
@@ -13,10 +13,11 @@ const spec = {
             introHeading: this.pageData.intro_heading,
             introDescription: this.pageData.intro_description
         } : {};
-    }
+    },
+    slug: 'set in init'
 };
 
-export default class Header extends CMSPageController {
+export default class Header extends componentType(spec) {
 
     init(slug) {
         super.init();


### PR DESCRIPTION
Adoption and Interest forms were not working because I hadn't changed CMSPageContoller to componentType() call.