### PR TITLE
Fix TOC drawer height when closed

### DIFF
--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -66,6 +66,10 @@ $gradient-sequence: ui-color(white), ui-color(white) 50%, transparent;
                 padding-right: calc(50vw - #{$content-max / 2});
             }
 
+            &:not(.drawer-open) > .toc-slideout {
+                height: 0;
+            }
+
             > .toc-slideout {
                 background-color: ui-color(white);
                 border-right: thin solid ui-color(form-border);


### PR DESCRIPTION
It only gets set when it is open, and when it is closed, the text gets wrapped into something very tall.
Set height to zero when it is closed: solved.