### PR TITLE
Consistent canonical urls

### DIFF
--- a/src/app/helpers/use-document-head.ts
+++ b/src/app/helpers/use-document-head.ts
@@ -3,6 +3,7 @@ import {htmlToText} from '~/helpers/data';
 import {setContentTags} from '~/helpers/tag-manager';
 import {camelCaseKeys} from '~/helpers/page-data-utils';
 import announcePageTitle from '~/components/shell/header/announce-page-title';
+import {useLocation} from 'react-router-dom';
 import $ from '~/helpers/$';
 
 function setCanonicalPath(newPath: string) {
@@ -34,16 +35,19 @@ function noindexMeta() {
 
 export function useCanonicalLink(
     controlsHeader = true,
-    path = window.location.pathname
+    path?: string
 ) {
+    const defaultPath = useLocation().pathname;
+    const newPath = (path || defaultPath).replace(/\/$/, '');
+
     useEffect(() => {
         if (!controlsHeader) {
             return () => null;
         }
-        const linkController = setCanonicalPath(path);
+        const linkController = setCanonicalPath(newPath);
 
         return () => linkController.remove();
-    }, [controlsHeader, path]);
+    }, [controlsHeader, newPath]);
 }
 
 export function useNoIndex(controlsHeader: boolean) {

--- a/src/app/helpers/use-document-head.ts
+++ b/src/app/helpers/use-document-head.ts
@@ -33,10 +33,7 @@ function noindexMeta() {
     return el;
 }
 
-export function useCanonicalLink(
-    controlsHeader = true,
-    path?: string
-) {
+export function useCanonicalLink(controlsHeader = true, path?: string) {
     const defaultPath = useLocation().pathname;
     const newPath = (path || defaultPath).replace(/\/$/, '');
 
@@ -179,12 +176,9 @@ export default function useDocumentHead({
     description?: string;
     noindex?: boolean;
 }) {
-    useEffect(
-        () => {
-            setPageTitleAndDescription(title, description);
-        },
-        [title, description]
-    );
+    useEffect(() => {
+        setPageTitleAndDescription(title, description);
+    }, [title, description]);
 
     useEffect(() => {
         if (noindex) {

--- a/src/app/pages/blog/blog.js
+++ b/src/app/pages/blog/blog.js
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 import useBlogContext, {BlogContextProvider} from './blog-context';
 import {Routes, Route, useLocation, useParams} from 'react-router-dom';
 import {WindowContextProvider} from '~/contexts/window';
-import useDocumentHead from '~/helpers/use-document-head';
+import useDocumentHead, {useCanonicalLink} from '~/helpers/use-document-head';
 import RawHTML from '~/components/jsx-helpers/raw-html';
 import ExploreBySubject from '~/components/explore-by-subject/explore-by-subject';
 import ExploreByCollection from '~/components/explore-by-collection/explore-by-collection';
@@ -107,6 +107,8 @@ export function ArticlePage() {
 export default function LoadBlog() {
     const location = useLocation();
     const TopLevelPage = location.search ? SearchResultsPage : MainBlogPage;
+
+    useCanonicalLink();
 
     return (
         <main className="blog page">

--- a/src/app/pages/subjects/new/specific/specific.tsx
+++ b/src/app/pages/subjects/new/specific/specific.tsx
@@ -17,6 +17,7 @@ import LazyLoad from 'react-lazyload';
 import useFoundSubject from './use-found-subject';
 import AboutOpenStax from '../about-openstax';
 import {InfoBoxes} from '../info-boxes';
+import { useCanonicalLink } from '~/helpers/use-document-head';
 import cn from 'classnames';
 import './specific.scss';
 
@@ -152,6 +153,8 @@ function SubjectInContext({subject}: {subject: FoundSubject}) {
 export default function LoadSubject() {
     const foundSubject = useFoundSubject();
     const timedOut = useDebounceTest(!foundSubject);
+
+    useCanonicalLink();
 
     if (!foundSubject) {
         // The timeout allows contexts that may just be in a transitional state

--- a/src/app/pages/webinars/webinars.tsx
+++ b/src/app/pages/webinars/webinars.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {WebinarContextProvider} from './webinar-context';
 import {Routes, Route} from 'react-router-dom';
+import {useCanonicalLink} from '~/helpers/use-document-head';
 import JITLoad from '~/helpers/jit-load';
 import './webinars.scss';
 
@@ -12,6 +13,8 @@ const importSearch = () => import('./import-search-page');
 
 
 export default function WebinarsLoader() {
+    useCanonicalLink();
+
     return (
         <main className='webinars page'>
             <WebinarContextProvider>

--- a/test/src/components/book-selector.test.js
+++ b/test/src/components/book-selector.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import {render, screen} from '@testing-library/preact';
 import BookSelector from '~/components/book-selector/book-selector';
+import {MemoryRouter} from 'react-router-dom';
+import {it, expect} from '@jest/globals';
 
 const props = {
     prompt: 'Which textbook(s) are you currently using?',
@@ -12,8 +14,12 @@ const props = {
     }
 };
 
-it ('lists the books', async () => {
-    render(<BookSelector {...props} />);
+it('lists the books', async () => {
+    render(
+        <MemoryRouter>
+            <BookSelector {...props} />
+        </MemoryRouter>
+    );
     const checkboxes = await screen.findAllByRole('checkbox');
 
     expect(checkboxes).toHaveLength(24);

--- a/test/src/pages/confirmation.test.js
+++ b/test/src/pages/confirmation.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import {render, screen} from '@testing-library/preact';
 import Confirmation from '~/pages/confirmation/confirmation';
+import {MemoryRouter} from 'react-router-dom';
+import {test, expect} from '@jest/globals';
 
 const referrers = {
     contact: 'Thanks for contacting us',
@@ -10,7 +12,11 @@ const referrers = {
 Reflect.ownKeys(referrers).forEach((ref) => {
     test(`does ${ref} thanks`, () => {
         window.history.pushState({}, 'confirmation', `/confirmation/${ref}`);
-        render(<Confirmation />)
+        render(
+            <MemoryRouter>
+                <Confirmation />
+            </MemoryRouter>
+        );
         expect(screen.getByRole('heading').textContent).toBe(referrers[ref]);
     });
 });

--- a/test/src/pages/details/book-details-context.js
+++ b/test/src/pages/details/book-details-context.js
@@ -2,6 +2,7 @@ import React from 'react';
 import LoaderPage from '~/components/jsx-helpers/loader-page';
 import ShellContextProvider from '../../../helpers/shell-context';
 import {DetailsContextProvider} from '~/pages/details/context';
+import {MemoryRouter} from 'react-router-dom';
 
 function BookDetailsWithContext({data, children}) {
     return (
@@ -15,6 +16,8 @@ function BookDetailsWithContext({data, children}) {
 
 export default function BookDetailsLoader({slug, children}) {
     return (
-        <LoaderPage slug={slug} Child={BookDetailsWithContext} doDocumentSetup props={{children}} />
+        <MemoryRouter initialEntries={[slug]}>
+            <LoaderPage slug={slug} Child={BookDetailsWithContext} doDocumentSetup props={{children}} />
+        </MemoryRouter>
     );
 }

--- a/test/src/pages/details/let-us-know.test.js
+++ b/test/src/pages/details/let-us-know.test.js
@@ -8,7 +8,7 @@ const polishTitle = 'Fizyka dla szkół wyższych. Tom 1';
 
 test('handles English title', async () => {
     render(
-        <BookDetailsLoader slug={'books/college-algebra'}>
+        <BookDetailsLoader slug='books/college-algebra'>
             <LetUsKnow title={englishTitle} />
         </BookDetailsLoader>
     );
@@ -16,7 +16,7 @@ test('handles English title', async () => {
 });
 test('handles Polish title', async () => {
     render(
-        <BookDetailsLoader slug={'books/college-algebra'}>
+        <BookDetailsLoader slug='books/college-algebra'>
             <LetUsKnow title={polishTitle} />
         </BookDetailsLoader>
     );

--- a/test/src/pages/details/resource-boxes.test.js
+++ b/test/src/pages/details/resource-boxes.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import {render, screen} from '@testing-library/preact';
 import BookDetailsLoader from './book-details-context';
-import {MemoryRouter} from 'react-router-dom';
 import ResourceBoxes from '~/pages/details/common/resource-box/resource-boxes';
 import {
     instructorResourceBoxPermissions,
     studentResourceBoxPermissions
 } from '~/pages/details/common/resource-box/resource-box';
+import {test, expect} from '@jest/globals';
 
 // Test all the conditions in here:
 // userStatus: isInstructor: true|false
@@ -25,17 +25,15 @@ const userStatus = {
 };
 const payload = {
     heading: 'This is the heading',
-    description: 'This is <b>a description</b> in HTML',
-}
+    description: 'This is <b>a description</b> in HTML'
+};
 
 function LangWrapResourceBoxes({models}) {
     // console.info('*** MODELS', models);
     return (
-        <MemoryRouter initialEntries={['/details/books/sometitle?Instructor%20resources']}>
-            <BookDetailsLoader slug='books/college-algebra'>
-                <ResourceBoxes models={models} />
-            </BookDetailsLoader>
-        </MemoryRouter>
+        <BookDetailsLoader slug='books/college-algebra'>
+            <ResourceBoxes models={models} />
+        </BookDetailsLoader>
     );
 }
 

--- a/test/src/pages/errata/errata-summary.test.js
+++ b/test/src/pages/errata/errata-summary.test.js
@@ -3,7 +3,8 @@ import {render, screen} from '@testing-library/preact';
 import {within} from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import ErrataSummaryLoader from '~/pages/errata-summary/errata-summary';
-import Table from '~/pages/errata-summary/table/table';
+import {MemoryRouter} from 'react-router-dom';
+import {test, expect} from '@jest/globals';
 
 const searchStr = '/errata/?book=Anatomy%20and%20Physiology';
 
@@ -21,11 +22,19 @@ async function getTableRows() {
 }
 
 test('shows all items in table', async () => {
-    render(<ErrataSummaryLoader />)
+    render(
+        <MemoryRouter>
+            <ErrataSummaryLoader />
+        </MemoryRouter>
+    );
     expect(await getTableRows()).toHaveLength(54);
 });
 test('filters', async () => {
-    render(<ErrataSummaryLoader />)
+    render(
+        <MemoryRouter>
+            <ErrataSummaryLoader />
+        </MemoryRouter>
+    );
     const filters = await screen.findByRole('radiogroup');
     const user = userEvent.setup({delay: null});
     const reviewButton = within(filters).queryByText('In Review');

--- a/test/src/pages/institutional-partnership/institutional-partnership.test.js
+++ b/test/src/pages/institutional-partnership/institutional-partnership.test.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import InstitutionalPartnership from '~/pages/institutional-partnership/institutional-partnership';
 import {render, screen} from '@testing-library/preact';
+import {MemoryRouter} from 'react-router-dom';
+import {describe, it, expect} from '@jest/globals';
 
 describe('InstitutionalPartnership', () => {
     it('creates', async () => {
         render(
-            <InstitutionalPartnership />
+            <MemoryRouter>
+                <InstitutionalPartnership />
+            </MemoryRouter>
         );
 
         await screen.findByText('About the program');

--- a/test/src/pages/team.test.js
+++ b/test/src/pages/team.test.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import {render, screen} from '@testing-library/preact';
 import TeamLoader from '~/pages/team/team';
+import {MemoryRouter} from 'react-router-dom';
+import {it, expect} from '@jest/globals';
 
 it('creates with a big chunk of data', async () => {
-    render(<TeamLoader />);
+    render(
+        <MemoryRouter>
+            <TeamLoader />
+        </MemoryRouter>
+    );
     expect(await screen.findByRole('navigation'));
     expect(screen.queryAllByRole('heading').length).toBeGreaterThan(3);
 });


### PR DESCRIPTION
[DISCO-139]
Consistently strip trailing slash from pathnames for canonical paths
Used `useLocation` rather than window.location, which made it necessary to add MemoryRouter to some tests.

[DISCO-139]: https://openstax.atlassian.net/browse/DISCO-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ