### PR TITLE
Hash generated script and style files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+indent_size = 4
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -23,6 +23,7 @@ module.exports = {
         'last 3 versions',
         'not ie < 11'
     ],
+    distUrlPrefix: '/cms/assets',
     name: project.name,
     version: project.version,
     license: project.license,

--- a/gulp/tasks/html.js
+++ b/gulp/tasks/html.js
@@ -1,19 +1,64 @@
 const gulp = require('gulp');
 const config = require('../config');
 const pi = require('gulp-load-plugins')();
+const rev = require('gulp-rev')
 
-function html() {
-    return gulp.src(`${config.dest}/*.html`, {
-        since: gulp.lastRun(html)
+const replaceURLs = (mapping) => {
+    let transform = gulp.src(`${config.src}/*.html`)
+    Object.keys(mapping).forEach((replacement) => {
+        transform = transform.pipe(
+            pi.replace(
+                new RegExp(`@${replacement}_URL@`, "g"),
+                mapping[replacement],
+            )
+        )
     })
-    .pipe(pi.replace(/@VERSION@/g, config.version))
-    .pipe(gulp.dest(config.dest));
+    return transform.pipe(gulp.dest(config.dest));
 }
 
+function hashFile(name) {
+    return () =>
+        gulp.src(`${config.dest}/${name}`)
+            .pipe(rev())
+            .pipe(gulp.dest(config.dest))
+            .pipe(rev.manifest({
+                path: `${config.dest}/rev-manifest.json`,
+                base: config.dest,
+                merge: true,
+            }))
+            .pipe(gulp.dest(config.dest))
+}
+
+// Don't need to do anything fancy in development, just replace the filename
+function devHTML() {
+    return replaceURLs({
+        BUNDLE:   '/bundle.js',
+        STYLES:   '/styles/main.css',
+        SETTINGS: '/settings.js',
+    })
+}
 function watchHtml() {
-    gulp.watch(`${config.dest}/*.html`, config.watchOpts)
-    .on('change', html);
+    gulp.watch(`${config.src}/*.html`, config.watchOpts)
+        .on('change', devHTML);
 }
+exports.devHTML = devHTML
+exports.devHTML.watch = watchHtml
 
-exports.html = html;
-exports.html.watch = watchHtml;
+// when building production distribution files,
+// include the file's SHA in the filenamnes
+function distHTML(distDone) {
+    return gulp.series(
+        hashFile('bundle.js'),   // while it might seem like this could be "parallel", that causes the
+        hashFile('settings.js'), // rev-manifest.json file to become mangled when both write to it
+        hashFile('styles/main.css'),
+        () => {
+            const revManifest = require(`../../${config.dest}/rev-manifest.json`);
+            return replaceURLs({
+                STYLES:   `${config.distUrlPrefix}/styles/${revManifest['main.css']}`,
+                BUNDLE:   `${config.distUrlPrefix}/${revManifest['bundle.js']}`,
+                SETTINGS: `${config.distUrlPrefix}/${revManifest['settings.js']}`,
+            })
+        }
+    )(distDone)
+}
+exports.distHTML = distHTML

--- a/gulp/tasks/humans.js
+++ b/gulp/tasks/humans.js
@@ -11,7 +11,7 @@ function humans() {
         stdio: [0, 'pipe', 'ignore']
     }).stdout.trim().split('\n');
 
-    return gulp.src(`${config.src}/index.html`)
+    return gulp.src(`${config.dest}/index.html`)
     .pipe(pi.humans({
         thanks: committers,
         site: [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,16 +1,17 @@
 const {series, parallel, task} = require('gulp');
 const allTheThings = require('require-dir')('./gulp/tasks');
 const {
-    clean, copy, development, production, favicon, html, scsslint, styles,
-    humans, images, eslint, scripts, settings, precache, templates, webpack,
-    watch
+  clean, copy, development, production, favicon, scsslint, styles,
+  humans, images, eslint, scripts, settings, precache, templates, webpack,
+  watch, devHTML, distHTML
 } = Object.assign({}, ...Object.values(allTheThings));
+
 
 const beforeWebpack = series(
     clean,
     parallel(
         copy,
-        series(favicon, html),
+        favicon,
         styles,
         scripts,
         templates,
@@ -25,6 +26,7 @@ module.exports = {
         development,
         beforeWebpack,
         settings,
+        devHTML,
         parallel(
             watch,
             webpack
@@ -34,6 +36,7 @@ module.exports = {
     dist: series(
         production,
         defaultBuild,
+        distHTML,
         precache,
         humans
     )

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
         "url": "https://github.com/openstax/os-webview.git"
     },
     "license": "AGPL-3.0",
-    "dependencies": {},
+    "dependencies": {
+        "gulp-rev": "^9.0.0"
+    },
     "devDependencies": {
         "babel-eslint": "7.2.3",
         "babel-jest": "*",

--- a/src/index.html
+++ b/src/index.html
@@ -51,9 +51,9 @@
         <script src="https://www.google-analytics.com/analytics.js"></script>
         <script src="https://cdn.optimizely.com/js/7893320024.js"></script>
         <script defer src="//script.crazyegg.com/pages/scripts/0013/0704.js"></script>
-        <script defer src="/settings.js?v2.32.0"></script>
+        <script defer src="@SETTINGS_URL@"></script>
         <script defer src="https://use.fontawesome.com/releases/v5.2.0/js/all.js"></script>
-        <script defer src="/bundle.js?v2.32.0"></script>
+        <script defer src="@BUNDLE_URL@"></script>
         <script>
             piAId = '219812';
             piCId = '1120';
@@ -69,7 +69,7 @@
             })();
         </script>
 
-        <link rel="stylesheet" href="/styles/main.css?v2.32.0">
+        <link rel="stylesheet" href="@STYLES_URL@">
         <link rel="stylesheet" href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.47.0/mapbox-gl.css'>
         <link rel="prefetch" href="/styles/fonts/3dac71eb-afa7-4c80-97f0-599202772905.woff2">
         <link rel="prefetch" href="/styles/fonts/531c5a28-5575-4f58-96d4-a80f7b702d7b.woff2">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4376,6 +4376,13 @@ first-chunk-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
   integrity sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=
 
+first-chunk-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
+  integrity sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=
+  dependencies:
+    readable-stream "^2.0.2"
+
 flagged-respawn@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
@@ -5162,6 +5169,20 @@ gulp-replace@0.6.1:
     istextorbinary "1.0.2"
     readable-stream "^2.0.1"
     replacestream "^4.0.0"
+
+gulp-rev@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-rev/-/gulp-rev-9.0.0.tgz#fe51b181c5fbbebfe740b64748d6980827e82878"
+  integrity sha512-Ytx/uzDA2xNxHlPG8GReS1ut00msd0HlKDk9Ai/0xF2yvg+DAeGRAviCFlQzQmdZtqAoXznYspwWoGEoxDvhyA==
+  dependencies:
+    modify-filename "^1.1.0"
+    plugin-error "^1.0.1"
+    rev-hash "^2.0.0"
+    rev-path "^2.0.0"
+    sort-keys "^2.0.0"
+    through2 "^2.0.0"
+    vinyl "^2.1.0"
+    vinyl-file "^3.0.0"
 
 gulp-sass@3.1.0:
   version "3.1.0"
@@ -7822,6 +7843,11 @@ mkdirp@*, mkdirp@0.5, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5
   dependencies:
     minimist "0.0.8"
 
+modify-filename@^1.0.0, modify-filename@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/modify-filename/-/modify-filename-1.1.0.tgz#9a2dec83806fbb2d975f22beec859ca26b393aa1"
+  integrity sha1-mi3sg4Bvuy2XXyK+7IWcoms5OqE=
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -9924,6 +9950,18 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+rev-hash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rev-hash/-/rev-hash-2.0.0.tgz#7720a236ed0c258df3e64bec03ec048b05b924c4"
+  integrity sha1-dyCiNu0MJY3z5kvsA+wEiwW5JMQ=
+
+rev-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rev-path/-/rev-path-2.0.0.tgz#10c978e824d76ce7dd1f7e66e88f50f5e71a0a6a"
+  integrity sha512-G5R2L9gYu9kEuqPfIFgO9gO+OhBWOAT83HyauOQmGHO6y9Fsa4acv+XsmNhNDrod0HDh1/VxJRmsffThzeHJlQ==
+  dependencies:
+    modify-filename "^1.0.0"
+
 rfg-api@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/rfg-api/-/rfg-api-0.3.0.tgz#42745648547f254f35d70edccf7cd3f465d9390a"
@@ -10459,6 +10497,13 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 sort-object@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/sort-object/-/sort-object-0.3.2.tgz#98e0d199ede40e07c61a84403c61d6c3b290f9e2"
@@ -10850,12 +10895,27 @@ strip-ansi@^5.0.0:
   dependencies:
     ansi-regex "^4.0.0"
 
+strip-bom-buf@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz#1cb45aaf57530f4caf86c7f75179d2c9a51dd572"
+  integrity sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=
+  dependencies:
+    is-utf8 "^0.2.1"
+
 strip-bom-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz#e7144398577d51a6bed0fa1994fa05f43fd988ee"
   integrity sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=
   dependencies:
     first-chunk-stream "^1.0.0"
+    strip-bom "^2.0.0"
+
+strip-bom-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz#f87db5ef2613f6968aa545abfe1ec728b6a829ca"
+  integrity sha1-+H217yYT9paKpUWr/h7HKLaoKco=
+  dependencies:
+    first-chunk-stream "^2.0.0"
     strip-bom "^2.0.0"
 
 strip-bom-string@1.X, strip-bom-string@^1.0.0:
@@ -11803,6 +11863,17 @@ vinyl-bufferstream@^1.0.1:
   dependencies:
     bufferstreams "1.0.1"
 
+vinyl-file@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vinyl-file/-/vinyl-file-3.0.0.tgz#b104d9e4409ffa325faadd520642d0a3b488b365"
+  integrity sha1-sQTZ5ECf+jJfqt1SBkLQo7SIs2U=
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.3.0"
+    strip-bom-buf "^1.0.0"
+    strip-bom-stream "^2.0.0"
+    vinyl "^2.0.1"
+
 vinyl-fs@^0.3.0:
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-0.3.14.tgz#9a6851ce1cac1c1cea5fe86c0931d620c2cfa9e6"
@@ -11883,7 +11954,7 @@ vinyl-sourcemaps-apply@^0.2.0, vinyl-sourcemaps-apply@^0.2.1:
   dependencies:
     source-map "^0.5.1"
 
-vinyl@*, vinyl@^2.0.0, vinyl@^2.1.0:
+vinyl@*, vinyl@^2.0.0, vinyl@^2.0.1, vinyl@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.2.0.tgz#d85b07da96e458d25b2ffe19fece9f2caa13ed86"
   integrity sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==


### PR DESCRIPTION
Adds a content segment to the script and style files and references them by their name.

I **think** this also fixes a few bugs:
  * The `src/index.html` file had hard-coded versions used as the query parameter, so the original regex in html.js would never match since the placeholders were not present
  * The 'humans.js` grunt task would overwrite `dist/index.html` with `src/index.html`.  So even if the `html.js`  substation had worked, it would have been overwritten.

Also while I'm personally a big fan of 4 space indent, my editor was setup to use 2 space for all OX projects.  I added an `.editorconfig` file so that it'd behave.