### PR TITLE
Hide header and footer when printing

### DIFF
--- a/src/app/pages/blog/more-stories/more-stories.scss
+++ b/src/app/pages/blog/more-stories/more-stories.scss
@@ -50,4 +50,8 @@ $image-height: 24rem;
     h2 {
         @include title-font(2.4rem);
     }
+
+    @media print {
+        display: none;
+    }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -186,6 +186,10 @@ sup {
         position: sticky;
         top: -5rem;
     }
+
+    @media print {
+        display: none;
+    }
 }
 
 #lower-sticky-note {
@@ -237,6 +241,10 @@ sup {
 
 #footer {
     z-index: 0;
+
+    @media print {
+        display: none;
+    }
 }
 
 #maincontent {


### PR DESCRIPTION
Also hide the "more stories" section on blog posts, which take along time to lay out, and probably aren't what a person wants when printing an article.