### PR TITLE
(Hotfix) Stop using allies list from book details

### DIFF
--- a/src/app/helpers/analytics.js
+++ b/src/app/helpers/analytics.js
@@ -182,11 +182,6 @@ class Analytics {
                 this.sourceByUrl[resource.link_document_url] = `${item.title} ${marker}`;
             });
         });
-        item.book_allies.forEach((ally) => {
-            const url = ally.book_link_url;
-
-            this.sourceByUrl[url] = ally.ally_heading;
-        });
     }
 
     lookupUrl(selectedUrl) {


### PR DESCRIPTION
(It was used for analytics, but the data is no longer attached to the book)