### PR TITLE
Enable userid tracking for non-GDPR countries

### DIFF
--- a/src/app/components/dialog/dialog.scss
+++ b/src/app/components/dialog/dialog.scss
@@ -34,7 +34,7 @@ dialog {
         @include wider-than($phone-max) {
             align-items: center;
             color: inherit;
-            padding: 2.5rem 3rem;
+            padding: 1.5rem 3rem;
         }
     }
 

--- a/src/app/components/shell/cookie-notice/cookie-notice.scss
+++ b/src/app/components/shell/cookie-notice/cookie-notice.scss
@@ -8,7 +8,7 @@
     margin: $normal-margin;
     max-width: none;
     position: fixed;
-    width: 100%;
+    width: calc(100% - #{2 * $normal-margin});
 }
 
 .cookie-notice {

--- a/src/app/helpers/analytics.js
+++ b/src/app/helpers/analytics.js
@@ -30,6 +30,10 @@ class Analytics {
         this[SETUP_GA]();
     }
 
+    setUser(userId) {
+        window.ga('set', 'userid', userId);
+    }
+
     send(fields) {
         waitForAnalytics.then(
             () => {
@@ -232,9 +236,6 @@ class Analytics {
 
             if (typeof role !== 'undefined') {
                 window.ga('send', 'pageview', {dimension1: role, nonInteraction: true});
-            }
-            if ('id' in accountResponse) {
-                window.ga('set', 'userid', accountResponse.id.toString());
             }
         });
 


### PR DESCRIPTION
I have set this up to look for JP's proposed `is_gdpr_location` and to not show the notice or set the tracking cookie unless that is explicitly false. That unblocks this and leaves the cookie/notice inactive until Accounts is serving that new flag.