### PR TITLE
Align rightmost menu dropdown with right edge

### DIFF
--- a/src/app/components/shell/header/main-menu/dropdown/dropdown.scss
+++ b/src/app/components/shell/header/main-menu/dropdown/dropdown.scss
@@ -14,7 +14,7 @@
 
 // Keeps rightmost menu from hanging off the screen
 .rightmost .dropdown-container {
-    right: -100%;
+    right: -$normal-margin;
 
     @include width-up-to($tablet-max) {
         right: auto;


### PR DESCRIPTION
The login menu used to be aligned with the left edge of the name; with short names that didn't give enough room onscreen for the menu itself. I initially overcorrected, but now have lined the login menu up with the right edge of the name.