### PR TITLE
Add analytics tracking attributes for key funnel links [CORE-1462]

### DIFF
--- a/src/app/pages/assignable/sections/banner/banner.tsx
+++ b/src/app/pages/assignable/sections/banner/banner.tsx
@@ -50,7 +50,7 @@ export default function Banner({data}: {data: BannerData}) {
                     <h1>{data.subheading}</h1>
                 </div>
                 <RawHTML className="text-content" html={data.headingDescription} />
-                <div className="button-row">
+                <div className="button-row" data-analytics-nav="Assignable CTAs">
                     <CTAButton
                         header={data.addAssignableCtaHeader}
                         href={data.addAssignableCtaLink}

--- a/src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.tsx
+++ b/src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.tsx
@@ -139,7 +139,7 @@ export default function OrderPrintCopy({slug}: {slug: string}) {
     }
 
     return (
-        <nav className="order-print-copy">
+        <nav className="order-print-copy" data-analytics-nav="Order print copy">
             <PhoneBoxes {...{contentArray}} />
             <DesktopBoxes {...{contentArray}} />
         </nav>

--- a/src/app/pages/details/common/let-us-know/let-us-know.tsx
+++ b/src/app/pages/details/common/let-us-know/let-us-know.tsx
@@ -40,7 +40,7 @@ function ButtonWithIcon({url, icon, text, reverse=false}: {
     reverse?: boolean;
 }) {
     return (
-        <a className="button-with-icon" href={url}>
+        <a className="button-with-icon" href={url} data-analytics-link>
             <span className={cn('book-icon', {reverse})}>
                 <FontAwesomeIcon icon={icon} />
             </span>

--- a/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.tsx
+++ b/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.tsx
@@ -60,7 +60,6 @@ export default function Partners({
             <div
                 className="blurb-scroller"
                 data-analytics-content-list={title}
-                data-analytics-nav={title}
             >
                 <ul className="blurbs">
                     {blurbs.map((blurb) => (

--- a/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.tsx
+++ b/src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.tsx
@@ -60,6 +60,7 @@ export default function Partners({
             <div
                 className="blurb-scroller"
                 data-analytics-content-list={title}
+                data-analytics-nav={title}
             >
                 <ul className="blurbs">
                     {blurbs.map((blurb) => (


### PR DESCRIPTION
## Summary

Adds analytics tracking attributes to important funnel events that were not being tracked in analytics. With the analytics helper, we just need to add `data-analytics-link` or `data-analytics-nav` attributes to enable link click tracking.

## Changes

✅ **"Using this book?" and "Sign up to learn more" buttons**
- File: `src/app/pages/details/common/let-us-know/let-us-know.tsx`
- Added `data-analytics-link` attribute to the `<a>` tag in the `ButtonWithIcon` component

✅ **Assignable page CTAs (3 links in top section)**
- File: `src/app/pages/assignable/sections/banner/banner.tsx`
- Added `data-analytics-nav="Assignable CTAs"` to the `button-row` container div

✅ **Tech partner list on instructor resources tab**
- File: `src/app/pages/details/desktop-view/instructor-resource-tab/partners/partners.tsx`
- Added `data-analytics-nav={title}` to the `blurb-scroller` div that contains the partner list items

✅ **"Buy print" / "Bookstore order" section**
- File: `src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.tsx`
- Added `data-analytics-nav="Order print copy"` to the `<nav>` element

## Test Plan

- [ ] Verify analytics tracking is working for "Using this book?" button on book details pages
- [ ] Verify analytics tracking for "Sign up to learn more" button on book details pages
- [ ] Test all 3 CTA buttons on the assignable landing page are tracked
- [ ] Confirm partner links in the instructor resources tab are tracked
- [ ] Check "Buy print" and "Order options" links are tracked

## Related

Jira: https://openstax.atlassian.net/browse/CORE-1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)