### PR TITLE
Fix CORS for webview-settings preloading and fonts

### DIFF
--- a/src/app/models/cmsFetch.js
+++ b/src/app/models/cmsFetch.js
@@ -13,10 +13,9 @@ export function urlFromSlug(initialSlug) {
 
 export default async function cmsFetch(path) {
     const url = path.replace(/[^?]+/, urlFromSlug);
-    const mode = process.env.API_ORIGIN ? 'cors' : 'no-cors';
 
     try {
-        return (await retry(() => fetch(url, {mode}))).json();
+        return (await retry(() => fetch(url))).json();
     } catch (err) {
         return Promise.reject(new Error(`Failed to fetch ${path}: ${err}`));
     }

--- a/src/app/models/cmsFetch.js
+++ b/src/app/models/cmsFetch.js
@@ -13,9 +13,10 @@ export function urlFromSlug(initialSlug) {
 
 export default async function cmsFetch(path) {
     const url = path.replace(/[^?]+/, urlFromSlug);
+    const mode = process.env.API_ORIGIN ? 'cors' : 'no-cors';
 
     try {
-        return (await retry(() => fetch(url))).json();
+        return (await retry(() => fetch(url, {mode}))).json();
     } catch (err) {
         return Promise.reject(new Error(`Failed to fetch ${path}: ${err}`));
     }

--- a/src/app/pages/blog/blog.js
+++ b/src/app/pages/blog/blog.js
@@ -14,12 +14,12 @@ import timers from './timers';
 import './blog.scss';
 
 function Document({title}) {
-  useEffect(
-    () => {document.title = title;},
-    [title]
-  )
+    useEffect(
+        () => {document.title = title;},
+        [title]
+    );
 
-  return null;
+    return null;
 }
 
 export function SearchResultsPage() {

--- a/src/index.html
+++ b/src/index.html
@@ -17,10 +17,10 @@
         <meta name="twitter:description" content="OpenStax offers free college textbooks for all types of students, making education accessible &amp; affordable for everyone. Browse our list of available subjects!">
         <meta name="twitter:image" content="https://assets.openstax.org/oscms-prodcms/media/images/Turning_textbook_highlighting_into_time_well-sp.original.jpg">
         <meta name="twitter:image:alt" content="OpenStax">
-        <link rel="preload" href="<%= process.env.API_ORIGIN %>/apps/cms/api/webview-settings/" as="fetch" <%= process.env.API_ORIGIN ? 'crossorigin' : '' %>>
-        <link rel="preload" as="font" type="font/woff2" crossorigin
+        <link rel="preload" href="<%= process.env.API_ORIGIN %>/apps/cms/api/webview-settings/" as="fetch" <%= process.env.API_ORIGIN ? 'crossorigin="anonymous"' : '' %>>
+        <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous"
             href="<%= process.env.API_ORIGIN %>/cms/assets/fonts/5b1fbd62-45dc-4433-a7df-a2b24a146411.woff2">
-        <link rel="preconnect" href="https://pi.pardot.com" crossorigin>
+        <link rel="preconnect" href="https://pi.pardot.com" crossorigin="anonymous">
         <!-- Anti-flicker snippet (recommended)  -->
         <style>.async-hide { opacity: 0 !important} </style>
         <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@
         <meta name="twitter:description" content="OpenStax offers free college textbooks for all types of students, making education accessible &amp; affordable for everyone. Browse our list of available subjects!">
         <meta name="twitter:image" content="https://assets.openstax.org/oscms-prodcms/media/images/Turning_textbook_highlighting_into_time_well-sp.original.jpg">
         <meta name="twitter:image:alt" content="OpenStax">
-        <link rel="preload" href="<%= process.env.API_ORIGIN %>/apps/cms/api/webview-settings/" as="fetch" <%= process.env.API_ORIGIN ? 'crossorigin="anonymous"' : '' %>>
+        <link rel="preload" href="<%= process.env.API_ORIGIN %>/apps/cms/api/webview-settings/" as="fetch" crossorigin="anonymous">
         <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous"
             href="/cms/assets/fonts/5b1fbd62-45dc-4433-a7df-a2b24a146411.woff2">
         <link rel="preconnect" href="https://pi.pardot.com" crossorigin="anonymous">

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,7 @@
         <meta name="twitter:image:alt" content="OpenStax">
         <link rel="preload" href="<%= process.env.API_ORIGIN %>/apps/cms/api/webview-settings/" as="fetch" <%= process.env.API_ORIGIN ? 'crossorigin="anonymous"' : '' %>>
         <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous"
-            href="<%= process.env.API_ORIGIN %>/cms/assets/fonts/5b1fbd62-45dc-4433-a7df-a2b24a146411.woff2">
+            href="/cms/assets/fonts/5b1fbd62-45dc-4433-a7df-a2b24a146411.woff2">
         <link rel="preconnect" href="https://pi.pardot.com" crossorigin="anonymous">
         <!-- Anti-flicker snippet (recommended)  -->
         <style>.async-hide { opacity: 0 !important} </style>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,8 +70,8 @@ const config = {
         })
     ],
     performance: {
-      maxEntrypointSize: 2.5 * 1000000, // 1MB
-      maxAssetSize: 2.1 * 1000000,
+        maxEntrypointSize: 2.5 * 1000000, // 1MB
+        maxAssetSize: 2.1 * 1000000,
     },
     resolve: {
         alias: {
@@ -87,8 +87,8 @@ const config = {
         extensions: ['.js', '.jsx']
     },
     watchOptions: {
-      aggregateTimeout: 500,
-      poll: 1000,
+        aggregateTimeout: 500,
+        poll: 1000,
     },
     devServer: {
       client: {
@@ -100,9 +100,9 @@ const config = {
           stats: 'errors-only',
       },
       headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
-        'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+          'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization',
       },
       historyApiFallback: true,
       hot: true,
@@ -110,13 +110,11 @@ const config = {
       open: true,
       port: devServerPort,
       proxy: {
-          context: (pathname) => true,
+          context: (path) => path === '/' || path.startsWith('/cms/assets/fonts'),
           target: `http://localhost:${devServerPort}`,
           pathRewrite: (path) => path === '/' ? '/dist/index.html' : path,
-          router: {
-            '/apps/cms/api': API_ORIGIN,
-            '/cms/assets': API_ORIGIN,
-          },
+          // fonts are always loaded with CORS but the CMS doesn't set CORS headers so we proxy them
+          router: { '/cms/assets/fonts': API_ORIGIN },
           changeOrigin: true
       },
       static: {


### PR DESCRIPTION
webview-settings seems to require crossorigin="anonymous"
fonts also require it but the CMS doesn't set a CORS header so instead of loading the fonts from the CMS and getting a CORS error we just proxy them using the webpack dev server

This seems to fix all console errors and warnings in dev.openstax.org
The dev server has some errors related to accounts (third party cookies) and google analytics.
Enabling third-party cookies for localhost allows you to login on local dev.