### PR TITLE
Add GA4 analytics tracking to K12 page elements

### DIFF
--- a/src/app/pages/k12/subject/books.tsx
+++ b/src/app/pages/k12/subject/books.tsx
@@ -39,7 +39,7 @@ function AdoptionBox({data}: {data: K12SubjectData}) {
         <div className="adoption-box boxed">
             <h2>{data.adoptionHeading}</h2>
             <RawHTML html={data.adoptionText} />
-            <a href={data.adoptionLink} className="btn primary">
+            <a href={data.adoptionLink} className="btn primary" data-analytics-link>
                 {data.adoptionLinkText}
             </a>
         </div>
@@ -52,7 +52,7 @@ export default function Books({data}: {data: K12SubjectData}) {
             <div className="boxed">
                 <Overview data={data} />
                 <AboutTheBooks data={data} />
-                <a className="resource-link" href="#resources">
+                <a className="resource-link" href="#resources" data-analytics-link>
                     Find Supplemental Resources
                 </a>
                 <AdoptionBox data={data} />

--- a/src/app/pages/k12/subject/subject.tsx
+++ b/src/app/pages/k12/subject/subject.tsx
@@ -63,7 +63,7 @@ function QuickLinks({
         <section className="quick-links">
             <div className="boxed">
                 <strong>Quick links:</strong>
-                <div className="items">
+                <div className="items" data-analytics-nav="k12-quick-links">
                     <a href="#books">Books</a>
                     {labels.map((text) => (
                         <a


### PR DESCRIPTION
## Summary

This PR adds GA4 analytics tracking to key user interaction elements on K12 subject pages.

## Changes

1. **Adoption Button** (Phase 1 - Original Request)
   - Added `data-analytics-link` to the "Report your adoption" button in `books.tsx:42`
   - Enables tracking of this primary conversion action

2. **Find Supplemental Resources Link** (Phase 2, Item 4)
   - Added `data-analytics-link` to the cross-section navigation link in `books.tsx:55`
   - Tracks user navigation to resource sections

3. **Quick Links Navigation** (Phase 2, Item 3)
   - Added `data-analytics-nav="k12-quick-links"` to the navigation container in `subject.tsx:66`
   - Tracks all quick link clicks (Books, Instructor resources, Student resources, Contact us)

## Analytics Implementation

The analytics-helpers system automatically tracks elements with these attributes and sends `click` events to GA4 with parameters including:
- `link_classes`: CSS classes
- `link_domain`: Target domain
- `link_url`: Full URL
- `link_text`: Link text content
- `outbound`: Whether external
- `link_nav`: Navigation identifier (for nav elements)

## Testing

- [ ] Verify buttons/links render correctly on K12 subject pages
- [ ] Verify links navigate correctly
- [ ] Verify GA4 events in browser dev tools or GA4 debug view

## Pages Affected

- All K12 subject pages (e.g., `/k12/business`, `/k12/science`, `/k12/math`)

## Related

Jira: [CORE-1742](https://openstax.atlassian.net/browse/CORE-1742)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1742]: https://openstax.atlassian.net/browse/CORE-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ