### PR TITLE
Notify blocked users that they cannot submit errata

### DIFF
--- a/src/app/components/dialog/dialog.js
+++ b/src/app/components/dialog/dialog.js
@@ -31,8 +31,9 @@ class Dialog extends Controller {
     }
 
     attachContent() {
-        if (this.props.content) {
+        if (this.props.content && !this.attached) {
             this.regions.main.append(this.props.content);
+            this.attached = true;
         }
     }
 

--- a/src/app/pages/errata-form/banned-notice/banned-notice.html
+++ b/src/app/pages/errata-form/banned-notice/banned-notice.html
@@ -1,0 +1,3 @@
+<template args="model">
+    {model.text}
+</template>

--- a/src/app/pages/errata-form/banned-notice/banned-notice.js
+++ b/src/app/pages/errata-form/banned-notice/banned-notice.js
@@ -1,0 +1,13 @@
+import componentType from '~/helpers/controller/init-mixin';
+import {description as template} from './banned-notice.html';
+import css from './banned-notice.css';
+
+const spec = {
+    template,
+    css,
+    view: {
+        classes: ['banned-notice']
+    }
+};
+
+export default componentType(spec);

--- a/src/app/pages/errata-form/banned-notice/banned-notice.scss
+++ b/src/app/pages/errata-form/banned-notice/banned-notice.scss
@@ -1,0 +1,5 @@
+@import 'pattern-library/core/pattern-library/headers';
+
+.banned-notice {
+    padding: $normal-margin;
+}

--- a/src/app/pages/errata-form/form/form.js
+++ b/src/app/pages/errata-form/form/form.js
@@ -4,6 +4,8 @@ import {on} from '~/helpers/controller/decorators';
 import $ from '~/helpers/$';
 import css from './form.css';
 import routerBus from '~/helpers/router-bus';
+import shellBus from '~/components/shell/shell-bus';
+import BannedNotice from '../banned-notice/banned-notice';
 import selectHandler from '~/handlers/select';
 import settings from 'settings';
 
@@ -146,6 +148,15 @@ export default class Form extends Controller {
         }).then((r) => r.json()).then((json) => {
             if (json.id) {
                 routerBus.emit('navigate', `/confirmation/errata?id=${json.id}`);
+            } else if (json.submitted_by_account_id) {
+                shellBus.emit('showDialog', () => ({
+                    title: 'Errata submission rejected',
+                    content: new BannedNotice({
+                        model: {
+                            text: json.submitted_by_account_id[0]
+                        }
+                    })
+                }));
             }
         }).catch((fetchError) => {
             this.model.submitFailed = `Submit failed: ${fetchError}.`;


### PR DESCRIPTION
When the CMS rejects errata submission, display the returned message in a dialog.