### PR TITLE
remove separate content list id and name

### DIFF
--- a/src/app/pages/blog/explore-page/explore-page.js
+++ b/src/app/pages/blog/explore-page/explore-page.js
@@ -86,8 +86,7 @@ export default function ExplorePage() {
                     <SectionHeader head="Popular blog posts" subhead={heading} />
                     <div
                         className="latest-blurbs cards"
-                        data-analytics-content-list="popular_blog_posts"
-                        data-list-name="Popular Blog Posts"
+                        data-analytics-content-list="Popular Blog Posts"
                     >
                         {
                             topicPopular.map(blurbModel).map((article) =>

--- a/src/app/pages/blog/more-stories/more-stories.js
+++ b/src/app/pages/blog/more-stories/more-stories.js
@@ -22,8 +22,7 @@ export function LatestBlurbs({page, pageSize, exceptSlug, openInNewWindow}) {
     return (
         <div
             className="latest-blurbs cards"
-            data-analytics-content-list="latest_blog_posts"
-            data-list-name="Latest Blog Posts"
+            data-analytics-content-list="Latest Blog Posts"
         >
             {
                 articles.map((article) =>

--- a/src/app/pages/blog/pinned-article/pinned-article.js
+++ b/src/app/pages/blog/pinned-article/pinned-article.js
@@ -17,8 +17,7 @@ export default function PinnedArticle({subhead}) {
             <SectionHeader head="Featured blog post" subhead={subhead} />
             <div
                 className="pinned-article"
-                data-list-name="Featured Blog Posts"
-                data-analytics-content-list="featured_blog_posts"
+                data-analytics-content-list="Featured Blog Posts"
             >
                 <ArticleSummary {...model} HeadTag='h3' />
             </div>

--- a/src/app/pages/details/common/featured-resources/featured-resources.js
+++ b/src/app/pages/details/common/featured-resources/featured-resources.js
@@ -27,7 +27,6 @@ function FeaturedResources({headline, resources, ...props}) {
             </div>
             <div
                 data-analytics-content-list={props['data-analytics-content-list']}
-                data-list-name={props['data-list-name']}
                 className="resources"
             >
                 <ResourceBoxes models={modResources} />

--- a/src/app/pages/details/desktop-view/instructor-resource-tab/instructor-resource-tab.js
+++ b/src/app/pages/details/desktop-view/instructor-resource-tab/instructor-resource-tab.js
@@ -100,8 +100,7 @@ function InstructorResourceTab({model, userStatus}) {
                 {
                     featuredModels.length > 0 &&
                         <FeaturedResourcesSection
-                            data-analytics-content-list="instructor_featured_resources"
-                            data-list-name="Instructor Featured Resources"
+                            data-analytics-content-list="Instructor Featured Resources"
                             header={model.featuredResourcesHeader}
                             models={featuredModels}
                         />

--- a/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.js
+++ b/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.js
@@ -81,8 +81,7 @@ export default function Partners({bookAbbreviation, model}) {
             </div>
             <div
               className="blurb-scroller"
-              data-analytics-content-list="book_partners"
-              data-list-name={title}
+              data-analytics-content-list={title}
             >
                 <div className="blurbs">
                     {

--- a/src/app/pages/details/desktop-view/student-resource-tab/student-resource-tab.js
+++ b/src/app/pages/details/desktop-view/student-resource-tab/student-resource-tab.js
@@ -30,8 +30,7 @@ function StudentResourceTab({model, userStatus}) {
             </div>
             <div
                 className="resources"
-                data-analytics-content-list="student_resources"
-                data-list-name="Student Resources"
+                data-analytics-content-list="Student Resources"
             >
                 <ResourceBoxes models={models} />
             </div>

--- a/src/app/pages/details/phone-view/instructor-resources-pane/instructor-resources-pane.js
+++ b/src/app/pages/details/phone-view/instructor-resources-pane/instructor-resources-pane.js
@@ -47,8 +47,7 @@ export function InstructorResourcesPane({model, userStatus}) {
             {
                 featuredModels.length > 0 &&
                     <FeaturedResourcesSection
-                        data-analytics-content-list="instructor_featured_resources"
-                        data-list-name="Instructor Featured Resources"
+                        data-analytics-content-list="Instructor Featured Resources"
                         header={model.featuredResourcesHeader}
                         models={featuredModels}
                     />

--- a/src/app/pages/partners/partners.js
+++ b/src/app/pages/partners/partners.js
@@ -134,8 +134,7 @@ function Partners({data}) {
             <MobileControlRow {...{advancedFilterOptions, typeOptions}} />
             <div
                 className="padding"
-                data-analytics-content-list="partners"
-                data-list-name={headline}
+                data-analytics-content-list={headline}
             >
                 <Results linkTexts={linkTexts} headerTexts={headerTexts} />
             </div>

--- a/src/app/pages/subjects/old/book-viewer/book-viewer.js
+++ b/src/app/pages/subjects/old/book-viewer/book-viewer.js
@@ -47,8 +47,7 @@ function CategorySection({categoryData, categorizedBooks, category}) {
             <RawHTML Tag="h2" html={subjectHtml} className="subject" />
               <div
                 className="row"
-                data-analytics-content-list={`subjects_${categoryData.value}`}
-                data-list-name={`Subjects (${categoryData.cms})`}
+                data-analytics-content-list={`Subjects (${categoryData.cms})`}
               >
                 {books.map((book) => <BookCover {...book} key={book.slug} />)}
             </div>


### PR DESCRIPTION
i thought it would be helpful to have a consistent id for lists in case the titles changed, but after getting into the reporting i'm seeing that its really not going to be used ever