### PR TITLE
use auth aware adoption form headings

### DIFF
--- a/src/app/components/form-header/form-header.tsx
+++ b/src/app/components/form-header/form-header.tsx
@@ -2,8 +2,38 @@ import React from 'react';
 import RawHTML from '~/components/jsx-helpers/raw-html';
 import LoaderPage from '~/components/jsx-helpers/loader-page';
 import useLanguageContext from '~/contexts/language';
+import useUserContext from '~/contexts/user';
 
 import './form-header.scss';
+
+function interpolateTags(template: string, replacements: Record<string, string>) {
+    return template.replace(/\{\{(\w+)\}\}/g, (_, key) => replacements[key] ?? '');
+}
+
+type UserStatus = ReturnType<typeof useUserContext>['userStatus'];
+
+function pickField(
+    data: Record<string, string>,
+    prefix: string,
+    suffix: string,
+    isLoggedIn: boolean
+) {
+    const override = isLoggedIn ? data[`${prefix}LoggedIn${suffix}`] : '';
+
+    return override || data[`${prefix}${suffix}`] || '';
+}
+
+/* eslint-disable camelcase */
+function buildReplacements(userStatus: UserStatus | undefined) {
+    const status = userStatus ?? ({} as Partial<UserStatus>);
+
+    return {
+        first_name: status.firstName || '',
+        last_name: status.lastName || '',
+        school: status.school || ''
+    };
+}
+/* eslint-enable camelcase */
 
 function FormHeader({
     data,
@@ -12,14 +42,17 @@ function FormHeader({
     data: Record<string, string>;
     prefix: string;
 }) {
-    const heading = data[`${prefix}IntroHeading`];
-    const description = data[`${prefix}IntroDescription`];
+    const {userStatus} = useUserContext();
+    const isLoggedIn = Boolean(userStatus?.userInfo?.last_name);
+    const heading = pickField(data, prefix, 'IntroHeading', isLoggedIn);
+    const description = pickField(data, prefix, 'IntroDescription', isLoggedIn);
+    const replacements = React.useMemo(() => buildReplacements(userStatus), [userStatus]);
 
     return (
         <div className="form-header">
             <div className="text-content subhead">
-                <h1>{heading}</h1>
-                <RawHTML Tag="span" html={description} />
+                <h1>{interpolateTags(heading, replacements)}</h1>
+                <RawHTML Tag="span" html={interpolateTags(description, replacements)} />
             </div>
         </div>
     );

--- a/test/src/components/form-header.test.tsx
+++ b/test/src/components/form-header.test.tsx
@@ -1,0 +1,98 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import {describe, expect, it, beforeEach} from '@jest/globals';
+import {render, screen} from '@testing-library/preact';
+import FormHeader from '~/components/form-header/form-header';
+import MemoryRouter from '../../helpers/future-memory-router';
+import {LanguageContextProvider} from '~/contexts/language';
+import {UserContextProvider} from '~/contexts/user';
+import * as UM from '~/models/usermodel';
+import userModel from '../data/userModel';
+import usePageData from '~/helpers/use-page-data';
+
+jest.mock('~/helpers/use-page-data');
+
+const baseData = {
+    adoption_intro_heading: 'Default heading',
+    adoption_intro_description: '<p>Default description</p>'
+};
+
+function Component() {
+    return (
+        <MemoryRouter initialEntries={['/adoption']}>
+            <LanguageContextProvider>
+                <UserContextProvider>
+                    <FormHeader prefix="adoption" />
+                </UserContextProvider>
+            </LanguageContextProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('FormHeader', () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('renders default heading when user is not logged in', () => {
+        (usePageData as jest.Mock).mockReturnValue({
+            ...baseData,
+            adoption_logged_in_intro_heading: 'Hi {{first_name}}',
+            adoption_logged_in_intro_description: '<p>Welcome back</p>'
+        });
+        render(<Component />);
+        expect(screen.getByText('Default heading')).toBeTruthy();
+        expect(screen.queryByText(/Hi/)).toBeNull();
+    });
+
+    it('renders logged-in heading when user is logged in and field present', () => {
+        jest.spyOn(UM, 'useUserModel').mockReturnValue(
+            userModel as unknown as UM.UserModelType
+        );
+        (usePageData as jest.Mock).mockReturnValue({
+            ...baseData,
+            adoption_logged_in_intro_heading: 'Hi {{first_name}}',
+            adoption_logged_in_intro_description: '<p>Welcome back {{first_name}}</p>'
+        });
+        render(<Component />);
+        expect(screen.getByText('Hi Roy')).toBeTruthy();
+        expect(screen.getByText(/Welcome back Roy/)).toBeTruthy();
+    });
+
+    it('falls back to default when logged-in fields are blank', () => {
+        jest.spyOn(UM, 'useUserModel').mockReturnValue(
+            userModel as unknown as UM.UserModelType
+        );
+        (usePageData as jest.Mock).mockReturnValue({
+            ...baseData,
+            adoption_logged_in_intro_heading: '',
+            adoption_logged_in_intro_description: ''
+        });
+        render(<Component />);
+        expect(screen.getByText('Default heading')).toBeTruthy();
+    });
+
+    it('substitutes school and last_name tags', () => {
+        jest.spyOn(UM, 'useUserModel').mockReturnValue(
+            userModel as unknown as UM.UserModelType
+        );
+        (usePageData as jest.Mock).mockReturnValue({
+            ...baseData,
+            adoption_logged_in_intro_heading: '{{last_name}} at {{school}}'
+        });
+        render(<Component />);
+        expect(screen.getByText('Johnson at Test University')).toBeTruthy();
+    });
+
+    it('replaces unknown tags with empty string', () => {
+        jest.spyOn(UM, 'useUserModel').mockReturnValue(
+            userModel as unknown as UM.UserModelType
+        );
+        (usePageData as jest.Mock).mockReturnValue({
+            ...baseData,
+            adoption_logged_in_intro_heading: 'Hello {{nonexistent}}there'
+        });
+        render(<Component />);
+        expect(screen.getByText('Hello there')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
This goes with CMS PR [#1677](https://github.com/openstax/openstax-cms/pull/1677)  
This pull request updates the `FormHeader` component to support personalized headings and descriptions based on user login status, and adds comprehensive tests for these new behaviors. The main changes focus on conditionally rendering and interpolating user-specific data into the form header, improving the user experience for logged-in users.

**Enhancements to Form Header Personalization:**

* The `FormHeader` component now checks if a user is logged in and, if so, displays special heading and description fields (`*_LoggedInIntroHeading` and `*_LoggedInIntroDescription`) with support for template tags like `{{first_name}}`, `{{last_name}}`, and `{{school}}`. If these fields are missing or empty, it falls back to the default fields.
* Added a utility function to interpolate template tags in headings and descriptions with actual user data, replacing unknown tags with empty strings.

**Testing Improvements:**

* Introduced a new test suite for `FormHeader` to verify:
    - Correct fallback to default fields when the user is not logged in.
    - Proper rendering of personalized headings/descriptions for logged-in users.
    - Fallback to default when logged-in fields are empty.
    - Substitution of all supported tags and correct handling of unknown tags.