### PR TITLE
Fix missing footer-copyright

### DIFF
--- a/src/app/components/shell/footer/footer.html
+++ b/src/app/components/shell/footer/footer.html
@@ -31,7 +31,7 @@
     <div class="bottom">
         <div class="boxed">
             <div class="copyrights">
-                <div data-html="copyright"></div>
+                <div data-html="copyright" skip="true"></div>
                 <ap-html data-html="apStatement" skip="true"></ap-html>
             </div>
 

--- a/src/app/pages/interest/interest.js
+++ b/src/app/pages/interest/interest.js
@@ -74,6 +74,7 @@ export default class InterestForm extends BaseClass {
             longLabel: 'How many students do you teach each semester?',
             type: 'number',
             min: '1',
+            max: '999',
             required: true,
             validationMessage: (name) => validationMessage.bind(howManyStudents)(name)
         });


### PR DESCRIPTION
Issue #700
Behavior consistent with an update overwriting inserted HTML. Noticed the element did not have `skip` which prevents such overwrites.