### PR TITLE
Clear "too many matching results"

### DIFF
--- a/src/app/pages/separatemap/search-box/results.js
+++ b/src/app/pages/separatemap/search-box/results.js
@@ -28,7 +28,7 @@ function useSchoolsPromise(searchString, filters, institution) {
 
 // eslint-disable-next-line complexity
 export default function useResults(searchString, selectedFilters, institution) {
-    const nothingSelected = searchString === '' && institution === '' &&
+    const nothingSelected = searchString === '' &&
         Array.from(selectedFilters.values()).length === 0;
     const schoolsPromise = useSchoolsPromise(searchString, selectedFilters, institution);
     const results = useDataFromPromise(schoolsPromise);


### PR DESCRIPTION
Ignore whether an institution type is selected; if the other inputs are clear, don't show the message.