### PR TITLE
Hide adoption and interest links for non-Salesforce books

### DIFF
--- a/src/app/models/use-school-suggestion-list.js
+++ b/src/app/models/use-school-suggestion-list.js
@@ -7,7 +7,7 @@ import debounce from 'lodash/debounce';
 const debouncedFetch = debounce(
     (schoolFetch, value, setSchools) => {
         if (value?.length > 1) {
-            schoolFetch(value).then((list) => list.map(
+            schoolFetch(value).then((list) => (list || []).map(
                 (entry) => ({
                     name: entry.name,
                     type: entry.school_type || entry.type, // different names in sfapi and old cms?

--- a/src/app/pages/details/common/let-us-know/let-us-know.js
+++ b/src/app/pages/details/common/let-us-know/let-us-know.js
@@ -34,7 +34,7 @@ export default function LetUsKnow({title}) {
     const {url1, url2, text1, text2} = useDataStuffFor(title);
     const {locale} = useIntl();
 
-    if (locale !== 'en') {
+    if (locale !== 'en' || !title) {
         return null;
     }
     return (


### PR DESCRIPTION
For: https://github.com/openstax/openstax.org/issues/2264

This PR just removes the links to the adoption and interest forms from the book details page if the book isn't in Salesforce. The forms will not list the book if it is not in Salesforce.
In general, Coming Soon books should not be in Salesforce, but there are edge cases (see Issue card discussion).