### PR TITLE
Fix dates for Errata

### DIFF
--- a/src/app/pages/errata-detail/errata-detail.js
+++ b/src/app/pages/errata-detail/errata-detail.js
@@ -8,7 +8,11 @@ import ProgressBar from './progress-bar/progress-bar';
 
 function localizedDate(dateStr) {
     if (dateStr) {
-        return new Date(dateStr).toLocaleDateString();
+        const d = new Date(dateStr);
+        const off = d.getTimezoneOffset();
+
+        d.setMinutes(d.getMinutes() + off);
+        return d.toLocaleDateString();
     }
     return '';
 }


### PR DESCRIPTION
`reviewed_date` and `corrected_date` come in as date-only, which `new Date` interprets as being GMT. This adjusts by the timezone offset so that the local date matches the intended date.