### PR TITLE
Get Rover image out of the way of text

### DIFF
--- a/src/app/pages/rover-by-openstax/sections/getting-started.scss
+++ b/src/app/pages/rover-by-openstax/sections/getting-started.scss
@@ -18,14 +18,15 @@
 
         @include width-up-to($phone-max) {
             grid-template-columns: 100%;
+            margin-bottom: 2rem;
         }
 
         .text-block {
             @include wider-than($phone-max) {
-                padding-right: calc(30vw - 7rem);
+                padding-right: calc(30vw - 3rem);
             }
             @include wider-than($media-content-max) {
-                padding-right: calc(#{$media-content-max / 2} - 27vw);
+                padding-right: calc(#{$media-content-max / 2} - 22vw);
             }
         }
 

--- a/src/app/pages/rover-by-openstax/sections/meet-rover.scss
+++ b/src/app/pages/rover-by-openstax/sections/meet-rover.scss
@@ -15,11 +15,11 @@
         grid-row-gap: 4rem;
 
         @include wider-than($phone-max) {
-            padding-left: calc(8.33vw + 12rem);
+            padding-left: calc(20vw + 1rem);
         }
 
-        @include wider-than($wide-screen-min) {
-            padding-left: calc(68rem - 40vw);
+        @include wider-than($media-content-max) {
+            padding-left: 25rem;
         }
 
         > .text-block {

--- a/src/app/pages/rover-by-openstax/sections/navigator/navigator.html
+++ b/src/app/pages/rover-by-openstax/sections/navigator/navigator.html
@@ -1,7 +1,7 @@
 <template args="model">
     <div class="top-bar">{model.heading}</div>
     <div class="bottom-bar">
-        <div each="sec in model" class="navigation-item" data-target-id="{sec.id}">
+        <div each="sec in model" class="navigation-item" data-target-id="{sec.id}" role="button" tabindex="1">
             <div>{sec.heading}</div>
             <div class="{`indicator ${model.currentId === sec.id ? 'active' : ''}`}"></div>
         </div>

--- a/src/app/pages/rover-by-openstax/sections/navigator/navigator.js
+++ b/src/app/pages/rover-by-openstax/sections/navigator/navigator.js
@@ -38,4 +38,13 @@ export default class extends componentType(spec, insertHtmlMixin) {
         }, 200);
     }
 
+    @on('keydown .navigation-item')
+    navigateIfEnterOrSpace(event) {
+        if ([' ', 'Enter'].includes(event.key)) {
+            event.preventDefault();
+            event.delegateTarget.blur();
+            this.navigate(event);
+        }
+    }
+
 };

--- a/src/app/pages/rover-by-openstax/sections/navigator/navigator.scss
+++ b/src/app/pages/rover-by-openstax/sections/navigator/navigator.scss
@@ -16,18 +16,15 @@ $indicator-size: 1rem;
         @include title-font(1.6rem);
     }
 
-    @include width-between($phone-max, $tablet-max) {
+    @include wider-than($phone-max) {
         @include title-font(2rem);
-    }
-
-    @include wider-than($tablet-max) {
-        @include title-font(2.4rem);
     }
 
     .top-bar {
         background-color: ui-color(default);
         border-top-left-radius: 0.4rem;
         border-top-right-radius: 0.4rem;
+        font-size: 112%;
         display: grid;
         justify-content: center;
         padding: $normal-margin;
@@ -66,10 +63,13 @@ $indicator-size: 1rem;
         }
     }
 
-    .indicator.active {
-        background-color: os-color(light-blue);
+    .indicator {
         border-radius: #{$indicator-size / 2};
         height: $indicator-size;
         width: $indicator-size;
+
+        &.active {
+            background-color: os-color(light-blue);
+        }
     }
 }


### PR DESCRIPTION
Tweak Rover image placement so that it does not overlay the text on any size screen. (Except 601 pixels, which is a pattern library issue for which a fix PR is up.)