### PR TITLE
Scroll to top when new page loads

### DIFF
--- a/src/app/components/shell/router.js
+++ b/src/app/components/shell/router.js
@@ -156,10 +156,18 @@ function FallbackToGeneralPage({name}) {
 
 function ImportedPage({name}) {
     const {Component, loadError} = useImportedComponent(name);
+    const history = useHistory();
 
     useAnalyticsPageView();
 
-    useEffect(() => window.scrollTo(0, 0), [name]);
+    useEffect(
+        () => {
+            if (history.action === 'PUSH') {
+                window.scrollTo(0, 0);
+            }
+        },
+        [name, history.action]
+    );
 
     if (loadError) {
         return (<FallbackToGeneralPage name={name} />);

--- a/src/app/components/shell/router.js
+++ b/src/app/components/shell/router.js
@@ -159,6 +159,8 @@ function ImportedPage({name}) {
 
     useAnalyticsPageView();
 
+    useEffect(() => window.scrollTo(0, 0), [name]);
+
     if (loadError) {
         return (<FallbackToGeneralPage name={name} />);
     }


### PR DESCRIPTION
The trick is when a new page loads, not simply a pathname change.