### PR TITLE
fix analytics events

### DIFF
--- a/src/app/components/shell/lower-sticky-note/lsn-content.js
+++ b/src/app/components/shell/lower-sticky-note/lsn-content.js
@@ -78,7 +78,7 @@ export default function LowerStickyNote({stickyData, PutAway}) {
             }
             onClick={trackClick}
             data-analytics-view
-            data-analytics-nudge="donation"
+            data-analytics-nudge="donate"
             data-nudge-placement="banner"
         >
             <PutAway />

--- a/src/app/components/shell/microsurvey-popup/sticky-content.js
+++ b/src/app/components/shell/microsurvey-popup/sticky-content.js
@@ -52,7 +52,7 @@ function StickyContent({stickyData, children}) {
             className="microsurvey-content"
             ref={ref}
             data-analytics-view
-            data-analytics-nudge="donation"
+            data-analytics-nudge="donate"
             data-nudge-placement="popup"
         >
             {children}

--- a/src/app/helpers/use-document-head.js
+++ b/src/app/helpers/use-document-head.js
@@ -59,7 +59,7 @@ function getPageDescriptionElement() {
 }
 
 export function getPageDescription() {
-    return getPageDescriptionElement().getAttribute('content');
+    return getPageDescriptionElement()?.getAttribute('content');
 }
 
 export function setPageDescription(description) {

--- a/src/app/helpers/use-document-head.js
+++ b/src/app/helpers/use-document-head.js
@@ -54,9 +54,17 @@ export function useNoIndex(controlsHeader) {
     );
 }
 
+function getPageDescriptionElement() {
+    return document.querySelector('head meta[name="description"]');
+}
+
+export function getPageDescription() {
+    return getPageDescriptionElement().getAttribute('content');
+}
+
 export function setPageDescription(description) {
-    const descriptionEl = document.querySelector('head meta[name="description"]');
     const defaultDescription = 'Access our free college textbooks and low-cost learning materials.';
+    const descriptionEl = getPageDescriptionElement();
 
     if (descriptionEl) {
         descriptionEl.setAttribute('content', description || defaultDescription);

--- a/src/app/helpers/use-document-head.js
+++ b/src/app/helpers/use-document-head.js
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 import {htmlToText} from '~/helpers/data';
+import {setContentTags} from '~/helpers/tag-manager';
 import {camelCaseKeys} from '~/helpers/page-data-utils';
 
 function setCanonicalPath(newPath) {
@@ -82,6 +83,14 @@ export function setPageTitleAndDescriptionFromBookData(data={}) {
     const meta = camelCaseKeys(data.meta || {});
     const defaultDescription = data.description ?
         htmlToText(data.description) : '';
+
+    const contentTags = [
+      `book=${data.title}`,
+      ...data.bookSubjects.map((subject) => `subject=${subject.subjectName}`),
+      ...data.bookCategories.map((category) => `category=${category.subjectCategory} (${category.subjectName})`)
+    ];
+
+    setContentTags(contentTags);
 
     setPageTitleAndDescription(
         meta.seoTitle || data.title,

--- a/src/app/helpers/use-document-head.js
+++ b/src/app/helpers/use-document-head.js
@@ -85,7 +85,6 @@ export function setPageTitleAndDescriptionFromBookData(data={}) {
     const defaultDescription = data.description ?
         htmlToText(data.description) : '';
 
-  console.log(data);
     const contentTags = [
       `book=${data.title}`,
       ...(data.bookSubjects || []).map((subject) => `subject=${subject.subjectName}`),

--- a/src/app/helpers/use-document-head.js
+++ b/src/app/helpers/use-document-head.js
@@ -79,15 +79,17 @@ function setPageTitleAndDescription(title='OpenStax', description) {
     document.title = title.includes('OpenStax') ? title : `${title} - OpenStax`;
 }
 
+// eslint-disable-next-line complexity
 export function setPageTitleAndDescriptionFromBookData(data={}) {
     const meta = camelCaseKeys(data.meta || {});
     const defaultDescription = data.description ?
         htmlToText(data.description) : '';
 
+  console.log(data);
     const contentTags = [
       `book=${data.title}`,
-      ...data.bookSubjects.map((subject) => `subject=${subject.subjectName}`),
-      ...data.bookCategories.map((category) => `category=${category.subjectCategory} (${category.subjectName})`)
+      ...(data.bookSubjects || []).map((subject) => `subject=${subject.subjectName}`),
+      ...(data.bookCategories || []).map((category) => `category=${category.subjectCategory} (${category.subjectName})`)
     ];
 
     setContentTags(contentTags);

--- a/src/app/pages/blog/article-summary/article-summary.js
+++ b/src/app/pages/blog/article-summary/article-summary.js
@@ -49,7 +49,12 @@ export default function ArticleSummary({
         'data-analytics-select-content': id,
         'data-content-type': 'blog_post',
         'data-content-name': headline,
-        'data-content-categories': [...collectionNames, ...articleSubjectNames]
+        'data-content-tags': [
+            '',
+            ...collectionNames.map((collection) => `collection=${collection}`),
+            ...articleSubjectNames.map((subject) => `subject=${subject}`),
+            ''
+        ].join(',')
     };
 
     return (

--- a/src/app/pages/blog/article-summary/article-summary.js
+++ b/src/app/pages/blog/article-summary/article-summary.js
@@ -29,7 +29,7 @@ export function blurbModel(data) {
 }
 
 export default function ArticleSummary({
-    id, articleSlug, altText, image, headline, subheading, body, date, author, collectionNames, articleSubjectNames,
+    articleSlug, altText, image, headline, subheading, body, date, author, collectionNames, articleSubjectNames,
     forwardRef={}, setPath, openInNewWindow, HeadTag='h2'
 }) {
     const tabTarget = openInNewWindow ? '_blank' : null;
@@ -46,9 +46,8 @@ export default function ArticleSummary({
     );
 
     const analytics = {
-        'data-analytics-select-content': id,
+        'data-analytics-select-content': headline,
         'data-content-type': 'blog_post',
-        'data-content-name': headline,
         'data-content-tags': [
             '',
             ...collectionNames.map((collection) => `collection=${collection}`),

--- a/src/app/pages/details/common/featured-resources/featured-resources.js
+++ b/src/app/pages/details/common/featured-resources/featured-resources.js
@@ -3,7 +3,7 @@ import ResourceBoxes from '../resource-box/resource-boxes';
 import {FormattedMessage} from 'react-intl';
 import './featured-resources.scss';
 
-function FeaturedResources({headline, resources}) {
+function FeaturedResources({headline, resources, ...props}) {
     const modResources = resources.map((res) => {
         const storageKey = `featured-resource-${res.heading}`;
         const seenTimes = 1 + Number(window.localStorage[storageKey] || 0);
@@ -26,8 +26,8 @@ function FeaturedResources({headline, resources}) {
                 {headline}
             </div>
             <div
-                data-analytics-content-list="featured_resources"
-                data-list-name="Featured Resources"
+                data-analytics-content-list={props['data-analytics-content-list']}
+                data-list-name={props['data-list-name']}
                 className="resources"
             >
                 <ResourceBoxes models={modResources} />
@@ -36,11 +36,11 @@ function FeaturedResources({headline, resources}) {
     );
 }
 
-export default function FeaturedResourcesSection({header, models}) {
+export default function FeaturedResourcesSection({header, models, ...props}) {
     return (
         <div>
             <div className="featured-resources">
-                <FeaturedResources headline={header} resources={models} />
+                <FeaturedResources headline={header} resources={models} {...props} />
             </div>
             <div className="divider">
                 <div className="line"></div>

--- a/src/app/pages/details/common/resource-box/resource-boxes.js
+++ b/src/app/pages/details/common/resource-box/resource-boxes.js
@@ -104,7 +104,7 @@ function BottomBasic({ leftContent, icon, model }) {
               data-analytics-select-content={model.id}
               data-content-type="book_resource"
               data-content-name={model.heading}
-              data-content-categories={model.resourceCategory}
+              data-content-tags={`,category=${model.resourceCategory},`}
             >
                 <FontAwesomeIcon icon={icon} />
                 {leftContent}
@@ -238,7 +238,7 @@ function LeftButton({ model }) {
                 data-analytics-select-content={model.id}
                 data-content-type="book_resource"
                 data-content-name={model.heading}
-                data-content-categories={model.resourceCategory}
+                data-content-tags={`,category=${model.resourceCategory},`}
             >
                 <FontAwesomeIcon icon={icon} />
                 <span>{model.link.text}</span>

--- a/src/app/pages/details/common/resource-box/resource-boxes.js
+++ b/src/app/pages/details/common/resource-box/resource-boxes.js
@@ -101,9 +101,8 @@ function BottomBasic({ leftContent, icon, model }) {
         <div className="bottom">
             <a
               className="left"
-              data-analytics-select-content={model.id}
+              data-analytics-select-content={model.heading}
               data-content-type="book_resource"
-              data-content-name={model.heading}
               data-content-tags={`,category=${model.resourceCategory},`}
             >
                 <FontAwesomeIcon icon={icon} />
@@ -235,9 +234,8 @@ function LeftButton({ model }) {
                 data-local={model.iconType === 'lock'}
                 onClick={openDialog}
                 data-track={model.heading}
-                data-analytics-select-content={model.id}
+                data-analytics-select-content={model.heading}
                 data-content-type="book_resource"
-                data-content-name={model.heading}
                 data-content-tags={`,category=${model.resourceCategory},`}
             >
                 <FontAwesomeIcon icon={icon} />

--- a/src/app/pages/details/desktop-view/instructor-resource-tab/instructor-resource-tab.js
+++ b/src/app/pages/details/desktop-view/instructor-resource-tab/instructor-resource-tab.js
@@ -100,6 +100,8 @@ function InstructorResourceTab({model, userStatus}) {
                 {
                     featuredModels.length > 0 &&
                         <FeaturedResourcesSection
+                            data-analytics-content-list="instructor_featured_resources"
+                            data-list-name="Instructor Featured Resources"
                             header={model.featuredResourcesHeader}
                             models={featuredModels}
                         />

--- a/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.js
+++ b/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.js
@@ -25,7 +25,7 @@ function Blurb({blurb, badgeImage, onClick}) {
           data-analytics-select-content={blurb.id}
           data-content-type="partner_profile"
           data-content-name={blurb.name}
-          data-content-categories={blurb.type}
+          data-content-tags={`,category=${blurb.type},`}
         >
             <div className="logo">
                 <img src={blurb.image} alt="" />

--- a/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.js
+++ b/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.js
@@ -22,9 +22,8 @@ function Blurb({blurb, badgeImage, onClick}) {
           className="blurb"
           href={blurb.url}
           onClick={trackClick}
-          data-analytics-select-content={blurb.id}
+          data-analytics-select-content={blurb.name}
           data-content-type="partner_profile"
-          data-content-name={blurb.name}
           data-content-tags={`,category=${blurb.type},`}
         >
             <div className="logo">

--- a/src/app/pages/details/phone-view/instructor-resources-pane/instructor-resources-pane.js
+++ b/src/app/pages/details/phone-view/instructor-resources-pane/instructor-resources-pane.js
@@ -46,7 +46,12 @@ export function InstructorResourcesPane({model, userStatus}) {
         <React.Fragment>
             {
                 featuredModels.length > 0 &&
-                    <FeaturedResourcesSection header={model.featuredResourcesHeader} models={featuredModels} />
+                    <FeaturedResourcesSection
+                        data-analytics-content-list="instructor_featured_resources"
+                        data-list-name="Instructor Featured Resources"
+                        header={model.featuredResourcesHeader}
+                        models={featuredModels}
+                    />
             }
             <a className="card filter-for-book" onClick={goToPartners}>
                 OpenStax Partners{' '}

--- a/src/app/pages/partners/partner-details/partner-details.js
+++ b/src/app/pages/partners/partner-details/partner-details.js
@@ -171,14 +171,14 @@ function PartnerDetails({model}) {
 
     return (
         <div
-            className="partner-details" onClick={(e) => e.stopPropagation()}
+            className="partner-details"
             ref={ref}
         >
             <div className="sticky-region">
                 <Synopsis {...{model, icon, partnerLinkProps}} />
                 <TabGroup {...{labels, selectedLabel, setSelectedLabel}} />
             </div>
-            <div className="scrolling-region boxed" onClick={(e) => e.stopPropagation()}>
+            <div className="scrolling-region boxed">
                 <div className="tab-content">
                     <ContentGroup activeIndex={labels.indexOf(selectedLabel)}>
                         <Overview model={model} icon={icon} />

--- a/src/app/pages/partners/partner-details/synopsis/synopsis.js
+++ b/src/app/pages/partners/partner-details/synopsis/synopsis.js
@@ -21,7 +21,7 @@ function VerifiedBadge({verifiedFeatures}) {
     );
 }
 
-function PartnerLink({partnerUrl, partnerLinkText}) {
+function PartnerLink({partnerUrl, partnerLinkText, partnerName}) {
     function trackPartnerVisit() {
         analyticsEvents.partnerWebsite(partnerUrl);
     }
@@ -32,6 +32,7 @@ function PartnerLink({partnerUrl, partnerLinkText}) {
                 className="partner-website" href={partnerUrl}
                 onClick={trackPartnerVisit}
                 target="_blank" rel="noreferrer"
+                data-analytics-link={`Partner Link (${partnerName})`}
             >
                 {partnerLinkText}{' '}
                 <FontAwesomeIcon icon={faExternalLinkAlt} />
@@ -62,7 +63,7 @@ export default function Synopsis({model, icon, partnerLinkProps}) {
                 }
             </div>
             <StarsAndCount rating={rating} count={reviewCount} showNumber />
-            <PartnerLink {...partnerLinkProps} />
+            <PartnerLink {...partnerLinkProps} partnerName={partnerName} />
         </section>
     );
 }

--- a/src/app/pages/partners/results/result-grid.js
+++ b/src/app/pages/partners/results/result-grid.js
@@ -47,7 +47,7 @@ function ResultCard({entry}) {
             data-analytics-select-content={id}
             data-content-type="partner_profile"
             data-content-name={title}
-            data-content-categories={type}
+            data-content-tags={`,category=${type},`}
         >
             <div className="logo">
                 {logoUrl && <img src={logoUrl} alt="" />}

--- a/src/app/pages/partners/results/result-grid.js
+++ b/src/app/pages/partners/results/result-grid.js
@@ -25,7 +25,7 @@ function modelFromEntry(entry) {
 
 function ResultCard({entry}) {
     const {
-        id, type, title, logoUrl, verifiedFeatures, badgeImage, tags, rating, ratingCount
+        type, title, logoUrl, verifiedFeatures, badgeImage, tags, rating, ratingCount
     } = modelFromEntry(entry);
     const summary = {count: ratingCount, rating};
     const navigate = useNavigate();
@@ -44,9 +44,8 @@ function ResultCard({entry}) {
             href={`?${encodeURIComponent(title)}`} type="button"
             className="card"
             onClick={onSelect}
-            data-analytics-select-content={id}
+            data-analytics-select-content={title}
             data-content-type="partner_profile"
-            data-content-name={title}
             data-content-tags={`,category=${type},`}
         >
             <div className="logo">

--- a/src/app/pages/subjects/old/book-viewer/book.js
+++ b/src/app/pages/subjects/old/book-viewer/book.js
@@ -137,7 +137,9 @@ export default function BookCover({
               data-analytics-select-content={cnxId}
               data-content-type="book"
               data-content-name={title}
-              data-content-categories={subjects.join(',')}
+              data-content-tags={['',
+                  ...subjects.map((subject) => `subject=${subject}`),
+              ''].join(',')}
             >
               <LazyLoad once offset={100}>
                   <img src={coverUrl} alt={title} />

--- a/src/app/pages/subjects/old/book-viewer/book.js
+++ b/src/app/pages/subjects/old/book-viewer/book.js
@@ -112,7 +112,6 @@ function ThreeDotMenu({slug, details}) {
 
 export default function BookCover({
     coverUrl,
-    cnxId,
     subjects,
     slug,
     title,
@@ -134,9 +133,8 @@ export default function BookCover({
             <ThreeDotMenu slug={slug} details={details} />
             <a
               href={`/details/${slug}`}
-              data-analytics-select-content={cnxId}
+              data-analytics-select-content={title}
               data-content-type="book"
-              data-content-name={title}
               data-content-tags={['',
                   ...subjects.map((subject) => `subject=${subject}`),
               ''].join(',')}


### PR DESCRIPTION
- aligned donation nudge name
- added logic that waits to configure GA tracker until content is loaded, and set user type tags on the config
- add logic that sets content tags when bookish pages are loaded (will be adding this to other page types like blog as well)
- remove `content-id` parameter from analytics, it turns out it was not really helpful and not worth the confusion of having it in there
- identify featured resources list as being instructor specific
- remove categories parameters from select-content events. the way they were being tracked was not really working, replaced with "tags" which are formatted in a way to make it easy to use a "contains" filter on them, but will not be able to be used as group_by in any meaningful way in GA, maybe another tool will be able to figure it out
- fixed tracking on partner links, i think maybe google doesn't track outbound links if they open target=_blank