### PR TITLE
Use name field of target iframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstax/os-webview",
-    "version": "2.140.0",
+    "version": "2.140.2",
     "description": "OpenStax webview",
     "scripts": {
         "test": "jest --coverage ./test/src",

--- a/src/app/pages/details/common/get-this-title-files/give-before-pdf/thank-you-form.tsx
+++ b/src/app/pages/details/common/get-this-title-files/give-before-pdf/thank-you-form.tsx
@@ -33,8 +33,7 @@ function FormWithAfterSubmit({
     return (
         <React.Fragment>
             <iframe
-                title={responseId}
-                id={responseId}
+                name={responseId}
                 className="hidden"
                 src=""
                 width="0"

--- a/test/src/pages/details/get-this-title/give-before-pdf.test.tsx
+++ b/test/src/pages/details/get-this-title/give-before-pdf.test.tsx
@@ -116,7 +116,7 @@ describe('give-before-pdf', () => {
         // Even firing the submit event doesn't cause anything to happen?
         fireEvent.submit(screen.getByRole('form'));
         // So we directly fire the load on the form target iframe
-        fireEvent.load(screen.getByTitle('form-response'));
+        fireEvent.load(document.querySelector('[name="form-response"]') as Node);
     });
     it('Exercise data-track and datalayer effect', async () => {
         (window as unknown as Window & {dataLayer: object[]}).dataLayer = [];


### PR DESCRIPTION
This was the hotfix from Thu 6 Mar. The issue was using `id` and `title` instead of the `name` attribute to identify the target iframe. That change required an update to a test.