### PR TITLE
Add startups sidebar to partners

### DIFF
--- a/src/app/layouts/default/header/menus/main-menu/main-menu.js
+++ b/src/app/layouts/default/header/menus/main-menu/main-menu.js
@@ -15,6 +15,9 @@ import {treatSpaceOrEnterAsClick} from '~/helpers/events';
 import './main-menu.scss';
 
 function DropdownOrMenuItem({item}) {
+    if (! item.name && ! item.label) {
+        return null;
+    }
     if ('menu' in item) {
         return (
             <Dropdown label={item.name} navAnalytics={`Main Menu (${item.name})`}>

--- a/src/app/layouts/default/header/menus/main-menu/main-menu.js
+++ b/src/app/layouts/default/header/menus/main-menu/main-menu.js
@@ -7,7 +7,7 @@ import {
 } from '~/components/language-selector/language-selector';
 import {FormattedMessage} from 'react-intl';
 import {useLocation} from 'react-router-dom';
-import { useDataFromSlug } from '~/helpers/page-data-utils';
+import {useDataFromSlug} from '~/helpers/page-data-utils';
 import Dropdown, {MenuItem} from './dropdown/dropdown';
 import LoginMenu from './login-menu/login-menu';
 import GiveButton from '../give-button/give-button';
@@ -20,7 +20,10 @@ function DropdownOrMenuItem({item}) {
     }
     if ('menu' in item) {
         return (
-            <Dropdown label={item.name} navAnalytics={`Main Menu (${item.name})`}>
+            <Dropdown
+                label={item.name}
+                navAnalytics={`Main Menu (${item.name})`}
+            >
                 <MenusFromStructure structure={item.menu} />
             </Dropdown>
         );
@@ -46,18 +49,11 @@ function MenusFromCMS() {
         return null;
     }
 
-    return (
-        <MenusFromStructure structure={structure} />
-    );
+    return <MenusFromStructure structure={structure} />;
 }
 
 function K12MenuItem() {
-    return (
-        <MenuItem
-            label='&#127822; For K12 Teachers'
-            url='/k12'
-        />
-    );
+    return <MenuItem label="&#127822; For K12 Teachers" url="/k12" />;
 }
 
 function SubjectsMenu() {
@@ -72,27 +68,38 @@ function SubjectsMenu() {
     }
 
     return (
-        <Dropdown className='subjects-dropdown' label='Subjects' navAnalytics="Main Menu (Subjects)">
-            {categories.filter((obj) => obj.html !== 'K12').map((obj) => (
-                <MenuItem
-                    key={obj.value}
-                    label={obj.html}
-                    url={`/subjects/${obj.value}`}
-                />
-            ))}
+        <Dropdown
+            className="subjects-dropdown"
+            label="Subjects"
+            navAnalytics="Main Menu (Subjects)"
+        >
+            {categories
+                .filter((obj) => obj.html !== 'K12')
+                .map((obj) => (
+                    <MenuItem
+                        key={obj.value}
+                        label={obj.html}
+                        url={`/subjects/${obj.value}`}
+                    />
+                ))}
             {pathname.startsWith('/details/books') ? null : (
                 <React.Fragment>
                     <LanguageSelectorWrapper>
-                        <FormattedMessage id='view' defaultMessage='View' />{' '}
+                        <FormattedMessage id="view" defaultMessage="View" />{' '}
                         <LanguageLink locale={otherLocale} />
                     </LanguageSelectorWrapper>
                     <LanguageSelectorWrapper>
-                        <FormattedMessage id='view' defaultMessage='View' />{' '}
-                        <LanguageLink locale='pl' />
+                        <FormattedMessage id="view" defaultMessage="View" />{' '}
+                        <LanguageLink locale="pl" />
                     </LanguageSelectorWrapper>
                 </React.Fragment>
-        )}
-            {language === 'en' ? <React.Fragment><hr /><K12MenuItem /></React.Fragment> : null}
+            )}
+            {language === 'en' ? (
+                <React.Fragment>
+                    <hr />
+                    <K12MenuItem />
+                </React.Fragment>
+            ) : null}
         </Dropdown>
     );
 }
@@ -102,12 +109,18 @@ function navigateWithArrows(event) {
         case 'ArrowRight':
             event.preventDefault();
             event.stopPropagation();
-            event.target.closest('li').nextElementSibling?.querySelector('a').focus();
+            event.target
+                .closest('li')
+                .nextElementSibling?.querySelector('a')
+                .focus();
             break;
         case 'ArrowLeft':
             event.preventDefault();
             event.stopPropagation();
-            event.target.closest('li').previousElementSibling?.querySelector('a').focus();
+            event.target
+                .closest('li')
+                .previousElementSibling?.querySelector('a')
+                .focus();
             break;
         default:
             break;
@@ -120,7 +133,7 @@ export function MainMenuItems() {
         <React.Fragment>
             <SubjectsMenu />
             <MenusFromCMS />
-            <li className='give-button-item' role='presentation'>
+            <li className="give-button-item" role="presentation">
                 <GiveButton />
             </li>
             <LoginMenu />
@@ -130,7 +143,11 @@ export function MainMenuItems() {
 
 export default function MainMenu() {
     return (
-        <ul className='nav-menu main-menu no-bullets' data-analytics-nav="Main Menu" onKeyDown={navigateWithArrows}>
+        <ul
+            className="nav-menu main-menu no-bullets"
+            data-analytics-nav="Main Menu"
+            onKeyDown={navigateWithArrows}
+        >
             <MainMenuItems />
         </ul>
     );

--- a/src/app/pages/partners/active-filters/active-filters.scss
+++ b/src/app/pages/partners/active-filters/active-filters.scss
@@ -2,7 +2,6 @@
 
 .active-filters {
     @extend %content;
-    padding: 0;
 
     @include wider-than($phone-max) {
         margin-top: 4rem;

--- a/src/app/pages/partners/active-filters/active-filters.scss
+++ b/src/app/pages/partners/active-filters/active-filters.scss
@@ -3,6 +3,8 @@
 .active-filters {
     @extend %content;
 
+    padding: 0;
+
     @include wider-than($phone-max) {
         margin-top: 4rem;
     }

--- a/src/app/pages/partners/results/results.scss
+++ b/src/app/pages/partners/results/results.scss
@@ -2,9 +2,7 @@
 @import 'mixins/placeholder-selectors';
 
 .partners .results {
-    align-items: start;
     padding: 2rem $normal-margin 20rem;
-    row-gap: 2rem;
 
     @include width-up-to($phone-max) {
         padding: 0 $normal-margin 6rem;
@@ -12,6 +10,16 @@
 
     @include wider-than($phone-max) {
         min-height: 60rem;
+    }
+
+    >:first-child {
+        @include width-up-to($phone-max) {
+            margin-bottom: $normal-margin;
+        }
+    
+        @include wider-than($phone-max) {
+            margin-bottom: 3rem;
+        }
     }
 
     h2 {
@@ -106,10 +114,11 @@
     }
 
     .boxed {
-        grid-gap: 3rem;
+        gap: 3rem;
 
         @include width-up-to($phone-max) {
-            grid-gap: $normal-margin;
+            gap: $normal-margin;
+            padding: 0;
         }
     }
 
@@ -123,11 +132,11 @@
                 padding: 0;
             }
 
+            &,
             .sidebar-content {
                 display: flex;
                 flex-direction: column;
-                grid-gap: 3rem;
-                margin-top: 3rem;
+                gap: $normal-margin;
             }
         }
 

--- a/src/app/pages/partners/results/results.scss
+++ b/src/app/pages/partners/results/results.scss
@@ -107,37 +107,68 @@
 
     .boxed {
         grid-gap: 3rem;
+
+        @include width-up-to($phone-max) {
+            grid-gap: $normal-margin;
+        }
     }
 
     .with-sidebar {
-        display: flex;
-        flex-direction: row;
-        gap: 3rem;
-        max-width: 120rem;
-        margin: 0 auto;
-        padding-right: $normal-margin;
-
-        .grid {
-            max-width: unset;
+        h2 {
+            text-align: center;
         }
 
-        > .sidebar {
-            min-width: 20rem;
-            border: thin solid black;
-            height: max-content;
+        @include width-up-to($phone-max) {
+            > .boxed {
+                padding: 0;
+            }
 
             .sidebar-content {
-                background-color: ui-color(white);
+                display: flex;
+                flex-direction: column;
+                grid-gap: 3rem;
+                margin-top: 3rem;
             }
+        }
 
-            h2 {
-                background-color: transparent;
-                padding: 0.5rem 0;
-                text-align: center;
-            }
+        @include wider-than($phone-max) {
+            display: flex;
+            flex-direction: row;
+            gap: 3rem;
+            max-width: 120rem;
+            margin: 0 auto;
+            padding-right: $normal-margin;    
 
             .grid {
-                gap: 0.2rem;
+                max-width: unset;
+            }
+    
+            > .sidebar {
+                min-width: 20rem;
+                border: thin solid black;
+                height: max-content;
+
+                .sidebar-content {
+                    background-color: ui-color(white);
+                }
+
+                h2 {
+                    @include set-font(h3);
+
+                    background-color: os-color(gray);
+                    color: ui-color(white);
+                    padding: $normal-margin;
+                }
+
+                .grid {
+                    gap: 0.2rem;
+                }
+
+                .card {
+                    border-radius: 0;
+                    box-shadow: none;
+                    border-bottom: thin solid ui-color(form-border);
+                }
             }
         }
     }

--- a/src/app/pages/partners/results/results.scss
+++ b/src/app/pages/partners/results/results.scss
@@ -3,7 +3,7 @@
 
 .partners .results {
     align-items: start;
-    padding: 2rem 0 20rem;
+    padding: 2rem $normal-margin 20rem;
     row-gap: 2rem;
 
     @include width-up-to($phone-max) {
@@ -105,16 +105,17 @@
         }
     }
 
+    .boxed {
+        grid-gap: 3rem;
+    }
+
     .with-sidebar {
         display: flex;
         flex-direction: row;
         gap: 3rem;
         max-width: 120rem;
         margin: 0 auto;
-
-        > .boxed {
-            grid-gap: 3rem;
-        }
+        padding-right: $normal-margin;
 
         .grid {
             max-width: unset;
@@ -125,8 +126,13 @@
             border: thin solid black;
             height: max-content;
 
+            .sidebar-content {
+                background-color: ui-color(white);
+            }
+
             h2 {
-                background-color: white;
+                background-color: transparent;
+                padding: 0.5rem 0;
                 text-align: center;
             }
 

--- a/src/app/pages/partners/results/results.scss
+++ b/src/app/pages/partners/results/results.scss
@@ -104,4 +104,35 @@
             }
         }
     }
+
+    .with-sidebar {
+        display: flex;
+        flex-direction: row;
+        gap: 3rem;
+        max-width: 120rem;
+        margin: 0 auto;
+
+        > .boxed {
+            grid-gap: 3rem;
+        }
+
+        .grid {
+            max-width: unset;
+        }
+
+        > .sidebar {
+            min-width: 20rem;
+            border: thin solid black;
+            height: max-content;
+
+            h2 {
+                background-color: white;
+                text-align: center;
+            }
+
+            .grid {
+                gap: 0.2rem;
+            }
+        }
+    }
 }

--- a/src/app/pages/partners/results/results.tsx
+++ b/src/app/pages/partners/results/results.tsx
@@ -200,7 +200,7 @@ function resultEntry(pd: PartnerData) {
         cost: pd.affordability_cost,
         rating: pd.average_rating.rating__avg,
         ratingCount: pd.rating_count,
-        partnershipLevel: pd.partnership_level as string,
+        partnershipLevel: pd.partnership_level,
         yearsAsPartner: pd.partner_anniversary_date
             ? differenceInYears(
                   Date.now(),
@@ -301,18 +301,25 @@ function ResultGridLoader({
                     linkTexts={linkTexts}
                     entries={filteredEntries}
                 />
-                <div className="with-sidebar">
-                    <div className="boxed">
-                        {otherAges.map((age) => (
-                            <HeadingAndResultGrid
-                                key={age}
-                                age={age}
-                                entries={partnersByAge[age]}
-                            />
-                        ))}
+                {
+                    otherAges.length > 0
+                    ? <div className="with-sidebar">
+                        <div className="boxed">
+                            {otherAges.map((age) => (
+                                <HeadingAndResultGrid
+                                    key={age}
+                                    age={age}
+                                    entries={partnersByAge[age]}
+                                />
+                            ))}
+                        </div>
+                        <Sidebar entries={startups} />
                     </div>
-                    <Sidebar entries={startups} />
-                </div>
+                    : <div className="boxed">
+                        <h2>Startups</h2>
+                        <ResultGrid entries={startups} />
+                    </div>
+                }
             </section>
         );
     }

--- a/src/app/pages/partners/results/results.tsx
+++ b/src/app/pages/partners/results/results.tsx
@@ -200,7 +200,7 @@ function resultEntry(pd: PartnerData) {
         cost: pd.affordability_cost,
         rating: pd.average_rating.rating__avg,
         ratingCount: pd.rating_count,
-        partnershipLevel: pd.partnership_level,
+        partnershipLevel: pd.partnership_level as string,
         yearsAsPartner: pd.partner_anniversary_date
             ? differenceInYears(
                   Date.now(),
@@ -254,8 +254,19 @@ function ResultGridLoader({
     partnerData: PartnerData[];
     linkTexts: LinkTexts;
 }) {
+    // // *** FOR TESTING because Dev data is missing some things
+    // let altered = false;
+
+    // if (!altered) {
+    //     partnerData.slice(-5).forEach((d) => {d.partnership_level = 'startup'});
+    //     partnerData.slice(0, 5).forEach((d, i) => {d.partner_anniversary_date = `10 Jun ${2014 + i}`});
+    //     altered = true;
+    // }
+    // // *** /FOR TESTING
     const entries = React.useMemo(
-        () => partnerData.map(resultEntry),
+        () => partnerData
+            .filter((d) => d.partnership_level !== null)
+            .map(resultEntry),
         [partnerData]
     );
     const filteredEntries = useFilteredEntries(entries);

--- a/test/src/pages/partners/partners.test.tsx
+++ b/test/src/pages/partners/partners.test.tsx
@@ -62,7 +62,7 @@ describe('partners/results', () => {
     });
 });
 
-describe('full page', () => {
+describe('partners full page', () => {
     const user = userEvent.setup();
 
     function Component() {
@@ -74,12 +74,11 @@ describe('full page', () => {
             </ShellContextProvider>
         );
     }
-    beforeEach(() => {
-        mockSfPartners.mockResolvedValue(sfPartners);
-        render(<Component />);
-    });
+
     jest.setTimeout(12000);
     it('displays grid that filters by type', async () => {
+        mockSfPartners.mockResolvedValue(sfPartners);
+        render(<Component />);
         const buttons = await screen.findAllByRole('button');
 
         expect(buttons).toHaveLength(6);
@@ -93,6 +92,8 @@ describe('full page', () => {
         expect(screen.getAllByRole('link')).toHaveLength(4);
     });
     it('filters by book', async () => {
+        mockSfPartners.mockResolvedValue(sfPartners);
+        render(<Component />);
         const bookButton = await screen.findByRole('button', {name: 'Books'});
 
         await user.click(bookButton);
@@ -106,6 +107,8 @@ describe('full page', () => {
         expect(checkboxes).toHaveLength(24);
     });
     it('filters by advanced filter', async () => {
+        mockSfPartners.mockResolvedValue(sfPartners);
+        render(<Component />);
         const filterButton = await screen.findByRole('button', {
             name: 'Advanced Filters'
         });
@@ -122,6 +125,8 @@ describe('full page', () => {
         expect(screen.getAllByRole('link')).toHaveLength(5);
     });
     it('sorts', async () => {
+        mockSfPartners.mockResolvedValue(sfPartners);
+        render(<Component />);
         const sortButtons = await screen.findAllByRole('button', {
             name: 'Sort'
         });
@@ -170,11 +175,22 @@ describe('full page', () => {
         ]);
     });
     it('shows details in dialog', async () => {
+        mockSfPartners.mockResolvedValue(sfPartners);
+        render(<Component />);
         const partnerLink = await screen.findByRole('link', {name: 'Rice Online Learning'});
 
         await user.click(partnerLink);
         screen.getByRole('dialog');
         screen.getByText('through the edX platform', {exact: false});
         await user.click(screen.getByRole('button', {name: 'close'}));
+    });
+    it('displays sidebar of startups', async () => {
+        sfPartners[0].partnership_level = 'startup'; // eslint-disable-line
+        mockSfPartners.mockResolvedValue(sfPartners);
+        render(<Component />);
+        const startupHeading = await screen.findByRole('heading', {level: 2, name: 'Startups'});
+
+        expect(startupHeading.parentNode?.textContent).toContain(sfPartners[0].partner_name);
+        sfPartners[0].partnership_level = 'Full partner'; // eslint-disable-line
     });
 });

--- a/test/src/pages/partners/partners.test.tsx
+++ b/test/src/pages/partners/partners.test.tsx
@@ -83,7 +83,7 @@ describe('partners full page', () => {
 
         expect(buttons).toHaveLength(6);
         await screen.findByText('Carolina Distance Learning');
-        expect(screen.getAllByRole('link')).toHaveLength(22);
+        expect(screen.getAllByRole('link')).toHaveLength(21);
         await user.click(buttons[1]);
         const options = screen.getAllByRole('option');
 


### PR DESCRIPTION
[CORE-609]
I have added a phone-format layout. On screens larger than phones, it has the sidebar which has a contrasting heading and a single column of partners. On small screens, the Startups section becomes just another grid at the bottom of the page (phone screens generally hold 2 partner info cards on each row).

[CORE-609]: https://openstax.atlassian.net/browse/CORE-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ