### PR TITLE
Fix CSS for takeover banner

### DIFF
--- a/src/app/layouts/default/takeover-dialog/content-desktop.scss
+++ b/src/app/layouts/default/takeover-dialog/content-desktop.scss
@@ -1,6 +1,6 @@
 @import 'pattern-library/core/pattern-library/headers';
 
-.modal.takeover-dialog dialog .takeover-content.desktop-only {
+.modal.takeover-dialog .takeover-content.desktop-only {
     @include width-up-to($phone-max) {
         display: none;
     }

--- a/src/app/layouts/default/takeover-dialog/content-mobile.scss
+++ b/src/app/layouts/default/takeover-dialog/content-mobile.scss
@@ -1,6 +1,6 @@
 @import 'pattern-library/core/pattern-library/headers';
 
-.modal.takeover-dialog dialog .takeover-content.mobile-only {
+.modal.takeover-dialog .takeover-content.mobile-only {
     @include width-up-to($phone-max) {
         display: grid;
     }


### PR DESCRIPTION
[CORE-632]
There is no longer a dialog element between the outer and inner layers

[CORE-632]: https://openstax.atlassian.net/browse/CORE-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ