### PR TITLE
eliminate 30x redirects due to missing trailing slash

### DIFF
--- a/src/app/components/shell/footer/footer.js
+++ b/src/app/components/shell/footer/footer.js
@@ -18,7 +18,9 @@ class Footer extends CMSPageController {
         /* eslint arrow-parens: 0 */
         (async () => {
             try {
-                const response = await fetch(`${settings.apiOrigin}${settings.apiPrefix}/documents?search=press%20kit`);
+                const response = await fetch(
+                    `${settings.apiOrigin}${settings.apiPrefix}/documents/?search=press%20kit`
+                );
                 const data = await response.json();
 
                 if (data.length) {

--- a/src/app/components/shell/sticky-note/sticky-note.js
+++ b/src/app/components/shell/sticky-note/sticky-note.js
@@ -15,7 +15,7 @@ class StickyNote extends CMSPageController {
         this.view = {
             classes: ['sticky-note']
         };
-        this.slug = 'sticky';
+        this.slug = 'sticky/';
         this.model = () => this.getModel();
         this.temporary = false;
         this.content = '';

--- a/src/app/helpers/controller/cms-mixin.js
+++ b/src/app/helpers/controller/cms-mixin.js
@@ -30,7 +30,7 @@ export function transformData(data) {
 }
 
 async function getUrlFor(slug) {
-    let apiUrl = `${settings.apiOrigin}${settings.apiPrefix}/${slug}`;
+    let apiUrl = `${settings.apiOrigin}${settings.apiPrefix}/${slug}/`;
 
     // A little magic to handle book titles
     const strippedSlug = slug.replace(/^books\/(.*)/, '$1');

--- a/src/app/pages/details/details.scss
+++ b/src/app/pages/details/details.scss
@@ -206,7 +206,7 @@ $gradient-sequence: ui-color(white), ui-color(white) 50%, transparent;
                 }
 
                 .title-image {
-                    max-height: 100%;
+                    height: 100%;
                 }
 
                 .title-logo {

--- a/src/index.html
+++ b/src/index.html
@@ -35,9 +35,9 @@
             })();
         </script>
         <link rel="stylesheet" href="@STYLES_URL@">
-        <link rel="prefetch" href="/apps/cms/api/books?format=json">
-        <link rel="prefetch" href="/apps/cms/api/footer?format=json">
-        <link rel="prefetch" href="/apps/cms/api/pages/openstax-homepage?format=json">
+        <link rel="prefetch" href="/apps/cms/api/books/?format=json">
+        <link rel="prefetch" href="/apps/cms/api/footer/?format=json">
+        <link rel="prefetch" href="/apps/cms/api/pages/openstax-homepage/?format=json">
         <script>
         (function() {
             var w = window, d = document;

--- a/test/helpers/fetch-mocker.js
+++ b/test/helpers/fetch-mocker.js
@@ -47,7 +47,7 @@ global.fetch = jest.fn().mockImplementation((...args) => {
     const isOsTutor = (/pages\/openstax-tutor/).test(args[0]);
     const isPartner = (/pages\/partners/).test(args[0]);
     const isPolishPhysics = (/fizyka/).test(args[0]);
-    const isPress = (/api\/press\?/).test(args[0]);
+    const isPress = (/api\/press\/\?/).test(args[0]);
     const isPressArticle = (/api\/press\//).test(args[0]);
     const isPrintOrder = (/pages\/print-order/).test(args[0]);
     const isResearch = (/pages\/research/).test(args[0]);


### PR DESCRIPTION
We've done good work over time to eliminate 30x redirects for our content on osweb (the ones that are just redirecting to add a trailing slash), but there are still 18 of them remaining.  They slow our site down and cost us in terms of requests made through Cloudfront.  Would be great if we could eliminate the remaining ones.  

Here's a stab at a few of them.

* I don't know where to fix the one for https://openstax.org/apps/cms/api/sticky?format=json
* I also can't see where to fix the ones for the images e.g. https://openstax.org/apps/cms/api/images/921

Ideally, a load of the home page should show no openstax.org 30x's in the chrome inspector.