### PR TITLE
Added meta tags to the home page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,19 @@
         <title>OpenStax</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
-        <meta name="description" content="">
+        <meta name="description" content="OpenStax offers free college textbooks for all types of students, making education accessible &amp; affordable for everyone. Browse our list of available subjects!">
+        <meta property="og:url" content="https://openstax.org/" />
+        <meta property="og:type" content="article" />
+        <meta property="og:title" content="OpenStax | Free Textbooks Online with No Catch" />
+        <meta property="og:description" content="OpenStax offers free college textbooks for all types of students, making education accessible &amp; affordable for everyone. Browse our list of available subjects!" />
+        <meta property="og:image" content="https://assets.openstax.org/oscms-prodcms/media/images/Turning_textbook_highlighting_into_time_well-sp.original.jpg" />
+        <meta property="og:image:alt" content="OpenStax: OpenStax | Free Textbooks Online with No Catch" />
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:site" content="@OpenStax">
+        <meta name="twitter:title" content="OpenStax | Free Textbooks Online with No Catch">
+        <meta name="twitter:description" content="OpenStax offers free college textbooks for all types of students, making education accessible &amp; affordable for everyone. Browse our list of available subjects!">
+        <meta name="twitter:image" content="https://assets.openstax.org/oscms-prodcms/media/images/Turning_textbook_highlighting_into_time_well-sp.original.jpg">
+        <meta name="twitter:image:alt" content="OpenStax">
         <link rel="preload" as="font" type="font/woff2" crossorigin
             href="/cms/assets/fonts/5b1fbd62-45dc-4433-a7df-a2b24a146411.woff2">
         <link rel="preconnect" href="https://pi.pardot.com" crossorigin>


### PR DESCRIPTION
Temporary solution that works for the home page only.
The url is also production-specific and the image is loaded from prod only.