### PR TITLE
update content reference categories

### DIFF
--- a/src/app/pages/blog/article-summary/article-summary.js
+++ b/src/app/pages/blog/article-summary/article-summary.js
@@ -47,7 +47,7 @@ export default function ArticleSummary({
 
     const analytics = {
         'data-analytics-select-content': headline,
-        'data-content-type': 'blog_post',
+        'data-content-type': 'Blog Post',
         'data-content-tags': [
             '',
             ...collectionNames.map((collection) => `collection=${collection}`),

--- a/src/app/pages/details/common/resource-box/resource-boxes.js
+++ b/src/app/pages/details/common/resource-box/resource-boxes.js
@@ -102,8 +102,7 @@ function BottomBasic({ leftContent, icon, model }) {
             <a
               className="left"
               data-analytics-select-content={model.heading}
-              data-content-type="book_resource"
-              data-content-tags={`,category=${model.resourceCategory},`}
+              data-content-type={`Book Resource (${model.resourceCategory})`}
             >
                 <FontAwesomeIcon icon={icon} />
                 {leftContent}
@@ -235,8 +234,7 @@ function LeftButton({ model }) {
                 onClick={openDialog}
                 data-track={model.heading}
                 data-analytics-select-content={model.heading}
-                data-content-type="book_resource"
-                data-content-tags={`,category=${model.resourceCategory},`}
+                data-content-type={`Book Resource (${model.resourceCategory})`}
             >
                 <FontAwesomeIcon icon={icon} />
                 <span>{model.link.text}</span>

--- a/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.js
+++ b/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.js
@@ -23,7 +23,7 @@ function Blurb({blurb, badgeImage, onClick}) {
           href={blurb.url}
           onClick={trackClick}
           data-analytics-select-content={blurb.name}
-          data-content-type="partner_profile"
+          data-content-type="Partner Profile"
           data-content-tags={`,category=${blurb.type},`}
         >
             <div className="logo">

--- a/src/app/pages/partners/results/result-grid.js
+++ b/src/app/pages/partners/results/result-grid.js
@@ -45,7 +45,7 @@ function ResultCard({entry}) {
             className="card"
             onClick={onSelect}
             data-analytics-select-content={title}
-            data-content-type="partner_profile"
+            data-content-type="Partner Profile"
             data-content-tags={`,category=${type},`}
         >
             <div className="logo">

--- a/src/app/pages/subjects/old/book-viewer/book.js
+++ b/src/app/pages/subjects/old/book-viewer/book.js
@@ -134,7 +134,7 @@ export default function BookCover({
             <a
               href={`/details/${slug}`}
               data-analytics-select-content={title}
-              data-content-type="book"
+              data-content-type="Book"
               data-content-tags={['',
                   ...subjects.map((subject) => `subject=${subject}`),
               ''].join(',')}


### PR DESCRIPTION
i realized that my changes to make the content reference metadata more taggy (mostly to support selecting books from the subjects lists) also made the book resources much less reportable, so i moved their one category into the type field, and made the type field generally more human readable since it'll be used as a default dimension. 