### PR TITLE
Support any browser that supports grid layout

### DIFF
--- a/src/app/helpers/device.js
+++ b/src/app/helpers/device.js
@@ -2,46 +2,7 @@ export function isMobileDisplay() {
     return window.innerWidth <= 960;
 }
 
-function browserId() {
-    const ua = window.navigator.userAgent;
-    let M = ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
-    let tem;
-    const checkEdge = () => {
-        if ((/\bEdge\b/).test(ua)) {
-            tem = ua.match(/Edge\/(\d+)/);
-            M = ['Edge', 'Edge', (tem[1] || '')];
-        }
-    };
-    const checkChrome = () => {
-        if (M[1] === 'Chrome' && (tem = ua.match(/\b(OPR|Edge)\/(\d+)/))) {
-            M = [tem[1].replace('OPR', 'Opera'), tem[2]];
-        }
-    };
-    const checkFirefox = () => {
-        if (M[1] === 'Firefox') {
-            M = ua.match(/.*\b(\w+)\/(\S+)/);
-        }
-    };
-
-    checkEdge();
-    checkChrome();
-    checkFirefox();
-    M = M[2] ? [M[1], M[2]] : [window.navigator.appName, window.navigator.appVersion, '-?'];
-    if ((tem = ua.match(/version\/([\d.]+)/i)) !== null) {
-        M.splice(1, 1, tem[1]);
-    }
-
-    return {name: M[0], version: M[1]};
-}
-
-// eslint-disable-next-line complexity
+// If the browser supports grid layout, it's probably ok
 export default function isSupported() {
-    const info = browserId();
-
-    return (
-        (info.name === 'Chrome' && parseFloat(info.version) >= 83) ||
-        (info.name === 'Edge' && parseFloat(info.version) >= 83) ||
-        (info.name === 'Firefox' && parseFloat(info.version) >= 74) ||
-        (info.name === 'Safari' && parseFloat(info.version) >= 14.1)
-    );
+    return window.CSS.supports('( display: grid )');
 }

--- a/src/app/helpers/device.js
+++ b/src/app/helpers/device.js
@@ -4,5 +4,5 @@ export function isMobileDisplay() {
 
 // If the browser supports grid layout, it's probably ok
 export default function isSupported() {
-    return window.CSS.supports('( display: grid )');
+    return window.CSS?.supports('( display: grid )') ?? false;
 }


### PR DESCRIPTION
[DISCO-263]
I simplified the test for supported browsers, reducing the risk of erroneously popping up the warning that the site might not render properly, but increasing the risk that some obscure browser will render badly and there will be no warning.
I don't know of any other likely-helpful features to test for in this regard.

It looks like [eslint-plugin-compat](https://stackoverflow.com/a/54942229) can check for these issues, but it wants node v18.

[DISCO-263]: https://openstax.atlassian.net/browse/DISCO-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ