### PR TITLE
DO show "Request instructor access" link in Login Menu when no faculty info

### DIFF
--- a/src/app/models/usermodel.js
+++ b/src/app/models/usermodel.js
@@ -86,7 +86,7 @@ function oldUserModel(sfUserModel) {
         }) || {}).value;
     const isStudent = ['student', 'unknown_role'].includes(sfUserModel.self_reported_role);
     const pending = !isStudent &&
-        ['pending_faculty', 'no_faculty_info'].includes(sfUserModel.faculty_status);
+        ['pending_faculty'].includes(sfUserModel.faculty_status);
     const groups = (function () {
         const result = (sfUserModel.applications || [])
             .map((obj) => obj.name)


### PR DESCRIPTION
The only time when the "Request instructor access" link shouldn't show is when instructors' `faculty_status == pending_faculty` because that means that they have already applied. 


This PR makes it so by removing `'no_faculty_info'` from the array that we check in order to determine when an instructor is "pending" access because the result from this check is used in the [login-menu.js](https://github.com/openstax/os-webview/blob/68e25083f6fad94520e286d4bc823bf744d84359/src/app/components/shell/header/main-menu/login-menu/login-menu.js#L76-L82).