### PR TITLE
Fix partner Type value list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstax/os-webview",
-    "version": "2.52.1",
+    "version": "2.52.2",
     "description": "OpenStax webview",
     "scripts": {
         "test": "jest ./test/src"

--- a/src/app/pages/partners/controls/controls.js
+++ b/src/app/pages/partners/controls/controls.js
@@ -58,7 +58,7 @@ export const typeOptions = [
     },
     {
         label: 'Adaptive courseware',
-        value: 'Courseware'
+        value: 'Adaptive Courseware'
     }
 ];
 


### PR DESCRIPTION
Was going to be a hotfix, but is just going into the next release.
Needs to be coordinated with a change in Salesforce.