### PR TITLE
Allow closing school info tooltips on map

### DIFF
--- a/src/app/helpers/link.js
+++ b/src/app/helpers/link.js
@@ -2,7 +2,7 @@ import settings from 'settings';
 
 const EXTERNAL = /^((f|ht)tps?:)?\/\//;
 const ABSOLUTE_OPENSTAX = new RegExp(
-    `(?:https?://openstax.org|${window.location.origin})(?!/(?:books|accounts|oxauth|blog-feed|support))`
+    `(?:https?://openstax.org|${window.location.origin})(?!/(?:books|accounts|oxauth|blog-feed)/)`
 );
 const MAILTO = /^mailto:(.+)/;
 const PDF = /.pdf$/;

--- a/src/app/helpers/map-api.js
+++ b/src/app/helpers/map-api.js
@@ -137,7 +137,14 @@ class BaseClass {
         if (!hasLngLat(schoolInfo)) {
             return;
         }
-        let html = `<b>${schoolInfo.fields.name}</b>`;
+        let html = `
+        <div class="put-away">
+            <button type="button">
+                <i  class="fa fa-times"></i>
+            </button>
+        </div>
+        <b>${schoolInfo.fields.name}</b>
+        `;
 
         if (schoolInfo.cityState) {
             html += `<br>${schoolInfo.cityState}`;

--- a/src/app/pages/separatemap/separatemap.js
+++ b/src/app/pages/separatemap/separatemap.js
@@ -111,6 +111,7 @@ export default class SeparateMap extends componentType(spec, canonicalLinkMixin,
                 sb.emit('show-one-school', schoolInfo);
             });
         });
+        this.map = map;
     }
 
     @on('click .popup-msg-cross')
@@ -119,6 +120,11 @@ export default class SeparateMap extends componentType(spec, canonicalLinkMixin,
             this.popupVisible = false;
             this.update();
         }
+    }
+
+    @on('click .mapboxgl-popup-content .put-away button')
+    closetooltip() {
+        this.map.tooltip.remove();
     }
 
     onClose() {

--- a/src/app/pages/separatemap/separatemap.scss
+++ b/src/app/pages/separatemap/separatemap.scss
@@ -84,6 +84,7 @@ $small-shadow: 0 0.2rem 0.5rem 0 rgba(0, 0, 0, 0.15);
         box-shadow: $big-shadow;
         color: text-color(normal);
         display: grid;
+        grid-auto-flow: column;
         grid-gap: 0;
         position: fixed;
         right: 2rem;
@@ -163,7 +164,18 @@ $small-shadow: 0 0.2rem 0.5rem 0 rgba(0, 0, 0, 0.15);
     }
 
     .mapboxgl-popup {
-        pointer-events: none;
+        .put-away {
+            display: grid;
+            justify-content: right;
+
+            > button {
+                background-color: unset;
+                color: unset;
+                cursor: pointer;
+                padding: 0.3rem;
+            }
+        }
     }
+
 
 }


### PR DESCRIPTION
They close if you click elsewhere on the map, but that may not be obvious.
I don't think this part of the code is testable.