### PR TITLE
Core 898 landing flex footer

### DIFF
--- a/src/app/components/shell/router-helpers/fallback-to.js
+++ b/src/app/components/shell/router-helpers/fallback-to.js
@@ -21,13 +21,16 @@ export default function FallbackTo({name}) {
     return <LoadedPage name={name} data={data} />;
 }
 
+export const isFlexPage = (data) => (
+    typeof data.meta?.type === 'string' &&
+    ['pages.FlexPage', 'pages.RootPage'].includes(data.meta.type)
+);
+
 // eslint-disable-next-line complexity
 function LoadedPage({data, name}) {
     const {setLayoutParameters, layoutParameters} = useLayoutContext();
     const hasError = 'error' in data;
-    const isFlex =
-        !hasError &&
-        ['pages.FlexPage', 'pages.RootPage'].includes(data.meta.type);
+    const isFlex = !hasError && isFlexPage(data);
 
     React.useEffect(() => {
         if (isFlex) {

--- a/src/app/layouts/default/footer/cookie-yes-toggle.tsx
+++ b/src/app/layouts/default/footer/cookie-yes-toggle.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function CookieYesToggle() {
+    return (
+        <button
+            type="button"
+            className="cky-banner-element small"
+        >
+            Manage cookies
+        </button>
+    );
+}

--- a/src/app/layouts/default/footer/copyright.tsx
+++ b/src/app/layouts/default/footer/copyright.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import RawHTML from '~/components/jsx-helpers/raw-html';
+
+type Props = {
+    copyright: string | undefined;
+    apStatement: string | undefined;
+}
+
+export default function Copyright({copyright, apStatement}: Props) {
+    const updatedCopyright = copyright
+        ? copyright.replace(/-\d+/, `-${new Date().getFullYear()}`)
+        : copyright;
+
+    return (
+        <React.Fragment>
+            <RawHTML html={updatedCopyright} />
+            <RawHTML Tag="ap-html" html={apStatement} />
+        </React.Fragment>
+    );
+}

--- a/src/app/layouts/default/footer/footer.js
+++ b/src/app/layouts/default/footer/footer.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import RawHTML from '~/components/jsx-helpers/raw-html';
 import LoaderPage from '~/components/jsx-helpers/loader-page';
+import Copyright from './copyright';
+import CookieYesToggle from './cookie-yes-toggle';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faFacebookF} from '@fortawesome/free-brands-svg-icons/faFacebookF';
 import {faXTwitter} from '@fortawesome/free-brands-svg-icons/faXTwitter';
@@ -23,8 +25,6 @@ function Footer({
         facebookLink, twitterLink, linkedinLink
     }
 }) {
-    const updatedCopyright = copyright ? copyright.replace(/-\d+/, `-${new Date().getFullYear()}`) : copyright;
-
     return (
         <React.Fragment>
             <div className="top">
@@ -61,8 +61,7 @@ function Footer({
             <div className="bottom">
                 <div className="boxed">
                     <div className="copyrights">
-                        <RawHTML html={updatedCopyright} />
-                        <RawHTML Tag="ap-html" html={apStatement} />
+                        <Copyright copyright={copyright} apStatement={apStatement} />
                     </div>
                     <ul className="social">
                         <li>
@@ -124,17 +123,6 @@ function Footer({
                 </div>
             </div>
         </React.Fragment>
-    );
-}
-
-function CookieYesToggle() {
-    return (
-        <button
-            type="button"
-            className="cky-banner-element small"
-        >
-            Manage cookies
-        </button>
     );
 }
 

--- a/src/app/layouts/default/footer/footer.scss
+++ b/src/app/layouts/default/footer/footer.scss
@@ -119,6 +119,11 @@ $lower-footer: #3b3b3b;
                 line-height: inherit;
                 padding: inherit;
                 text-align: inherit;
+                text-decoration: none;
+
+                &:hover {
+                    text-decoration: underline;
+                }
             }
 
             &.col1 {

--- a/src/app/layouts/landing/footer/flex.scss
+++ b/src/app/layouts/landing/footer/flex.scss
@@ -83,6 +83,11 @@ $lower-footer: #3b3b3b;
                 line-height: inherit;
                 padding: inherit;
                 text-align: inherit;
+                text-decoration: none;
+
+                &:hover {
+                    text-decoration: underline;
+                }
             }
 
             &.col1 {

--- a/src/app/layouts/landing/footer/flex.scss
+++ b/src/app/layouts/landing/footer/flex.scss
@@ -1,0 +1,98 @@
+@import 'pattern-library/core/pattern-library/headers';
+
+$lower-footer: #3b3b3b;
+
+.page-footer {
+    color: text-color(footer);
+    display: grid;
+
+    .flex-page {
+        background-color: ui-color(footer-bg);
+
+        a {
+            color: inherit;
+        }
+
+        @include width-up-to($phone-max) {
+            padding: $normal-margin;
+        }
+
+        @include wider-than($phone-max) {
+            padding: 2.5rem 0;
+        }
+
+        .boxed {
+            display: grid;
+            grid-row-gap: 2rem;
+
+            @include width-up-to($phone-max) {
+                grid-template: 'copyright'
+                'col1'
+                'col2';
+            }
+
+            @include wider-than($phone-max) {
+                align-items: start;
+                grid-column-gap: 4rem;
+                grid-template: 'copyright col1 col2' / minmax(auto, 70rem) auto auto;
+            }
+
+            @include wider-than($tablet-max) {
+                grid-column-gap: 8rem;
+            }
+        }
+
+        .list-of-links {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+                
+        .copyrights {
+            @include body-font(1.2rem);
+            display: grid;
+            grid-area: copyright;
+            grid-gap: 1rem;
+        }
+
+        .column {
+            display: grid;
+            grid-gap: 0.5rem;
+
+            a {
+                @include width-up-to($phone-max) {
+                    padding: 1.15rem 0;
+                }
+                text-decoration: none;
+
+                &:hover {
+                    text-decoration: underline;
+                }
+            }
+
+            button {
+                background-color: transparent;
+                color: inherit;
+                display: inline;
+                font-size: inherit;
+                font-weight: inherit;
+                line-height: inherit;
+                padding: inherit;
+                text-align: inherit;
+            }
+
+            &.col1 {
+                grid-area: col1;
+            }
+
+            &.col2 {
+                grid-area: col2;
+            }
+        }
+    }
+
+}

--- a/src/app/layouts/landing/footer/flex.scss
+++ b/src/app/layouts/landing/footer/flex.scss
@@ -1,7 +1,5 @@
 @import 'pattern-library/core/pattern-library/headers';
 
-$lower-footer: #3b3b3b;
-
 .page-footer {
     color: text-color(footer);
     display: grid;
@@ -26,7 +24,7 @@ $lower-footer: #3b3b3b;
             grid-row-gap: 2rem;
 
             @include width-up-to($phone-max) {
-                grid-template: 'copyright'
+                grid-template: 'copyrights'
                 'col1'
                 'col2';
             }
@@ -34,7 +32,7 @@ $lower-footer: #3b3b3b;
             @include wider-than($phone-max) {
                 align-items: start;
                 grid-column-gap: 4rem;
-                grid-template: 'copyright col1 col2' / minmax(auto, 70rem) auto auto;
+                grid-template: 'copyrights col1 col2' / minmax(auto, 70rem) auto auto;
             }
 
             @include wider-than($tablet-max) {
@@ -51,11 +49,10 @@ $lower-footer: #3b3b3b;
             gap: 0.5rem;
         }
 
-                
         .copyrights {
             @include body-font(1.2rem);
             display: grid;
-            grid-area: copyright;
+            grid-area: copyrights;
             grid-gap: 1rem;
         }
 
@@ -99,5 +96,4 @@ $lower-footer: #3b3b3b;
             }
         }
     }
-
 }

--- a/src/app/layouts/landing/footer/flex.scss
+++ b/src/app/layouts/landing/footer/flex.scss
@@ -1,5 +1,15 @@
 @import 'pattern-library/core/pattern-library/headers';
 
+.contact-dialog {
+    width: 75vw;
+    height: 75vh;
+
+    .main-region, iframe {
+        width: 100%;
+        height: 100%;
+    }
+}
+
 .page-footer {
     color: text-color(footer);
     display: grid;

--- a/src/app/layouts/landing/footer/flex.tsx
+++ b/src/app/layouts/landing/footer/flex.tsx
@@ -72,6 +72,7 @@ export function useContactDialog() {
 
 function FlexFooter({data}: Props) {
     const {ContactDialog, open: openContactDialog} = useContactDialog();
+    const contactFormParams = [{key: 'source_url', value: window.location.href}];
 
     return (
         <div className="flex-page">
@@ -83,7 +84,10 @@ function FlexFooter({data}: Props) {
                     <ListOfLinks>
                         <button onClick={openContactDialog}>
                             Contact Us
-                            <ContactDialog className="contact-dialog" />
+                            <ContactDialog
+                                className="contact-dialog"
+                                contactFormParams={contactFormParams}
+                            />
                         </button>
                         <a href="/tos">Terms of Use</a>
                         <a href="/privacy">Privacy Notice</a>

--- a/src/app/layouts/landing/footer/flex.tsx
+++ b/src/app/layouts/landing/footer/flex.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Copyright from '~/layouts/default/footer/copyright';
+import CookieYesToggle from '~/layouts/default/footer/cookie-yes-toggle';
+import LoaderPage from '~/components/jsx-helpers/loader-page';
+import './flex.scss';
+
+type Props = {
+    data: {
+        copyright: string | undefined;
+        apStatement: string | undefined;
+    }
+}
+
+function ListOfLinks({children}: React.PropsWithChildren<object>) {
+    return (
+        <ul className="list-of-links">
+            {React.Children.toArray(children).map((c, i) => (<li key={i}>{c}</li>))}
+        </ul>
+    );
+}
+
+function FlexFooter({data}: Props) {
+    return (
+        <div className="flex-page">
+            <div className="boxed">
+                <div className="copyrights">
+                    <Copyright {...data} />
+                </div>
+                <div className="column col1">
+                    <ListOfLinks>
+                        <a href="/contact">Contact Us</a>
+                        <a href="/tos">Terms of Use</a>
+                        <a href="/privacy">Privacy Notice</a>
+                    </ListOfLinks>
+                </div>
+                <div className="column col2">
+                    <ListOfLinks>
+                        <a href="/accessibility-statement">Accessibility Statement</a>
+                        <a href="/privacy">Privacy Notice</a>
+                        <CookieYesToggle />
+                    </ListOfLinks>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function FooterLoader() {
+    return (
+        <footer className="page-footer" data-analytics-nav="Footer">
+            <LoaderPage slug="footer" Child={FlexFooter} />
+        </footer>
+    );
+}

--- a/src/app/layouts/landing/footer/flex.tsx
+++ b/src/app/layouts/landing/footer/flex.tsx
@@ -20,7 +20,7 @@ function ListOfLinks({children}: React.PropsWithChildren<object>) {
     );
 }
 
-function useContactDialog() {
+export function useContactDialog() {
     const [Dialog, open, close] = useDialog();
 
     function ContactDialog(

--- a/src/app/layouts/landing/landing.tsx
+++ b/src/app/layouts/landing/landing.tsx
@@ -8,8 +8,9 @@ import useLanguageContext from '~/contexts/language';
 import ReactModal from 'react-modal';
 import cn from 'classnames';
 import { LinkFields } from '../../pages/flex-page/components/Link';
-import './landing.scss';
 import JITLoad from '~/helpers/jit-load';
+import { isFlexPage } from '~/components/shell/router-helpers/fallback-to';
+import './landing.scss';
 
 type Props = {
     data: {
@@ -25,10 +26,8 @@ type Props = {
     }
 }
 
-function Footer({data: {meta}}: Props) {
-    const type = meta?.type;
-    const isFlex = type === 'pages.FlexPage' || type === 'pages.RootPage';
-    const importFn = isFlex
+function Footer({data}: Props) {
+    const importFn = isFlexPage(data)
         ? () => import('~/layouts/landing/footer/flex')
         : () => import('~/layouts/default/footer/footer');
 

--- a/src/app/layouts/landing/landing.tsx
+++ b/src/app/layouts/landing/landing.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Header from './header/header';
-import Footer from '../default/footer/footer';
 import {SalesforceContextProvider} from '~/contexts/salesforce';
 import useMainClassContext, {
     MainClassContextProvider
@@ -10,16 +9,30 @@ import ReactModal from 'react-modal';
 import cn from 'classnames';
 import { LinkFields } from '../../pages/flex-page/components/Link';
 import './landing.scss';
+import JITLoad from '~/helpers/jit-load';
 
 type Props = {
     data: {
         title: string;
+        meta?: {
+            type: string;
+        },
         layout: Array<{
             value: {
                 navLinks: LinkFields[];
             }
         }>
     }
+}
+
+function Footer({data: {meta}}: Props) {
+    const type = meta?.type;
+    const isFlex = type === 'pages.FlexPage' || type === 'pages.RootPage';
+    const importFn = isFlex
+        ? () => import('~/layouts/landing/footer/flex')
+        : () => import('~/layouts/default/footer/footer');
+
+    return <JITLoad importFn={importFn} />;
 }
 
 export default function LandingLayout({children, data}: React.PropsWithChildren<Props>) {
@@ -36,7 +49,7 @@ export default function LandingLayout({children, data}: React.PropsWithChildren<
                 </MainClassContextProvider>
             </SalesforceContextProvider>
             <footer id="footer">
-                <Footer />
+                <Footer data={data} />
             </footer>
         </React.Fragment>
     );

--- a/test/src/layouts/landing/footer.test.tsx
+++ b/test/src/layouts/landing/footer.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import userEvent, { UserEvent } from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 import {render, screen, waitFor} from '@testing-library/preact';
 import {describe, it} from '@jest/globals';
 import { MemoryRouter } from 'react-router-dom';
 import { useContactDialog } from '~/layouts/landing/footer/flex';
+
+const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
 
 function ShowContactDialog(props: Parameters<ReturnType<typeof useContactDialog>['ContactDialog']>[0]) {
     const {ContactDialog, open: openContactDialog} = useContactDialog();
@@ -18,11 +20,8 @@ function ShowContactDialog(props: Parameters<ReturnType<typeof useContactDialog>
 
 describe('flex landing footer', () => {
     describe('contact dialog', () => {
-        let user: UserEvent;
-
         beforeEach(() => {
             jest.useFakeTimers();
-            user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         });
 
         it('opens and closes', async () => {

--- a/test/src/layouts/landing/footer.test.tsx
+++ b/test/src/layouts/landing/footer.test.tsx
@@ -1,35 +1,39 @@
 import React from 'react';
-import userEvent from '@testing-library/user-event';
+import userEvent, { UserEvent } from '@testing-library/user-event';
 import {render, screen, waitFor} from '@testing-library/preact';
 import {describe, it} from '@jest/globals';
 import { MemoryRouter } from 'react-router-dom';
 import { useContactDialog } from '~/layouts/landing/footer/flex';
 
-jest.useFakeTimers();
-const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
-
-function ShowDialogWithParams() {
+function ShowContactDialog(props: Parameters<ReturnType<typeof useContactDialog>['ContactDialog']>[0]) {
     const {ContactDialog, open: openContactDialog} = useContactDialog();
-    const contactFormParams = [
-        { key: 'userId', value: 'test' }
-    ];
 
     return (
         <button onClick={openContactDialog}>
             Contact Us
-            <ContactDialog contactFormParams={contactFormParams} />
+            <ContactDialog {...props} />
         </button>
     );
 }
 
 describe('flex landing footer', () => {
     describe('contact dialog', () => {
+        let user: UserEvent;
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+            user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+        });
+
         it('opens and closes', async () => {
             const getIframe = () => document.querySelector('iframe');
+            const contactFormParams = [
+                { key: 'userId', value: 'test' }
+            ];
 
             render(
                 <MemoryRouter initialEntries={['']}>
-                    <ShowDialogWithParams />
+                    <ShowContactDialog contactFormParams={contactFormParams} />
                 </MemoryRouter>
             );
             expect(getIframe()).toBeNull();

--- a/test/src/layouts/landing/footer.test.tsx
+++ b/test/src/layouts/landing/footer.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import {render, screen, waitFor} from '@testing-library/preact';
+import {describe, it} from '@jest/globals';
+import { MemoryRouter } from 'react-router-dom';
+import { useContactDialog } from '~/layouts/landing/footer/flex';
+
+jest.useFakeTimers();
+const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+
+function ShowDialogWithParams() {
+    const {ContactDialog, open: openContactDialog} = useContactDialog();
+    const contactFormParams = [
+        { key: 'userId', value: 'test' }
+    ];
+
+    return (
+        <button onClick={openContactDialog}>
+            Contact Us
+            <ContactDialog contactFormParams={contactFormParams} />
+        </button>
+    );
+}
+
+describe('flex landing footer', () => {
+    describe('contact dialog', () => {
+        it('opens and closes', async () => {
+            const getIframe = () => document.querySelector('iframe');
+
+            render(
+                <MemoryRouter initialEntries={['']}>
+                    <ShowDialogWithParams />
+                </MemoryRouter>
+            );
+            expect(getIframe()).toBeNull();
+            await user.click(await screen.findByText('Contact Us'));
+            expect(getIframe()?.src.endsWith('body=userId%3Dtest')).toBe(true);
+
+            jest.useRealTimers();
+
+            // Should do nothing
+            window.postMessage('Some Other Message', '*');
+
+            // Should close the dialog
+            window.postMessage('CONTACT_FORM_SUBMITTED', '*');
+            await waitFor(() => expect(getIframe()).toBeNull());
+        });
+    });
+});

--- a/test/src/layouts/layouts.test.tsx
+++ b/test/src/layouts/layouts.test.tsx
@@ -56,6 +56,8 @@ describe('layouts/landing', () => {
 
         // Find social links by title
         expect(await screen.findAllByTitle(/^OpenStax on .+$/)).toHaveLength(5);
+        // Default footer has 16 links + 4 links in layout = 20 links
+        expect(await screen.findAllByRole('link')).toHaveLength(20);
     });
     it('renders the flex footer for flex pages', async () => {
         data.meta = { type: 'pages.FlexPage' };
@@ -71,5 +73,7 @@ describe('layouts/landing', () => {
         await expect(screen.findAllByTitle(/^OpenStax on .+$/))
             .rejects
             .toThrow(/Unable to find an element/);
+        // Flex footer has 4 links + 4 links in layout = 8 links
+        expect(await screen.findAllByRole('link')).toHaveLength(8);
     });
 });

--- a/test/src/layouts/layouts.test.tsx
+++ b/test/src/layouts/layouts.test.tsx
@@ -44,4 +44,32 @@ describe('layouts/landing', () => {
         );
         expect(screen.getAllByRole('link')).toHaveLength(4);
     });
+    it('renders the default footer for non-flex pages', async () => {
+        data.meta = { type: 'not-a-flex-page' };
+        render(
+            <MemoryRouter initialEntries={['']}>
+                <LandingLayout data={data}>
+                    <div>child contents</div>
+                </LandingLayout>
+            </MemoryRouter>
+        );
+
+        // Find social links by title
+        expect(await screen.findAllByTitle(/^OpenStax on .+$/)).toHaveLength(5);
+    });
+    it('renders the flex footer for flex pages', async () => {
+        data.meta = { type: 'pages.FlexPage' };
+        render(
+            <MemoryRouter initialEntries={['']}>
+                <LandingLayout data={data}>
+                    <div>child contents</div>
+                </LandingLayout>
+            </MemoryRouter>
+        );
+
+        // Flex footer does not have social links
+        await expect(screen.findAllByTitle(/^OpenStax on .+$/))
+            .rejects
+            .toThrow(/Unable to find an element/);
+    });
 });

--- a/test/src/layouts/layouts.test.tsx
+++ b/test/src/layouts/layouts.test.tsx
@@ -61,7 +61,12 @@ describe('layouts/landing', () => {
         expect(screen.getAllByRole('link')).toHaveLength(2);
     });
     it('renders the default footer for non-flex pages', async () => {
-        data.meta = { type: 'not-a-flex-page' };
+        const title = 'some-title';
+        const layout = [{value: {navLinks: []}}];
+        const type = 'not-a-flex-page';
+        const meta = {type};
+        const data = {title, layout, meta} as const;
+
         render(
             <MemoryRouter initialEntries={['']}>
                 <LandingLayout data={data}>
@@ -72,11 +77,16 @@ describe('layouts/landing', () => {
 
         // Find social links by title
         expect(await screen.findAllByTitle(/^OpenStax on .+$/)).toHaveLength(5);
-        // Default footer has 16 links + 4 links in layout = 20 links
-        expect(await screen.findAllByRole('link')).toHaveLength(20);
+        // Default footer has 16 links + 1 link in layout = 17 links
+        expect(await screen.findAllByRole('link')).toHaveLength(17);
     });
     it('renders the flex footer for flex pages', async () => {
-        data.meta = { type: 'pages.FlexPage' };
+        const title = 'some-title';
+        const layout = [{value: {navLinks: []}}];
+        const type = 'pages.FlexPage';
+        const meta = {type};
+        const data = {title, layout, meta} as const;
+
         render(
             <MemoryRouter initialEntries={['']}>
                 <LandingLayout data={data}>
@@ -89,7 +99,7 @@ describe('layouts/landing', () => {
         await expect(screen.findAllByTitle(/^OpenStax on .+$/))
             .rejects
             .toThrow(/Unable to find an element/);
-        // Flex footer has 4 links + 4 links in layout = 8 links
-        expect(await screen.findAllByRole('link')).toHaveLength(8);
+        // Default footer has 4 links + 1 link in layout = 5 links
+        expect(await screen.findAllByRole('link')).toHaveLength(5);
     });
 });


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-898

Add a new footer for landing layout flex pages.

I am a bit new to this code, but it seemed like this combination of `import` and `JITLoad` was a common way to avoid importing styles/code that isn't actively used. I realize that the footer loader has its own loading placeholder which is then placed inside the `JITLoad` which also has a loading placeholder. Maybe there's a better way that I overlooked.

I am also wondering if (1) the condition for flex pages is correct and (2) if I should export a list of flex page types somewhere that can be used here and in `fallback-to` so that this condition is not duplicated.

## Desktop

<img width="1792" alt="Screenshot 2025-04-16 at 3 09 33 PM" src="https://github.com/user-attachments/assets/57d1bd61-beb9-4cf6-9244-f5679e0faa52" />

## Mobile

<img width="561" alt="Screenshot 2025-04-16 at 3 09 48 PM" src="https://github.com/user-attachments/assets/6204ccc3-8e58-43b2-8b25-8f9f5416843d" />

## Contact Us Dialog (iframe)

<img width="1447" alt="Screenshot 2025-04-17 at 4 47 56 PM" src="https://github.com/user-attachments/assets/6edff314-12a3-4fc3-92ce-b05d900865df" />

