### PR TITLE
Handle different-sizes of blog article images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstax/os-webview",
-    "version": "2.35.0",
+    "version": "2.36.0",
     "description": "OpenStax webview",
     "scripts": {
         "test": "jest ./test/src"

--- a/src/app/components/body-units/aligned-image.html
+++ b/src/app/components/body-units/aligned-image.html
@@ -1,6 +1,6 @@
 <template args="model">
-    <figure>
-        <img class="align-{model.alignment}" src="{model.imageUrl}" alt="{model.alt_text}">
+    <figure class="{model.alignmentClass}">
+        <img src="{model.imageUrl}" alt="{model.imageAlt}">
         <figcaption data-html="caption"></figcaption>
     </figure>
 </template>

--- a/src/app/components/body-units/body-units.js
+++ b/src/app/components/body-units/body-units.js
@@ -29,9 +29,14 @@ class AlignedImage extends BodyUnit {
     init(data) {
         super.init(data);
         this.template = alignedImageTemplate;
-        this.model = Object.assign({
-            imageUrl: data.image
-        }, data);
+        const selectedImage = data.image.original;
+
+        this.model = {
+            imageUrl: selectedImage.src,
+            imageAlt: selectedImage.alt,
+            caption: data.caption,
+            alignmentClass: ['left', 'right'].includes(data.alignment) ? data.alignment : ''
+        };
     }
 
     onLoaded() {

--- a/src/app/pages/blog/article/article.scss
+++ b/src/app/pages/blog/article/article.scss
@@ -2,9 +2,11 @@
 
 .blog.page .article {
     background-color: ui-color(white);
+    max-width: 100vw;
+    width: 100%;
 
     .hero {
-        background-position: 60% 40%;
+        background-position: 33% 20%;
         background-repeat: no-repeat;
         background-size: cover;
         height: 60rem;
@@ -12,6 +14,10 @@
         padding: 0;
         position: relative;
         width: 100vw;
+
+        @include width-up-to($phone-max) {
+            height: 40rem;
+        }
 
         @include wider-than($media-content-max) {
             height: calc(4rem + 40vw);
@@ -23,12 +29,14 @@
         @extend %text-content;
 
         align-items: flex-start;
+        width: 100%;
+        padding: 0 $normal-margin;
     }
 
     .body {
         img {
             margin-top: $normal-margin;
-            width: 100%;
+            max-width: 100%;
         }
 
         figcaption {
@@ -40,5 +48,31 @@
                 margin-top: 0;
             }
         }
+    }
+
+    figure {
+        display: grid;
+        justify-content: center;
+        margin: 0;
+
+        @include wider-than($phone-max) {
+            &.left,
+            &.right {
+                margin-right: $normal-margin;
+                max-width: 50%;
+            }
+
+            &.right {
+                float: right;
+            }
+
+            &.left {
+                float: left;
+            }
+        }
+    }
+
+    br {
+        display: none;
     }
 }

--- a/src/app/pages/blog/blog.scss
+++ b/src/app/pages/blog/blog.scss
@@ -2,8 +2,6 @@
 
 .blog.page {
     background-color: ui-color(white);
-    display: grid;
-    grid-row-gap: 3rem;
     justify-items: center;
     padding-bottom: 5rem;
     width: 100%;


### PR DESCRIPTION
If the alignment is "left" and not on phone, the image will be 50% of the text width and floated left. Similarly, "right" will float right.
Otherwise, the image will be up to the full width of the text.
