### PR TITLE
adding a robots.txt to cms-*.openstax.org

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,3 @@
+# robots.txt
+User-agent: *
+Disallow: /


### PR DESCRIPTION
There is already a robots.txt in place in CloudFront, this file will block Google from indexing the cms-*.openstax.org URLs.