### PR TITLE
Allow books to be in multiple subject categories

### DIFF
--- a/src/app/pages/subjects/book-viewer/book-viewer.js
+++ b/src/app/pages/subjects/book-viewer/book-viewer.js
@@ -18,15 +18,16 @@ function organizeBooksByCategory(books) {
     result[apId] = [];
 
     for (const book of books) {
-        const cmsCategory = book.subject;
-
-        if (!(cmsCategory in result)) {
-            result[cmsCategory] = [];
-        }
-        result[cmsCategory].push(book);
-        if (book.is_ap) {
-            result[apId].push(book);
-        }
+        book.subjects
+            .forEach((cmsCategory) => {
+                if (!(cmsCategory in result)) {
+                    result[cmsCategory] = [];
+                }
+                result[cmsCategory].push(book);
+                if (book.is_ap) {
+                    result[apId].push(book);
+                }
+            });
     }
 
     addLabels();


### PR DESCRIPTION
Use `subjects` field to categorize books (also still uses special AP flag).
No longer uses `subject` field from CMS at all. Will require that books be categorized using the `subjects` field to show up on the Subjects page.