### PR TITLE
Update Crazy Egg, remove Optimizely

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstax/os-webview",
-    "version": "2.40.0",
+    "version": "2.41.0",
     "description": "OpenStax webview",
     "scripts": {
         "test": "jest ./test/src"

--- a/src/index.html
+++ b/src/index.html
@@ -7,8 +7,7 @@
         <meta name="description" content="">
 
         <script src="https://www.google-analytics.com/analytics.js"></script>
-        <script defer src="https://cdn.optimizely.com/js/7893320024.js"></script>
-        <script defer src="//script.crazyegg.com/pages/scripts/0013/0704.js"></script>
+        <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0084/9271.js" async="async"></script>
         <script defer src="@SETTINGS_URL@"></script>
         <script defer src="https://use.fontawesome.com/releases/v5.2.0/js/all.js"></script>
         <script defer src="@BUNDLE_URL@"></script>


### PR DESCRIPTION
We are now using our own Crazy Egg account instead of trial-piggybacking on our consultant's.