### PR TITLE
readd the draft param for live cms previews

### DIFF
--- a/src/app/helpers/page-data-utils.ts
+++ b/src/app/helpers/page-data-utils.ts
@@ -59,8 +59,11 @@ export async function getUrlFor(initialSlug: string) {
     }
 
     const qsChar = (/\?/).test(apiUrl) ? '&' : '?';
+    const draftParams = new URLSearchParams(window.location.search).has('preview')
+        ? `&draft=${Date.now()}`
+        : '';
 
-    return `${apiUrl}${qsChar}format=json`;
+    return `${apiUrl}${qsChar}format=json${draftParams}`;
 }
 
 function camelCase(underscored: string) {


### PR DESCRIPTION
The draftParams logic was accidentally dropped when page-data-utils.js was ported to TypeScript in PR #2698. This restors it inside getUrlFor() at line 62.

Now when a page is visited with `?preview` in the URL, all CMS API calls will include `&draft=<timestamp>`, which tells the CMS to return draft (unpublished) content. I also improved on the original implementation by evaluating `window.location.search` per-call rather than at module load time, so it works correctly during SPA navigation.