### PR TITLE
Add videos tab to book details page

### DIFF
--- a/src/app/pages/details/details.js
+++ b/src/app/pages/details/details.js
@@ -7,6 +7,7 @@ import InstructorResourceTab from './instructor-resource-tab/instructor-resource
 import PartnersTab from './partners-tab/partners-tab';
 import PhoneView from './phone-view/phone-view';
 import StudentResourceTab from './student-resource-tab/student-resource-tab';
+import VideosTab from './videos-tab/videos-tab';
 import TabGroup from '~/components/tab-group/tab-group';
 import userModel from '~/models/usermodel';
 import {formatDateForBlog as formatDate} from '~/helpers/data';
@@ -284,6 +285,14 @@ export default class Details extends BaseClass {
                 ally: {
                     heading: this.pageData.ally_content.content.heading,
                     blurb: this.pageData.ally_content.content.content
+                }
+            }));
+        }
+
+        if (this.pageData.videos.length) {
+            addTab('Videos', new VideosTab({
+                model: {
+                    videos: this.pageData.videos[0]
                 }
             }));
         }

--- a/src/app/pages/details/videos-tab/videos-tab.html
+++ b/src/app/pages/details/videos-tab/videos-tab.html
@@ -1,0 +1,7 @@
+<template args="model">
+    <div each="item in model.videos" class="video-block">
+        <h2 class="title">{item.title}</h2>
+        <div data-html="videos[{$item}].description" skip="true" class="description"></div>
+        <div data-html="videos[{$item}].embed" skip="true" class="embed"></div>
+    </div>
+</template>

--- a/src/app/pages/details/videos-tab/videos-tab.js
+++ b/src/app/pages/details/videos-tab/videos-tab.js
@@ -1,0 +1,13 @@
+import componentType, {insertHtmlMixin} from '~/helpers/controller/init-mixin';
+import {description as template} from './videos-tab.html';
+import css from './videos-tab.css';
+
+const spec = {
+    template,
+    css,
+    view: {
+        classes: ['videos-tab']
+    }
+};
+
+export default componentType(spec, insertHtmlMixin);

--- a/src/app/pages/details/videos-tab/videos-tab.scss
+++ b/src/app/pages/details/videos-tab/videos-tab.scss
@@ -1,0 +1,27 @@
+@import 'pattern-library/core/pattern-library/headers';
+
+.videos-tab {
+    .video-block {
+        align-content: start;
+        display: grid;
+        grid-column-gap: 3rem;
+        grid-template: 'title embed'
+        'description embed' 1fr;
+        justify-content: left;
+        margin-bottom: 4rem;
+
+        .title {
+            grid-area: title;
+            margin: 0;
+        }
+
+        .embed {
+            grid-area: embed;
+        }
+
+        .description {
+            grid-area: description;
+            max-width: $text-content-max;
+        }
+    }
+}

--- a/test/src/data/details-biology-2e.js
+++ b/test/src/data/details-biology-2e.js
@@ -3418,5 +3418,6 @@ export default {
         "id": "8d50a0af-948b-4204-a71d-4826cba765b8@15.3"
     },
     "tutor_marketing_book": true,
-    "promote_image": null
+    "promote_image": null,
+    "videos": []
 };

--- a/test/src/data/details-polish.js
+++ b/test/src/data/details-polish.js
@@ -1553,5 +1553,6 @@ export default {
         "title": "Fizyka dla szkół wyższych. Tom 1"
     },
     "tutor_marketing_book": false,
-    "promote_image": null
+    "promote_image": null,
+    "videos": []
 };

--- a/test/src/data/details.js
+++ b/test/src/data/details.js
@@ -3679,7 +3679,8 @@ const details = {
             }
         ]
     },
-    "tutor_marketing_book": true
+    "tutor_marketing_book": true,
+    "videos": []
 };
 
 for (const prop in details) {


### PR DESCRIPTION
This is an experimental feature. If there are `videos` on the book details page, it will display a video tab. So don't do that in production.
Issue #727