### PR TITLE
add fonts.css to hashed styles

### DIFF
--- a/gulp/tasks/html.js
+++ b/gulp/tasks/html.js
@@ -55,6 +55,7 @@ function distHTML(distDone) {
     return gulp.series(
         hashFile('scripts', 'bundle.js'), // while it might seem like this could be "parallel",
         hashFile('styles', 'main.css'),   // mangled when multiple writers access it
+        hashFile('styles', 'fonts.css'),
         () => {
             const revManifest = require(`../../${config.dest}${config.urlPrefix}/rev-manifest.json`);
             return replaceURLs({

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -74,12 +74,17 @@ function compileChangedStyles() {
     return compileStyles(src);
 }
 
-function compileMainStyle() {
-
-    const src = gulp.src(`${config.src}/styles/main.scss`);
-    const dest = `${config.dest}${config.urlPrefix}/styles`;
-
-    return compileStyles(src, dest);
+function compileMainStyle(mainDone) {
+    return gulp.parallel(
+        () => compileStyles(
+            gulp.src(`${config.src}/styles/main.scss`),
+            `${config.dest}${config.urlPrefix}/styles`
+        ),
+        () => compileStyles(
+            gulp.src(`${config.src}/styles/fonts.scss`),
+            `${config.dest}${config.urlPrefix}/styles`
+        ),
+    )(mainDone)
 }
 
 function watchStyles() {


### PR DESCRIPTION
This way unified can read the manifest.json and re-load the fonts if needed