### PR TITLE
Ensure usermodel is loaded before page slug

### DIFF
--- a/src/app/helpers/controller/cms-mixin.js
+++ b/src/app/helpers/controller/cms-mixin.js
@@ -1,6 +1,7 @@
 import settings from 'settings';
 import $ from '~/helpers/$';
 import {bookPromise} from '~/models/book-titles';
+import userModel from '~/models/usermodel';
 
 const LOAD_IMAGES = Symbol();
 
@@ -60,6 +61,8 @@ async function getUrlFor(slug) {
 
 export async function fetchFromCMS(slug, preserveWrapping) {
     const apiUrl = await getUrlFor(slug);
+    // Ensure userModel is loaded before fetching a slug.
+    const userInfo = await userModel.load();
     const data = await fetch(apiUrl, {credentials: 'include'})
         .then((response) => response.json());
 

--- a/src/app/pages/blog-with-search/article-summary/article-summary.js
+++ b/src/app/pages/blog-with-search/article-summary/article-summary.js
@@ -2,7 +2,6 @@ import componentType, {insertHtmlMixin} from '~/helpers/controller/init-mixin';
 import {description as template} from './article-summary.html';
 import debounce from 'lodash/debounce';
 import $ from '~/helpers/$';
-import {fetchFromCMS} from '~/helpers/controller/cms-mixin';
 
 const spec = {
     template

--- a/src/app/pages/blog-with-search/more-stories/more-stories.js
+++ b/src/app/pages/blog-with-search/more-stories/more-stories.js
@@ -1,7 +1,6 @@
 import componentType from '~/helpers/controller/init-mixin';
 import ArticleSummary from '../article-summary/article-summary';
 import css from './more-stories.css';
-import {fetchFromCMS} from '~/helpers/controller/cms-mixin';
 
 const cardSpec = {
     view: {


### PR DESCRIPTION
Now that book details depend on the user (and other requests may, in the future), ensure user info is loaded before any slug.