### PR TITLE
Pass pop up text to pulsing dot widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstax/os-webview",
-    "version": "2.34.0",
+    "version": "2.35.0",
     "description": "OpenStax webview",
     "scripts": {
         "test": "jest ./test/src"

--- a/src/app/pages/openstax-tutor/openstax-tutor.js
+++ b/src/app/pages/openstax-tutor/openstax-tutor.js
@@ -196,7 +196,11 @@ export default class Tutor extends BaseClass {
             mainSection.classList.add('openstax-tutor-main');
         }
 
-        const pulsingDot = new PulsingDot();
+        const pulsingDot = new PulsingDot({
+            model: {
+                html: data.pop_up_text
+            }
+        });
 
         this.regions.floatingTools.append(pulsingDot);
         if (window.location.hash) {


### PR DESCRIPTION
Fixes the issue of no popup displaying when you hover on the !-dot. Pulsing and stopping pulsing when clicked was not broken.