### PR TITLE
remove hashing from secrets.js, scripts in subdirectory

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -23,7 +23,7 @@ module.exports = {
         'last 3 versions',
         'not ie < 11'
     ],
-    distUrlPrefix: '/cms/assets',
+    urlPrefix: this.env === 'development' ? '' : '/cms/assets',
     name: project.name,
     version: project.version,
     license: project.license,

--- a/gulp/tasks/html.js
+++ b/gulp/tasks/html.js
@@ -16,23 +16,23 @@ const replaceURLs = (mapping) => {
     return transform.pipe(gulp.dest(config.dest));
 }
 
-function hashFile(name) {
+function hashFile(directory, name) {
     return () =>
-        gulp.src(`${config.dest}/${name}`)
+        gulp.src(`${config.dest}/${directory}/${name}`)
             .pipe(rev())
             .pipe(gulp.dest(config.dest))
             .pipe(rev.manifest({
                 path: `${config.dest}/rev-manifest.json`,
-                base: config.dest,
+                base: `${config.dest}/${directory}`,
                 merge: true,
             }))
-            .pipe(gulp.dest(config.dest))
+            .pipe(gulp.dest(`${config.dest}/${directory}`))
 }
 
 // Don't need to do anything fancy in development, just replace the filename
 function devHTML() {
     return replaceURLs({
-        BUNDLE:   '/bundle.js',
+        BUNDLE:   '/scripts/bundle.js',
         STYLES:   '/styles/main.css',
         SETTINGS: '/settings.js',
     })
@@ -48,15 +48,14 @@ exports.devHTML.watch = watchHtml
 // include the file's SHA in the filenamnes
 function distHTML(distDone) {
     return gulp.series(
-        hashFile('bundle.js'),   // while it might seem like this could be "parallel", that causes the
-        hashFile('settings.js'), // rev-manifest.json file to become mangled when both write to it
-        hashFile('styles/main.css'),
+        hashFile('scripts', 'bundle.js'),     // while it might seem like this could be "parallel",
+        hashFile('styles', 'main.css'),  // mangled when multiple writers access it
         () => {
             const revManifest = require(`../../${config.dest}/rev-manifest.json`);
             return replaceURLs({
-                STYLES:   `${config.distUrlPrefix}/styles/${revManifest['main.css']}`,
-                BUNDLE:   `${config.distUrlPrefix}/${revManifest['bundle.js']}`,
-                SETTINGS: `${config.distUrlPrefix}/${revManifest['settings.js']}`,
+                STYLES:   `${config.urlPrefix}/styles/${revManifest['main.css']}`,
+                BUNDLE:   `${config.urlPrefix}/scripts/${revManifest['bundle.js']}`,
+                SETTINGS: `${config.urlPrefix}/settings.js?${config.version}`,
             })
         }
     )(distDone)

--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -11,7 +11,7 @@ function webpack() {
     const output = {
         path: path.resolve(config.dest, '..'),
         filename: "bundle.js",
-        publicPath: "/", // for where to request chunks when the SinglePageApp changes the URL
+        publicPath: `${config.urlPrefix}/scripts`, // for where to request chunks when the SinglePageApp changes the URL
         chunkFilename: "chunk-[chunkhash].js"
     };
     const webpackConfig = {
@@ -63,7 +63,7 @@ function webpack() {
         `${config.dest}/app/main.js`
     ])
     .pipe(webpackStream(webpackConfig))
-    .pipe(gulp.dest(config.dest));
+    .pipe(gulp.dest(`${config.dest}/scripts`));
 }
 
 function loadOrReload(done) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,10 @@ const beforeWebpack = series(
 const defaultBuild = series(beforeWebpack, webpack);
 
 module.exports = {
-    default: defaultBuild,
+    default: series(
+        defaultBuild,
+        distHTML,
+    ),
     dev: series(
         development,
         beforeWebpack,


### PR DESCRIPTION
and also call the distHTML grunt task as part of the default task

Otherwise the substations don't happen and the build is broken utterly

I'm unsure of the `/cms/assets` prefix.  Maybe that should be set somewhere else since I don't think cloud front is active yet