### PR TITLE
Fix trailing-slash issue

### DIFF
--- a/src/app/models/cmsFetch.js
+++ b/src/app/models/cmsFetch.js
@@ -3,7 +3,7 @@ import memoize from 'lodash/memoize';
 
 export function urlFromSlug(initialSlug) {
     const slug = initialSlug === 'news' ? 'pages/openstax-news' : initialSlug;
-    const possibleSlash = slug.endsWith('/') ? '' : '/';
+    const possibleSlash = (slug.endsWith('/') || slug.includes('?')) ? '' : '/';
     const apiPrefix = slug.includes('pages') ? $.apiOriginAndPrefix :
         $.apiOriginAndOldPrefix;
 


### PR DESCRIPTION
Issue #1230
Was adding a slash to query parameters at the end of a url.
Fix: don't add slash when url includes query string