### PR TITLE
Fix stretched ally logo on Partners page

### DIFF
--- a/src/app/pages/partners/partners.scss
+++ b/src/app/pages/partners/partners.scss
@@ -23,7 +23,7 @@
 
         .ally-logo {
             display: block;
-            height: 100%;
+            height: auto;
             margin-top: 2rem;
             width: calc(15rem + 5%);
         }


### PR DESCRIPTION
Height was set to 100% for some reason.