### PR TITLE
Fix local links opening in new tabs

### DIFF
--- a/src/app/helpers/link.js
+++ b/src/app/helpers/link.js
@@ -66,7 +66,7 @@ function stripOpenStaxDomain(href) {
 }
 
 function isExternal(href) {
-    return EXTERNAL.test(href);
+    return EXTERNAL.test(href) && !ABSOLUTE_OPENSTAX.test(href);
 }
 
 function isCNX(href) {


### PR DESCRIPTION
Test for external URL needed to exclude OpenStax addresses.
(Formerly OS domain was pre-stripped, but don't want to do that with the new umbrella domain.)