### PR TITLE
Fix Rover logo placement for mobile, Getting Started section

### DIFF
--- a/src/app/pages/rover-by-openstax/sections/getting-started.scss
+++ b/src/app/pages/rover-by-openstax/sections/getting-started.scss
@@ -4,6 +4,10 @@
     padding: calc(4rem + 10vw) 0;
     position: relative;
 
+    @include width-up-to($phone-max) {
+        padding-bottom: 39vw;
+    }
+
     .cards {
         display: grid;
         grid-gap: $normal-margin;


### PR DESCRIPTION
Leave more space for Rover logo so it doesn't overlay text