### PR TITLE
Fix duplicate testimonial form on close and reopen

### DIFF
--- a/src/app/pages/separatemap/separatemap.js
+++ b/src/app/pages/separatemap/separatemap.js
@@ -84,6 +84,7 @@ export default class SeparateMap extends componentType(spec, canonicalLinkMixin,
 
                 tf.on('close-form', () => {
                     shellBus.emit('hideDialog');
+                    this.testimonialForm = null;
                 });
                 return tf;
             };
@@ -92,9 +93,12 @@ export default class SeparateMap extends componentType(spec, canonicalLinkMixin,
                 loggedIn: true
             });
             sb.on('submit-testimonial', () => {
+                if (!this.testimonialForm) {
+                    this.testimonialForm = newForm();
+                }
                 shellBus.emit('showDialog', () => ({
                     title: 'Submit your testimonial',
-                    content: newForm()
+                    content: this.testimonialForm
                 }));
             });
         });


### PR DESCRIPTION
Was displaying a new form every time the window opened, but only removing the previous form on submit. So closing the window caused duplicate form.