### PR TITLE
fix archive override handling

### DIFF
--- a/src/app/models/rex-release.js
+++ b/src/app/models/rex-release.js
@@ -32,9 +32,11 @@ const fetchContents = memoize((cnxId, rexOrigin) => {
               ? archiveOverride.replace(/^\/apps\/archive\//, '')
               : rexInfo.config.REACT_APP_ARCHIVE
             ;
-            const bookVersion = rexInfo.release.books[cnxId].defaultVersion;
 
-            return fetch(`${window.SETTINGS.apiOrigin}/apps/archive/${archiveVersion}/contents/${cnxId}@${bookVersion}.json`);
+            const bookVersion = rexInfo.release.books[cnxId].defaultVersion;
+            const archivePath = `apps/archive/${archiveVersion}`;
+
+            return fetch(`${window.SETTINGS.apiOrigin}/${archivePath}/contents/${cnxId}@${bookVersion}.json`);
         })
         .then((response) => response.json());
 });

--- a/src/app/models/rex-release.js
+++ b/src/app/models/rex-release.js
@@ -27,16 +27,14 @@ const fetchContents = memoize((cnxId, rexOrigin) => {
     }
     return fetchRexInfo(rexOrigin)
         .then((rexInfo) => {
-            const archiveVersion = rexInfo.release.books[cnxId].archiveOverride || rexInfo.config.REACT_APP_ARCHIVE;
+            const archiveOverride = rexInfo.release.books[cnxId].archiveOverride;
+            const archiveVersion = archiveOverride
+              ? archiveOverride.replace(/^\/apps\/archive\//, '')
+              : rexInfo.config.REACT_APP_ARCHIVE
+            ;
             const bookVersion = rexInfo.release.books[cnxId].defaultVersion;
 
-            // this line is only necessary to support rex releases without the REACT_APP_ARCHIVE parameter,
-            // remove after 9/22/21 release is on production
-            const archivePath = archiveVersion ?
-                `/apps/archive/${archiveVersion}` :
-                rexInfo.config.REACT_APP_ARCHIVE_URL;
-
-            return fetch(`${window.SETTINGS.apiOrigin}${archivePath}/contents/${cnxId}@${bookVersion}.json`);
+            return fetch(`${window.SETTINGS.apiOrigin}/apps/archive/${archiveVersion}/contents/${cnxId}@${bookVersion}.json`);
         })
         .then((response) => response.json());
 });


### PR DESCRIPTION
archiveOverride currently includes `/apps/archive` even though i would prefer for it not to. the current logic had it putting that prefix in twice, this change makes it work, and will continue to work if i remove the prefix from the override.