### PR TITLE
Use location.origin for path

### DIFF
--- a/src/app/components/shell/header/header.js
+++ b/src/app/components/shell/header/header.js
@@ -27,8 +27,8 @@ class Header extends Controller {
         };
 
         this.model = {
-            login: `${settings.apiOrigin}/oxauth/login/`,
-            logout: `${settings.apiOrigin}/oxauth/logout/`,
+            login: `${window.location.origin}/oxauth/login/`,
+            logout: `${window.location.origin}/oxauth/logout/`,
             user: {
                 username: null,
                 groups: []


### PR DESCRIPTION
settings.apiOrigin is now an empty string, so we don't get the expected fully qualified path