### PR TITLE
update gtag integration

### DIFF
--- a/src/app/helpers/tag-manager.js
+++ b/src/app/helpers/tag-manager.js
@@ -23,6 +23,4 @@ const tagManagerID = 'GTM-W6N7PB';
 })(window, document, 'script', 'dataLayer', tagManagerID);
 
 window.dataLayer = window.dataLayer || [];
-// eslint-disable-next-line prefer-rest-params
-window.gtag = window.gtag || function () {window.dataLayer.push(arguments);};
-window.gtag('set', {platform: 'osweb'});
+window.dataLayer.push({event: 'app_loaded', app: 'osweb'});


### PR DESCRIPTION
OK so there are a few things going on here. one is that there was an existing default `Platform` dimension in GA that i didn't want to get confused with, so i renamed our platform thing to "app"

i was also [educated](https://stackoverflow.com/questions/76177242/can-ga4-custom-dimensions-be-updated-after-the-initial-config-call) on how to correctly use dataLayer directly.

finally i would much prefer to move the `app_loaded` call to after we've established the user state and can include a user role on the event, but theres something hinky going on with that code that i need to investigate or talk to roy about.