### PR TITLE
Fix Contact page header

### DIFF
--- a/src/app/helpers/controller/salesforce-form-mixin.js
+++ b/src/app/helpers/controller/salesforce-form-mixin.js
@@ -1,7 +1,61 @@
 import $ from '~/helpers/$';
 import {on} from '~/helpers/controller/decorators';
+import mix from '~/helpers/controller/mixins';
 
-export default (superclass) => class extends superclass {
+export function salesforceFormFunctions(superclass) {
+    return class extends superclass {
+
+        @on('change')
+        updateOnChange() {
+            this.update();
+        }
+
+        @on('click [type="submit"]')
+        doCustomValidation(event) {
+            const invalid = Array.from(this.el.querySelectorAll('form :invalid'))
+                .find((el) => {
+                    const r = el.getBoundingClientRect();
+
+                    return r.top !== r.bottom;
+                });
+
+            this.hasBeenSubmitted = true;
+            if (invalid) {
+                $.scrollTo(invalid.parentNode);
+                event.preventDefault();
+                this.update();
+            }
+            this.submitClicked = true;
+            return invalid;
+        }
+
+        beforeSubmit() {
+            return true;
+        }
+
+        @on('submit form')
+        changeSubmitMode(e) {
+            // Running through beforeSubmit was somehow causing me to receive
+            // a second submit event. This stops that.
+            if (! this.submitClicked) {
+                e.stopImmediatePropagation();
+                e.preventDefault();
+                return;
+            }
+            this.submitClicked = false;
+            if (this.beforeSubmit()) {
+                this.submitted = true;
+                this.update();
+            } else {
+                e.stopImmediatePropagation();
+                e.preventDefault();
+            }
+        }
+
+    };
+}
+
+export default (superclass) => class extends mix(superclass).with(salesforceFormFunctions) {
 
     init() {
         if (super.init) {
@@ -32,53 +86,6 @@ export default (superclass) => class extends superclass {
                 coverUrl: book.cover_url
             }))
             .sort((a, b) => a.text < b.text ? -1 : 1);
-    }
-
-    @on('change')
-    updateOnChange() {
-        this.update();
-    }
-
-    @on('click [type="submit"]')
-    doCustomValidation(event) {
-        const invalid = Array.from(this.el.querySelectorAll('form :invalid'))
-            .find((el) => {
-                const r = el.getBoundingClientRect();
-
-                return r.top !== r.bottom;
-            });
-
-        this.hasBeenSubmitted = true;
-        if (invalid) {
-            $.scrollTo(invalid.parentNode);
-            event.preventDefault();
-            this.update();
-        }
-        this.submitClicked = true;
-        return invalid;
-    }
-
-    beforeSubmit() {
-        return true;
-    }
-
-    @on('submit form')
-    changeSubmitMode(e) {
-        // Running through beforeSubmit was somehow causing me to receive
-        // a second submit event. This stops that.
-        if (! this.submitClicked) {
-            e.stopImmediatePropagation();
-            e.preventDefault();
-            return;
-        }
-        this.submitClicked = false;
-        if (this.beforeSubmit()) {
-            this.submitted = true;
-            this.update();
-        } else {
-            e.stopImmediatePropagation();
-            e.preventDefault();
-        }
     }
 
 };

--- a/src/app/pages/contact/contact.js
+++ b/src/app/pages/contact/contact.js
@@ -1,7 +1,5 @@
-import SalesforceForm from '~/controllers/salesforce-form';
-import CMSPageController from '~/controllers/cms';
-import {canonicalLinkMixin} from '~/helpers/controller/init-mixin';
-import mix from '~/helpers/controller/mixins';
+import componentType, {canonicalLinkMixin, insertHtmlMixin} from '~/helpers/controller/init-mixin';
+import {salesforceFormFunctions} from '~/helpers/controller/salesforce-form-mixin';
 import salesforce from '~/models/salesforce';
 import router from '~/router';
 import $ from '~/helpers/$';
@@ -23,49 +21,34 @@ const subjects = [
     'Website',
     'OpenStax Polska'
 ];
+const spec = {
+    template,
+    css,
+    view: {
+        classes: ['contact-page', 'page']
+    },
+    model: {
+        salesforce,
+        subjects
+    },
+    slug: 'pages/contact'
+};
 
-class ContactData extends CMSPageController {
+export default class Contact extends componentType(
+    spec, salesforceFormFunctions, canonicalLinkMixin, insertHtmlMixin
+) {
 
     init() {
-        this.slug = 'pages/contact';
-        this.template = () => null;
-    }
-
-}
-
-const BaseClass = mix(SalesforceForm).with(canonicalLinkMixin);
-
-export default class Contact extends BaseClass {
-
-    init() {
-        this.dataController = new ContactData();
-        this.dataController.onDataLoaded = () => {
-            this.pageData = this.dataController.pageData;
-            this.onDataLoaded();
-        };
-        this.template = template;
-        this.css = css;
-        this.view = {
-            classes: ['contact-page', 'page']
-        };
-        this.model = {
-            salesforce,
-            subjects,
-            tagline: '',
-            title: '',
-            'mailing_header': '',
-            'mailing_address': '',
-            'phone_number': '',
-            validationMessage: (name) => {
-                const el = this.el.querySelector(`[name="${name}"]`);
-
-                return (this.hasBeenSubmitted && el) ? el.validationMessage : '';
-            }
-        };
         super.init();
+        this.model.validationMessage = (name) => {
+            const el = this.el.querySelector(`[name="${name}"]`);
+
+            return (this.hasBeenSubmitted && el) ? el.validationMessage : '';
+        };
     }
 
     onLoaded() {
+        super.onLoaded();
         document.title = 'Contact Us - OpenStax';
 
         // NOTE: Cannot set this in the template due to `each` restriction
@@ -91,9 +74,8 @@ export default class Contact extends BaseClass {
     }
 
     onDataLoaded() {
-        this.model = Object.assign(this.model, this.pageData);
+        Object.assign(this.model, this.pageData);
         this.update();
-        $.insertHtml(this.el, this.model);
     }
 
     @on('change [name="subject"]')


### PR DESCRIPTION
It was loading the Subjects page data as well as the Contact page data because the SalesforceFormMixin did that. I separated out the subject-loading functionality from the form functionality so the Contact page could use just the latter.