### PR TITLE
Use current rex version in toc links

### DIFF
--- a/src/app/models/table-of-contents-html.js
+++ b/src/app/models/table-of-contents-html.js
@@ -1,11 +1,23 @@
 import settings from 'settings';
 
-function cnxFetch(cnxId) {
-    return fetch(`//archive.cnx.org/contents/${cnxId}.json`)
-        .then((r) => r.json());
-}
-
 export default function ({isRex, cnxId, webviewLink}) {
+    const rexUrl = new URL(webviewLink);
+
+    function cnxFetch() {
+        const rexOrigin = rexUrl.origin;
+
+        if (isRex) {
+            return fetch(`${rexOrigin}/rex/environment.json`)
+                .then((r) => r.json())
+                .then((r) => fetch(`${rexOrigin}/rex/releases/${r.release_id}/rex/release.json`))
+                .then((r) => r.json())
+                .then((r) => fetch(`//archive.cnx.org/contents/${cnxId}@${r.books[cnxId]}`))
+                .then((r) => r.json());
+        }
+        return fetch(`//archive.cnx.org/contents/${cnxId}.json`)
+            .then((r) => r.json());
+    }
+
     function pageLink(entry) {
         const rexRoot = webviewLink.replace(/\/pages\/.*/, '');
 
@@ -34,7 +46,7 @@ export default function ({isRex, cnxId, webviewLink}) {
         return htmlEntities;
     }
 
-    return cnxFetch(cnxId).then(
+    return cnxFetch().then(
         (cnxData) => buildTableOfContents(cnxData.tree.contents, 'div').join(''),
         (err) => {
             console.warn(`Error fetching TOC for ${cnxId}: ${err}`);

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,6 @@
                 else { window.addEventListener('load', async_load, false); }
             })();
         </script>
-        <link rel="preconnect" href="https://pi.pardot.com">
         <link rel="stylesheet" href="@STYLES_URL@">
         <link rel="prefetch" href="/apps/cms/api/books?format=json">
         <link rel="prefetch" href="/apps/cms/api/footer?format=json">


### PR DESCRIPTION
Due to CORS issues, this cannot be tested on cms-dev. It will have to go to staging or something that has its REX origin the same as the osweb origin.