### PR TITLE
Fix data item spellings on Rover page

### DIFF
--- a/src/app/pages/rover-by-openstax/rover-by-openstax.js
+++ b/src/app/pages/rover-by-openstax/rover-by-openstax.js
@@ -66,7 +66,7 @@ export default class RoverRedesign extends BaseClass {
                         imageAltText: 'need some alt text',
                         description: c.blurb
                     })),
-                    webinarLink: data.section_3.button_link,
+                    webinarLink: data.section_3.buttonLink,
                     webinarLinkText: data.section_3.buttonCta
                 }
             }),
@@ -79,7 +79,7 @@ export default class RoverRedesign extends BaseClass {
                         description: c.blurb,
                         image: {
                             image: c.image.file,
-                            imageAltText: c.image_alt_text
+                            imageAltText: c.imageAltText
                         }
                     }))
                 }


### PR DESCRIPTION
I had converted names to camelCase, but was using underscore_separators