### PR TITLE
CORE-1019: Fix how-using dropdown

### DIFF
--- a/src/app/pages/adoption/how-using/how-using.js
+++ b/src/app/pages/adoption/how-using/how-using.js
@@ -50,7 +50,7 @@ function HowUsingBook({book, dispatch}) {
     };
 
     adoptionOptions.forEach((opt) => {
-        opt.text = adoptionTexts[opt.key];
+        opt.label = adoptionTexts[opt.key];
     });
 
     return (


### PR DESCRIPTION
[CORE-1019]
Previous update change dropdown to expect only `label` for options, but how-using was still sending `text`.

[CORE-1019]: https://openstax.atlassian.net/browse/CORE-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ