### PR TITLE
Fix nav items position on login

### DIFF
--- a/src/app/components/shell/header/main-menu/main-menu.html
+++ b/src/app/components/shell/header/main-menu/main-menu.html
@@ -15,13 +15,15 @@
         <li class="subjects-dropdown" skip="true"></li>
         <li class="technology-dropdown" skip="true"></li>
         <li class="what-we-do-dropdown" skip="true"></li>
-        <li class="nav-menu-item login{model.user.username ? ' dropdown' : ''}">
-            <if condition="!model.user.username">
+        <if condition="!model.user.username">
+            <li class="nav-menu-item login">
                 <a href="{model.login}" class="pardotTrackClick" data-local="true" role="menuitem">Login</a>
-            <else>
+            </li>
+        <else>
+            <li class="login dropdown">
                 <div class="login-dropdown rightmost" skip="true"></div>
-            </if>
-        </li>
+            </li>
+        </if>
     </ul>
     <button class="expand" aria-haspopup="true" aria-label="Toggle Meta Navigation Menu" tabindex="0">
       <span></span>


### PR DESCRIPTION
Remove `nav-menu-item` class from the `Hi, <name>` menu, because it has extra margin.