### PR TITLE
Fix iframe as target of forms issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstax/os-webview",
-    "version": "2.43.0",
+    "version": "2.44.0",
     "description": "OpenStax webview",
     "scripts": {
         "test": "jest ./test/src"

--- a/src/app/components/salesforce-form/salesforce-form.html
+++ b/src/app/components/salesforce-form/salesforce-form.html
@@ -1,0 +1,9 @@
+<template args="model">
+    <iframe name="form-response" id="form-response" class="hidden"
+        src="" width="0" height="0" tabindex="-1"></iframe>
+    <form accept-charset="UTF-8" class="form" target="form-response"
+        action="{model.postTo}" method="post">
+        <input type="hidden" name="orgid" value="{model.oid}">
+        <div class="form-content" skip="true"></div>
+    </form>
+</template>

--- a/src/app/components/salesforce-form/salesforce-form.js
+++ b/src/app/components/salesforce-form/salesforce-form.js
@@ -1,0 +1,45 @@
+import componentType from '~/helpers/controller/init-mixin';
+import busMixin from '~/helpers/controller/bus-mixin';
+import {salesforceFormFunctions} from '~/helpers/controller/salesforce-form-mixin';
+import {description as template} from './salesforce-form.html';
+import salesforce from '~/models/salesforce';
+import {on} from '~/helpers/controller/decorators';
+
+const defaultPostTo = `https://${salesforce.salesforceHome}/servlet/servlet.WebToCase?encoding=UTF-8`;
+const spec = {
+    template,
+    model() {
+        return {
+            oid: salesforce.oid,
+            postTo: this.postTo || defaultPostTo
+        };
+    },
+    afterSubmit() {
+        console.info('After Submit has fired');
+    },
+    postTo: null,
+    regions: {
+        formBody: '.form-content'
+    }
+};
+
+function selfRemovingListener(target, eventName, callback) {
+    const selfRemoving = (event) => {
+        callback(event);
+        target.removeEventListener(eventName, selfRemoving);
+    };
+
+    target.addEventListener(eventName, selfRemoving);
+}
+
+export default class extends componentType(spec, busMixin, salesforceFormFunctions) {
+
+    @on('submit form')
+    watchForResponse(event) {
+        const responseTarget = this.el.querySelector(`[name="${event.target.target}"]`);
+
+        this.listeningForResponse = true;
+        selfRemovingListener(responseTarget, 'load', this.afterSubmit.bind(this));
+    }
+
+};

--- a/src/app/helpers/controller/bus-mixin.js
+++ b/src/app/helpers/controller/bus-mixin.js
@@ -75,18 +75,10 @@ export default (superclass) => class extends superclass {
         this[BUS] = new Bus();
         this.on('update-props', (obj) => {
             Object.assign(this, obj);
-        });
-    }
-
-    onLoaded() {
-        if (super.onLoaded) {
-            super.onLoaded();
-        }
-        if (this.whenPropsUpdated) {
-            this.on('update-props', (obj) => {
+            if (this.whenPropsUpdated) {
                 this.whenPropsUpdated(obj);
-            });
-        }
+            }
+        });
     }
 
     on(...args) {

--- a/src/app/pages/adoption-confirmation/supplemental-form.html
+++ b/src/app/pages/adoption-confirmation/supplemental-form.html
@@ -5,7 +5,7 @@
             extra information below.
         </h2>
     </div>
-    <iframe name="form-response" id="form-response" src="" width="0" height="0"></iframe>
+    <iframe name="form-response" id="form-response" src="about:blank" width="0" height="0"></iframe>
     <form accept-charset="UTF-8" class="form" target="form-response"
      action="{model.salesforce.webtoleadUrl}" method="post">
         <div>

--- a/src/app/pages/contact/contact-form/contact-form.html
+++ b/src/app/pages/contact/contact-form/contact-form.html
@@ -1,0 +1,29 @@
+<template args="model">
+    <input type="hidden" name="external" value="1">
+    <label>
+        What is your question about?
+        <div skip="true" tabindex="0"></div>
+        <select name="subject">
+            <option each="subject in model.subjects" value="{subject}"
+                selected="{model.selected(subject)}">{subject}
+            </option>
+        </select>
+        <span class="invalid-message">{model.validationMessage('subject')}</span>
+    </label>
+    <label>
+        Your Name
+        <input name="name" type="text" size="20" required>
+        <span class="invalid-message">{model.validationMessage('name')}</span>
+    </label>
+    <label>
+        Your Email Address
+        <input name="email" type="email" required>
+        <span class="invalid-message">{model.validationMessage('email')}</span>
+    </label>
+    <label class="auto-height">
+        Your Message
+        <textarea cols="50" name="description" rows="6" required skip="true"></textarea>
+        <span class="invalid-message">{model.validationMessage('description')}</span>
+    </label>
+    <input type="submit" value="Send" class="btn btn-orange">
+</template>

--- a/src/app/pages/contact/contact-form/contact-form.js
+++ b/src/app/pages/contact/contact-form/contact-form.js
@@ -1,0 +1,73 @@
+import componentType from '~/helpers/controller/init-mixin';
+import busMixin from '~/helpers/controller/bus-mixin';
+import {salesforceFormFunctions} from '~/helpers/controller/salesforce-form-mixin';
+import {description as template} from './contact-form.html';
+import selectHandler from '~/handlers/select';
+import $ from '~/helpers/$';
+import {on} from '~/helpers/controller/decorators';
+
+const subjects = [
+    'General',
+    'Adopting OpenStax Textbooks',
+    'OpenStax Tutor Support',
+    'OpenStax CNX',
+    'Donations',
+    'College/University Partnerships',
+    'Media Inquiries',
+    'Foundational Support',
+    'OpenStax Partners',
+    'Website',
+    'OpenStax Polska'
+];
+const spec = {
+    template,
+    model() {
+        return {
+            subjects,
+            selected: (subj) => $.booleanAttribute(subj === this.selectedSubject),
+            validationMessage: this.validationMessage
+        };
+    }
+};
+
+export default class extends componentType(spec, busMixin, salesforceFormFunctions) {
+
+    init(...args) {
+        if (super.init) {
+            super.init(...args);
+        }
+        const queryDict = $.parseSearchString(window.location.search);
+
+        this.selectedSubject = queryDict.subject ? queryDict.subject[0] : 'General';
+        this.validationMessage = (name) => {
+            const el = this.el.querySelector(`[name="${name}"]`);
+
+            return (this.hasBeenSubmitted && el) ? el.validationMessage : '';
+        };
+    }
+
+    onLoaded() {
+        if (super.onLoaded) {
+            super.onLoaded();
+        }
+        selectHandler.setup(this);
+        this.notifyIfPolishStateChanged();
+    }
+
+    notifyIfPolishStateChanged() {
+        const newPolishState = this.selectedSubject === 'OpenStax Polska';
+
+        if (this.polishState !== newPolishState) {
+            this.emit('is-polish', newPolishState);
+            this.polishState = newPolishState;
+        }
+    }
+
+    @on('change [name="subject"]')
+    updateSelectedSubject(event) {
+        this.selectedSubject = event.target.value;
+        this.update();
+        this.notifyIfPolishStateChanged();
+    }
+
+};

--- a/src/app/pages/contact/contact.html
+++ b/src/app/pages/contact/contact.html
@@ -8,40 +8,7 @@
         </div>
         <img class="strips" src="/images/components/strips.svg" height="10" alt="" role="presentation">
         <div class="boxed left-justified">
-            <div class="col">
-                <iframe name="form-response" id="form-response" src="" width="0" height="0"></iframe>
-                <form class="form" action="{model.formTarget}"
-                target="form-response" method="post">
-                    <input type="hidden" name="orgid" value="{model.salesforce.oid}">
-                    <input type="hidden" name="external" value="1">
-                    <label>
-                        What is your question about?
-                        <div skip="true" tabindex="0"></div>
-                        <select name="subject">
-                            <option each="subject in model.subjects" value="{subject}"
-                                selected="{model.selected(subject)}">{subject}
-                            </option>
-                        </select>
-                        <span class="invalid-message">{model.validationMessage('subject')}</span>
-                    </label>
-                    <label>
-                        Your Name
-                        <input name="name" type="text" size="20" required>
-                        <span class="invalid-message">{model.validationMessage('name')}</span>
-                    </label>
-                    <label>
-                        Your Email Address
-                        <input name="email" type="email" required>
-                        <span class="invalid-message">{model.validationMessage('email')}</span>
-                    </label>
-                    <label class="auto-height">
-                        Your Message
-                        <textarea cols="50" name="description" rows="6" required skip="true"></textarea>
-                        <span class="invalid-message">{model.validationMessage('description')}</span>
-                    </label>
-                    <input type="submit" value="Send" class="btn btn-orange">
-                </form>
-            </div>
+            <div class="col form-container" skip="true"></div>
             <div class="col">
                 <h2>{model.mailing_header}</h2>
                 <address data-html="mailing_address" skip="true"></address>

--- a/src/app/pages/contact/contact.js
+++ b/src/app/pages/contact/contact.js
@@ -1,86 +1,53 @@
-import componentType, {canonicalLinkMixin, insertHtmlMixin, loaderMixin} from '~/helpers/controller/init-mixin';
-import {salesforceFormFunctions} from '~/helpers/controller/salesforce-form-mixin';
-import salesforce from '~/models/salesforce';
+import componentType, {canonicalLinkMixin, insertHtmlMixin} from '~/helpers/controller/init-mixin';
+import SalesforceForm from '~/components/salesforce-form/salesforce-form';
+import ContactForm from './contact-form/contact-form';
 import routerBus from '~/helpers/router-bus';
-import $ from '~/helpers/$';
-import {on} from '~/helpers/controller/decorators';
-import selectHandler from '~/handlers/select';
 import {description as template} from './contact.html';
 import css from './contact.css';
 
-const subjects = [
-    'General',
-    'Adopting OpenStax Textbooks',
-    'OpenStax Tutor Support',
-    'OpenStax CNX',
-    'Donations',
-    'College/University Partnerships',
-    'Media Inquiries',
-    'Foundational Support',
-    'OpenStax Partners',
-    'Website',
-    'OpenStax Polska'
-];
 const spec = {
     template,
+    model() {
+        return Object.assign({}, this.pageData);
+    },
     css,
     view: {
         classes: ['contact-page', 'page']
     },
-    model() {
-        return Object.assign({
-            salesforce,
-            subjects,
-            selected: this.isSelected,
-            validationMessage: this.validationMessage,
-            formTarget: this.selectedSubject === 'OpenStax Polska' ?
-                '/apps/cms/api/mail/send_mail' :
-                `https://${salesforce.salesforceHome}/servlet/servlet.WebToCase?encoding=UTF-8`
-        }, this.pageData);
-    },
     slug: 'pages/contact'
 };
 
-export default class Contact extends componentType(
-    spec, salesforceFormFunctions, canonicalLinkMixin, insertHtmlMixin, loaderMixin
+export default class extends componentType(
+    spec, canonicalLinkMixin, insertHtmlMixin
 ) {
 
-    init() {
-        super.init();
-        const queryDict = $.parseSearchString(window.location.search);
-
-        this.selectedSubject = queryDict.subject ? queryDict.subject[0] : 'General';
-        this.isSelected = (subj) => $.booleanAttribute(subj === this.selectedSubject);
-        this.validationMessage = (name) => {
-            const el = this.el.querySelector(`[name="${name}"]`);
-
-            return (this.hasBeenSubmitted && el) ? el.validationMessage : '';
-        };
-        document.title = 'Contact Us - OpenStax';
-    }
-
-    setUpForm() {
-        selectHandler.setup(this);
-        this.formResponseEl = this.el.querySelector('#form-response');
-        this.goToConfirmation = () => {
-            if (this.submitted) {
-                this.submitted = false;
-                routerBus.emit('navigate', '/confirmation/contact');
-            }
-        };
-        this.formResponseEl.addEventListener('load', this.goToConfirmation);
+    onUpdate() {
+        if (super.onUpdate) {
+            super.onUpdate();
+        }
     }
 
     onDataLoaded() {
-        this.hideLoader();
+        if (super.onDataLoaded) {
+            super.onDataLoaded();
+        }
         this.update();
-        this.setUpForm();
+        const formContainer = this.el.querySelector('.form-container');
+        const sfForm = new SalesforceForm({
+            afterSubmit: () => {
+                routerBus.emit('navigate', '/confirmation/contact');
+            }
+        });
+        const formBody = new ContactForm({
+            el: sfForm.regions.formBody.el
+        });
+
+        this.regionFrom(formContainer).attach(sfForm);
+        formBody.on('is-polish', (whether) => {
+            sfForm.emit('update-props', {
+                postTo: whether ? '/apps/cms/api/mail/send_mail' : null
+            });
+        });
     }
 
-    @on('change [name="subject"]')
-    setFormTarget(event) {
-        this.selectedSubject = event.target.value;
-        this.update();
-    }
-
-}
+};

--- a/src/app/pages/contact/contact.scss
+++ b/src/app/pages/contact/contact.scss
@@ -65,7 +65,7 @@
             resize: none;
         }
 
-        > label {
+        > .form-content > label {
             display: block;
             height: $form-element-height;
             margin-bottom: $form-element-height;

--- a/src/app/pages/details/request-form/request-form.html
+++ b/src/app/pages/details/request-form/request-form.html
@@ -8,7 +8,7 @@
             <div class="header">Book requested</div>
             <img src="{model.coverUrl}">
             {model.title}
-            <iframe name="form-response" id="form-response" src="" width="0" height="0"></iframe>
+            <iframe name="form-response" id="form-response" src="about:blank" width="0" height="0"></iframe>
         </div>
         <form accept-charset="UTF-8" target="form-response"
          action="{model.salesforce.webtoleadUrl}" method="post"

--- a/src/app/pages/give/give.html
+++ b/src/app/pages/give/give.html
@@ -485,7 +485,7 @@
             </div>
         </div>
         <div>
-          <iframe name="form-response" id="form-response" src="" width="0" height="0"></iframe>
+          <iframe name="form-response" id="form-response" src="about:blank" width="0" height="0"></iframe>
           <form id="donation-update" accept-charset="UTF-8" class="form" target="form-response"
            action="{model.salesforce.webtoleadUrl}" method="post">
               <input type="hidden" name="oid" value="{model.salesforce.oid}">

--- a/src/app/pages/separatemap/separatemap.js
+++ b/src/app/pages/separatemap/separatemap.js
@@ -84,6 +84,7 @@ export default class SeparateMap extends componentType(spec, canonicalLinkMixin,
 
                 tf.on('close-form', () => {
                     shellBus.emit('hideDialog');
+                    this.testimonialForm = null;
                 });
                 return tf;
             };
@@ -92,9 +93,12 @@ export default class SeparateMap extends componentType(spec, canonicalLinkMixin,
                 loggedIn: true
             });
             sb.on('submit-testimonial', () => {
+                if (!this.testimonialForm) {
+                    this.testimonialForm = newForm();
+                }
                 shellBus.emit('showDialog', () => ({
                     title: 'Submit your testimonial',
-                    content: newForm()
+                    content: this.testimonialForm
                 }));
             });
         });


### PR DESCRIPTION
I recently discovered that there are two ways to insert a component. The "new" way doesn't create in intermediate container element, so I started using it. Due to a still-not-understood quirk in the framework, using that method caused form targeting to fail.
Investigating the problem gave me a chance to refactor the Contact form. The new components will be useful in refactoring adoption and interest forms, reducing redundant code.