### PR TITLE
Chrome only: wrap long titles in errata ToC

### DIFF
--- a/src/app/pages/errata-form/form/ErrorLocationSelector/ErrorLocationSelector.scss
+++ b/src/app/pages/errata-form/form/ErrorLocationSelector/ErrorLocationSelector.scss
@@ -9,6 +9,10 @@
         display: initial;
         padding-left: 0.7rem;
 
+        option {
+            white-space: normal;
+        }
+
         .indent-1 {
             margin-left: 1rem;
         }


### PR DESCRIPTION
Issue #1013
There is no solution in browsers other than Chrome