### PR TITLE
revert timeouts, not necessary anymore

### DIFF
--- a/src/app/components/accordion-group/accordion-group.js
+++ b/src/app/components/accordion-group/accordion-group.js
@@ -130,7 +130,7 @@ export default function AccordionGroup({
                     20
                 );
             }
-            window.setTimeout(() => onChange(...args), 1);
+            onChange(...args);
         },
         [onChange, noScroll]
     );

--- a/src/app/components/shell/header/menus/main-menu/dropdown/dropdown.js
+++ b/src/app/components/shell/header/menus/main-menu/dropdown/dropdown.js
@@ -50,16 +50,14 @@ export default function Dropdown({Tag='li', className, label, children, excludeW
 
         event.preventDefault();
 
-        window.setTimeout(() => {
-          dropdownCtx.setActiveDropdown(topRef);
-          dropdownCtx.setSubmenuLabel(label);
-          if (isMobileDisplay()) {
-              event.target.blur();
-              if (previousActiveDropdown === topRef) {
-                  closeMenu();
-              }
-          }
-        }, 1);
+        dropdownCtx.setActiveDropdown(topRef);
+        dropdownCtx.setSubmenuLabel(label);
+        if (isMobileDisplay()) {
+            event.target.blur();
+            if (previousActiveDropdown === topRef) {
+                closeMenu();
+            }
+        }
     }
 
     function openDesktopMenu(event) {

--- a/src/app/components/tab-group/tab-group.js
+++ b/src/app/components/tab-group/tab-group.js
@@ -7,7 +7,7 @@ function Tab({label, selectedLabel, setSelectedLabel, TabTag, analytics}) {
     const blurAndSetLabel = React.useCallback(
         (event) => {
             event.currentTarget.blur();
-            window.setTimeout(() => setSelectedLabel(label), 1);
+            setSelectedLabel(label);
         },
         [setSelectedLabel, label]
     );

--- a/src/app/pages/details/common/get-this-title-files/options.js
+++ b/src/app/pages/details/common/get-this-title-files/options.js
@@ -335,7 +335,7 @@ export function OptionExpander({expanded, additionalOptions, toggle}) {
     const text = useExpanderText(additionalOptions)[expanded ? 'fewer' : 'more'];
     const doToggle = React.useCallback(
         (event) => {
-            window.setTimeout(toggle, 1);
+            toggle();
             event.preventDefault();
         },
         [toggle]


### PR DESCRIPTION
i had put these in here to allow the analytics code to run before the handlers modified the page, but after changing the analytics code to use capture mode event handlers they're no longer necessary