### PR TITLE
Handle long titles in Adoption/Interest forms

### DIFF
--- a/src/app/components/book-checkbox/book-checkbox.scss
+++ b/src/app/components/book-checkbox/book-checkbox.scss
@@ -9,12 +9,12 @@
     display: grid;
     grid-gap: $normal-margin;
     grid-template-columns: 1fr auto;
-    height: $form-element-height;
+    min-height: $form-element-height;
     padding-left: $normal-margin;
 
     &.has-image {
         grid-template-columns: $form-element-height 1fr auto;
-        padding-left: 0;
+        padding: 0.3rem;
     }
 
     &.checked {

--- a/src/app/pages/details/phone-view/instructor-resources-pane/instructor-resources-pane.scss
+++ b/src/app/pages/details/phone-view/instructor-resources-pane/instructor-resources-pane.scss
@@ -41,7 +41,7 @@
             @include set-font(h4);
         }
 
-        .Login to unlockx {
+        .resource-box {
             width: 20rem;
 
             &.double {


### PR DESCRIPTION
This is a simple fix. It doesn't match the design, but it's better than before.