### PR TITLE
Patch to v2.65.0 — Bring back "Request instructor access" link

### DIFF
--- a/src/app/components/shell/header/main-menu/login-menu/login-menu.js
+++ b/src/app/components/shell/header/main-menu/login-menu/login-menu.js
@@ -62,7 +62,7 @@ class LoginMenu extends componentType(spec, busMixin) {
 
     attachLoginDropdown() {
         const facultySignupStep4 = `${settings.accountHref}/i/signup/educator/profile_form`;
-        const reqFacultyAccessLink = `${settings.accountHref}/i/signup/educator/cs_form`;
+        const facultyAccessLink = `${settings.accountHref}/faculty_access/apply`;
         const items = [
             {
                 label: 'Account Profile',
@@ -83,14 +83,15 @@ class LoginMenu extends componentType(spec, busMixin) {
                     this.user.stale_verification
                 )
             },
-            // {
-            //     label: 'Request instructor access',
-            //     url: reqFacultyAccessLink,
-            //     exclude: () => Boolean(
-            //         (this.user.groups || []).includes('Faculty') ||
-            //         (!this.user.stale_verification && this.user.pending_verification)
-            //     )
-            // },
+            {
+                label: 'Request instructor access',
+                url: facultyAccessLink,
+                exclude: () => Boolean(
+                    (this.user.groups || []).includes('Faculty') ||
+                    (this.user.groups || []).includes('Student') ||
+                    this.user.pending_verification
+                )
+            },
             {
                 get url() {
                     return linkHelper.logoutLink();

--- a/src/app/components/shell/header/main-menu/login-menu/login-menu.js
+++ b/src/app/components/shell/header/main-menu/login-menu/login-menu.js
@@ -88,7 +88,6 @@ class LoginMenu extends componentType(spec, busMixin) {
                 url: facultyAccessLink,
                 exclude: () => Boolean(
                     (this.user.groups || []).includes('Faculty') ||
-                    (this.user.groups || []).includes('Student') ||
                     this.user.pending_verification
                 )
             },


### PR DESCRIPTION
It was removed **entirely** by accident when trying to revert some changes that didn't pass QA tests. It should, instead, have been reverted to the logic before the changes which didn't pass QA tests. This PR fixes that.