### PR TITLE
Fix v2 requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstax/os-webview",
-    "version": "2.52.2",
+    "version": "2.60.0",
     "description": "OpenStax webview",
     "scripts": {
         "test": "jest ./test/src"

--- a/src/app/helpers/controller/cms-mixin.js
+++ b/src/app/helpers/controller/cms-mixin.js
@@ -1,6 +1,7 @@
 import settings from 'settings';
 import $ from '~/helpers/$';
 import bookPromise from '~/models/book-titles';
+import {urlFromSlug} from '~/models/cmsFetch';
 
 const LOAD_IMAGES = Symbol();
 
@@ -29,25 +30,21 @@ export function transformData(data) {
     return data;
 }
 
-async function getUrlFor(slug) {
-    const possibleSlash = slug.endsWith('/') ? '' : '/';
-    let apiUrl = `${settings.apiOrigin}${settings.apiPrefix}/${slug}${possibleSlash}`;
+async function getUrlFor(initialSlug) {
+    let apiUrl = urlFromSlug(initialSlug);
 
     // A little magic to handle book titles
-    const strippedSlug = slug.replace(/^books\/(.*)/, '$1');
+    if (initialSlug.startsWith('books/')) {
+        const strippedSlug = initialSlug.substr(6);
 
-    if (strippedSlug) {
-        const bookList = await bookPromise;
-        const bookEntry = bookList.find((e) => e.meta.slug === strippedSlug);
+        if (strippedSlug) {
+            const bookList = await bookPromise;
+            const bookEntry = bookList.find((e) => e.meta.slug === strippedSlug);
 
-        if (bookEntry) {
-            apiUrl = bookEntry.meta.detail_url;
+            if (bookEntry) {
+                apiUrl = bookEntry.meta.detail_url;
+            }
         }
-    }
-
-    // A little magic to handle the news slug
-    if (slug === 'news') {
-        apiUrl = `${settings.apiOrigin}${settings.apiPrefix}/pages/openstax-news`;
     }
 
     const qsChar = (/\?/.test(apiUrl)) ? '&' : '?';

--- a/src/app/models/book-titles.js
+++ b/src/app/models/book-titles.js
@@ -1,4 +1,4 @@
 import cmsFetch from './cmsFetch';
 
-export default cmsFetch('v2/pages/?type=books.Book&fields=title,id&limit=250')
+export default cmsFetch('pages/?type=books.Book&fields=title,id&limit=250')
     .then((r) => r.items);

--- a/src/app/models/cmsFetch.js
+++ b/src/app/models/cmsFetch.js
@@ -1,8 +1,19 @@
 import settings from 'settings';
 import memoize from 'lodash/memoize';
 
+export function urlFromSlug(initialSlug) {
+    const slug = initialSlug === 'news' ? 'pages/openstax-news' : initialSlug;
+    const possibleSlash = slug.endsWith('/') ? '' : '/';
+    const apiPrefix = slug.includes('pages') ? settings.apiPrefix :
+        settings.apiPrefix.replace('/v2', '');
+
+    return `${settings.apiOrigin}${apiPrefix}/${slug}${possibleSlash}`;
+}
+
 export default async function cmsFetch(path) {
-    return await (await fetch(`${settings.apiOrigin}${settings.apiPrefix}/${path}`)).json();
+    const url = path.replace(/[^?]+/, urlFromSlug);
+
+    return await (await fetch(url)).json();
 }
 
 /**

--- a/test/helpers/fetch-mocker.js
+++ b/test/helpers/fetch-mocker.js
@@ -32,7 +32,7 @@ global.fetch = jest.fn().mockImplementation((...args) => {
     const isAdoption = (/pages\/adoption-form/).test(args[0]);
     const isBiology = (/v2\/pages\/207/).test(args[0]);
     const isBlogArticle = (/blog-article/).test(args[0]);
-    const isBooks = (/api\/v2\/books/).test(args[0]);
+    const isBooks = (/api\/books/).test(args[0]);
     const isBooksForAnalytics = (/book_student_resources/).test(args[0]);
     const isBookTitles = (/fields=title,id/).test(args[0]);
     const isErrata = (/pages\/errata\/$/).test(args[0]);
@@ -40,24 +40,24 @@ global.fetch = jest.fn().mockImplementation((...args) => {
     const isErrata7199 = (/errata[?/]7199/).test(args[0]);
     const isErrataResources = (/errata-fields\?field/).test(args[0]);
     const isErrataSummary = args[0] === 'https://cms-dev.openstax.org/apps/cms/api/pages/errata?format=json';
-    const isFooter = (/api\/v2\/footer/).test(args[0]);
+    const isFooter = (/api\/footer/).test(args[0]);
     const isInstitutionalPartnership = (/pages\/institutional-partners/).test(args[0]);
     const isHomepage = (/openstax-homepage/).test(args[0]);
     const isOsNews = (/openstax-news/).test(args[0]);
     const isOsTutor = (/pages\/openstax-tutor/).test(args[0]);
     const isPartner = (/pages\/partners/).test(args[0]);
     const isPolishPhysics = (/fizyka/).test(args[0]);
-    const isPress = (/api\/v2\/press\/\?/).test(args[0]);
-    const isPressArticle = (/api\/v2\/press\//).test(args[0]);
+    const isPress = (/api\/press\/\?/).test(args[0]);
+    const isPressArticle = (/api\/press\//).test(args[0]);
     const isPrintOrder = (/pages\/print-order/).test(args[0]);
     const isResearch = (/pages\/research/).test(args[0]);
     const isRoles = (/snippets\/roles/).test(args[0]);
     const isSchools = (/salesforce\/schools/).test(args[0]);
-    const isSticky = (/api\/v2\/sticky/).test(args[0]);
+    const isSticky = (/api\/sticky/).test(args[0]);
     const isSubjects = (/snippets\/subjects/).test(args[0]);
     const isTeam = (/pages\/team/).test(args[0]);
-    const isUser = (/accounts.*\/api\/v2\/user/).test(args[0]);
-    const isImage = (/api\/v2\/images/).test(args[0]);
+    const isUser = (/accounts.*\/api\/user/).test(args[0]);
+    const isImage = (/api\/images/).test(args[0]);
     const isArchive = (/archive\.cnx/).test(args[0]);
 
     return new Promise(


### PR DESCRIPTION
Attaching to #853, but this is really just a bug fix.
Book page errata messages can be updated in the CMS.