### PR TITLE
Use slash-less canonical paths and footer routes

### DIFF
--- a/src/app/components/shell/router-helpers/page-routes.tsx
+++ b/src/app/components/shell/router-helpers/page-routes.tsx
@@ -169,7 +169,7 @@ const FOOTER_PAGES = [
     'privacy-policy',
     'accessibility-statement',
     'careers'
-].map((s) => `/${s}/`);
+].map((s) => `/${s}`);
 
 export function generateFooterPageRoutes() {
     return FOOTER_PAGES.map((path) => (

--- a/src/app/pages/general/general.tsx
+++ b/src/app/pages/general/general.tsx
@@ -33,7 +33,9 @@ function isCanonical(slug: string) {
 }
 
 function getCanonicalPath(slug: string) {
-    return `${slug.replace(/.*\/(?!$)/, '/')}${slug.endsWith('/') ? '' : '/'}`;
+    const lastSegment = slug.replace(/\/$/, '').split('/').pop();
+
+    return `/${lastSegment}`;
 }
 
 export function GeneralPageFromSlug({slug}: {slug: string}) {


### PR DESCRIPTION
## Why

The CMS `sitemap.xml` now emits canonical, **slash-less** `<loc>` URLs (e.g. `/blog/foo`, `/license`). This aligns the frontend so every public-facing URL it generates uses the same slash-less form.

Note: this only touches **public/canonical/navigation** URLs. CMS **API request** URLs (`url-from-slug.ts`, `page-data-utils.ts`) intentionally keep their trailing slash, since the DRF routers require it — those are unchanged.

## Changes

- **`general.tsx` `getCanonicalPath`** — returns a leading-slash, slash-less canonical path. Previously it appended a trailing slash (which `useCanonicalLink` stripped downstream anyway, so the emitted tag is unchanged in practice). This also fixes a latent bug where single-segment slugs like `kinetic` produced a path with **no leading slash** (`kinetic` → `https://openstax.orgkinetic`); it now yields `/kinetic`.
- **`page-routes.tsx` `FOOTER_PAGES`** — route paths defined without a trailing slash. React Router v6 matches both forms, so `/license` and `/license/` both continue to resolve; this is for consistency with the slash-less convention.

## Verification

- `yarn lint:ts` (tsc) — clean
- `eslint` on both changed files — clean
- `jest` for `general`, `footer-page`, and `shell` suites — 31 passed

## Context

Companion to the CMS-side fix that makes `sitemap.xml` emit slash-less `<loc>` entries (committed separately in openstax-cms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)