### PR TITLE
Make dialog cover menus

### DIFF
--- a/src/app/components/dialog/dialog.js
+++ b/src/app/components/dialog/dialog.js
@@ -86,6 +86,7 @@ class Dialog extends Controller {
         if (this.props.customClass) {
             this.el.classList.remove(this.props.customClass);
         }
+        this.attached = false;
     }
 
     @on('keydown')
@@ -107,7 +108,8 @@ export default class ModalDialog extends Controller {
     template() {}
 
     onLoaded() {
-        this.regions.self.attach(new ModalContent(this.dialog));
+        this.mc = new ModalContent(this.dialog);
+        this.regions.self.attach(this.mc);
     }
 
     update() {
@@ -116,8 +118,13 @@ export default class ModalDialog extends Controller {
         }
     }
 
+    hide() {
+        this.mc.hide();
+    }
+
     closeDialog() {
         this.dialog.closeDialog();
+        this.hide();
     }
 
 }

--- a/src/app/components/modal-content/modal-content.js
+++ b/src/app/components/modal-content/modal-content.js
@@ -1,10 +1,13 @@
 import {Controller} from 'superb.js';
-import $ from '~/helpers/$';
 import css from './modal-content.css';
 import shellBus from '~/components/shell/shell-bus';
 
 export default class ModalContent extends Controller {
 
+    /**
+     * Provides a background overlay that covers the page
+     * so that only the content is clearly visible and centered
+     */
     init(content) {
         this.content = content;
         this.view = {
@@ -18,12 +21,16 @@ export default class ModalContent extends Controller {
     }
 
     onLoaded() {
-        shellBus.emit('with-sticky');
         this.regions.self.append(this.content);
+        shellBus.emit('with-modal');
+    }
+
+    hide() {
+        shellBus.emit('no-modal');
     }
 
     onClose() {
-        shellBus.emit('no-sticky');
+        this.hide();
     }
 
 }

--- a/src/app/components/popup/popup.js
+++ b/src/app/components/popup/popup.js
@@ -20,11 +20,11 @@ export default class Popup extends Controller {
     }
 
     onLoaded() {
-        shellBus.emit('with-sticky');
+        shellBus.emit('with-modal');
     }
 
     onClose() {
-        shellBus.emit('no-sticky');
+        shellBus.emit('no-modal');
     }
 
     @on('click .dismiss')

--- a/src/app/components/shell/shell.js
+++ b/src/app/components/shell/shell.js
@@ -67,6 +67,7 @@ class Shell extends Controller {
                 closeDialog: () => {
                     region.el.setAttribute('hidden', '');
                     document.body.classList.remove('no-scroll');
+                    this.dialog.hide();
                 }
             });
             region.attach(this.dialog);
@@ -102,7 +103,14 @@ bus.on('no-sticky', () => {
         shell.regions.main.el.classList.remove('with-sticky');
     }
 });
-
+bus.on('with-modal', () => {
+    shell.regions.main.el.classList.add('with-modal');
+    document.body.classList.add('no-scroll');
+});
+bus.on('no-modal', () => {
+    shell.regions.main.el.classList.remove('with-modal');
+    document.body.classList.remove('no-scroll');
+});
 bus.on('updateDialog', () => shell.dialog.update());
 bus.on('showDialog', shell.showDialog.bind(shell));
 bus.on('hideDialog', shell.hideDialog.bind(shell));

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -151,6 +151,7 @@ sup {
 
 .no-scroll {
     overflow: hidden;
+    max-height: 100vh;
 }
 
 .mac-scroll {
@@ -199,8 +200,12 @@ sup {
     flex: 1 0 auto;
     z-index: 0;
 
-    &.with-sticky {
+    &.with-sticky:not(.with-modal) {
         z-index: 1;
+    }
+
+    &.with-modal {
+        z-index: 2;
     }
 }
 

--- a/test/src/components/modal-content.test.js
+++ b/test/src/components/modal-content.test.js
@@ -4,21 +4,12 @@ import shellBus from '~/components/shell/shell-bus';
 
 describe('ModalContent', () => {
 
-    it('sends "with-sticky" and "no-sticky" on attach and detatch', () => {
-
-        const gotWithSticky = new Promise((resolve) => {
-            shellBus.on('with-sticky', resolve, 'once');
-        });
-        const gotNoSticky = new Promise((resolve) => {
-            shellBus.on('with-sticky', resolve, 'once');
-        });
+    it('creates', () => {
 
         const mc = new ModalContent(new ResourceBox({}));
 
+        expect(mc).toBeTruthy();
         mc.detach();
-        return Promise.all([gotWithSticky, gotNoSticky]).then(() => {
-            return true;
-        });
     });
 
 });


### PR DESCRIPTION
Previously, menus were visible when a modal message was displayed. Now they are hidden behind the overlay. Page scrolling is also disabled when a modal is up.