### PR TITLE
Add some analytics metadata

### DIFF
--- a/src/app/helpers/tag-manager.js
+++ b/src/app/helpers/tag-manager.js
@@ -22,23 +22,7 @@ const tagManagerID = 'GTM-W6N7PB';
     }
 })(window, document, 'script', 'dataLayer', tagManagerID);
 
-// GA4 stuff
-const {GA4: ga4id} = window.SETTINGS;
-
-if (ga4id) {
-    const tag = document.createElement('script');
-
-    tag.type = 'text/javascript';
-    tag.onload = () => {
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag(...args) {
-            window.dataLayer.push(args);
-        }
-
-        gtag('js', new Date());
-        gtag('config', ga4id);
-    };
-    tag.src = `https://www.googletagmanager.com/gtag/js?id=${ga4id}`;
-    document.body.appendChild(tag);
-}
+window.dataLayer = window.dataLayer || [];
+// eslint-disable-next-line prefer-rest-params
+window.gtag = window.gtag || function () {window.dataLayer.push(arguments);};
+window.gtag('set', {platform: 'osweb'});

--- a/src/app/pages/subjects/old/book-viewer/book-viewer.js
+++ b/src/app/pages/subjects/old/book-viewer/book-viewer.js
@@ -45,7 +45,11 @@ function CategorySection({categoryData, categorizedBooks, category}) {
     return (
         <div className={cn('book-category', {hidden})}>
             <RawHTML Tag="h2" html={subjectHtml} className="subject" />
-            <div className="row">
+              <div
+                className="row"
+                data-analytics-content-list={`subjects_${categoryData.value}`}
+                data-list-name={`Subjects (${categoryData.cms})`}
+              >
                 {books.map((book) => <BookCover {...book} key={book.slug} />)}
             </div>
         </div>

--- a/src/app/pages/subjects/old/book-viewer/book.js
+++ b/src/app/pages/subjects/old/book-viewer/book.js
@@ -112,6 +112,8 @@ function ThreeDotMenu({slug, details}) {
 
 export default function BookCover({
     coverUrl,
+    cnxId,
+    subjects,
     slug,
     title,
     bookState: state,
@@ -130,11 +132,17 @@ export default function BookCover({
     return (
         <div className={className}>
             <ThreeDotMenu slug={slug} details={details} />
-            <a href={`/details/${slug}`}>
-                <LazyLoad once offset={100}>
-                    <img src={coverUrl} alt={title} />
-                </LazyLoad>
-                <div className="cover-caption">{title}</div>
+            <a
+              href={`/details/${slug}`}
+              data-analytics-select-content={cnxId}
+              data-content-type="book"
+              data-content-name={title}
+              data-content-categories={subjects.join(',')}
+            >
+              <LazyLoad once offset={100}>
+                  <img src={coverUrl} alt={title} />
+              </LazyLoad>
+              <div className="cover-caption">{title}</div>
             </a>
         </div>
     );


### PR DESCRIPTION
I'm working on adding shared analytics-events code via GTM and [this other helper](https://github.com/openstax/analytics-helpers). meaning all we have to do in osweb is add the metadata as data attributes.

there is a cms change (https://github.com/openstax/openstax-cms/pull/1446) to add the cnx_id to the default book data response, the analytics won't work until both changes are in place but nothing breaks without the supporting change.