### PR TITLE
Minimize use of /api/user

### DIFF
--- a/src/app/components/shell/adoption-dialog/adoption-dialog.js
+++ b/src/app/components/shell/adoption-dialog/adoption-dialog.js
@@ -100,7 +100,6 @@ export class AdoptionDialog extends componentType(spec, busMixin, salesforceForm
     }
 
     notReadyToSubmit() {
-        console.info(this.adoptions.map((obj) => obj.title));
         return this.adoptions.find((obj) => obj.title === '');
     }
 

--- a/src/app/components/shell/header/main-menu/main-menu.js
+++ b/src/app/components/shell/header/main-menu/main-menu.js
@@ -54,9 +54,7 @@ export default class MainMenu extends Controller {
                 {url: '/institutional-partnership', label: 'Institutional Partnerships'}
             ]
         }));
-        attachLoginMenu(this.regions.loginMenu.el).then((c) => {
-            this.loginMenuComponent = c;
-        });
+        attachLoginMenu(this.regions.loginMenu.el);
     }
 
 }

--- a/test/src/components/shell/header.test.js
+++ b/test/src/components/shell/header.test.js
@@ -1,5 +1,6 @@
+import userModel from '~/models/usermodel';
 import header from '~/components/shell/header/header';
-import {clickElement} from '../../test-utils';
+import {clickElement} from '../../../test-utils';
 
 describe('Header', () => {
 

--- a/test/src/components/shell/main-menu.test.js
+++ b/test/src/components/shell/main-menu.test.js
@@ -1,9 +1,0 @@
-import MainMenu from '~/components/shell/header/main-menu/main-menu';
-
-describe('main-menu', () => {
-    const m = new MainMenu();
-
-    it('creates', () => {
-        expect(m).toBeTruthy();
-    });
-});


### PR DESCRIPTION
Redid the user info cache (which was broken). Cache is invalidated by leaving the window (like by going to another tab), and data refreshes when tab is re-entered. This way you might login in another tab and when you come back, the Login menu updates.
