### PR TITLE
Fix date format

### DIFF
--- a/src/app/helpers/errata.js
+++ b/src/app/helpers/errata.js
@@ -4,7 +4,7 @@ function approvedStatuses(detail) {
     const y = posted.getFullYear();
     const postedSpring = m > 1 && m < 9;
     const correctionSeason = postedSpring ? `Fall ${y}` : `Spring ${y + 1}`;
-    const correctionDate = new Date(postedSpring ? `${y}-11-1` : `${y + 1}-3-1`);
+    const correctionDate = new Date(postedSpring ? `${y}/11/1` : `${y + 1}/3/1`);
     const done = Date.now() > correctionDate;
     const barStatus = done ? 'Corrected' : 'Will correct';
 


### PR DESCRIPTION
Safari does not accept 'yyyy-mm-dd' as a Date initializer. Need to use slashes.
Issue #768