### PR TITLE
add wagtail userbar (a11y and content checks)

### DIFF
--- a/src/app/components/headless-userbar/headless-userbar.tsx
+++ b/src/app/components/headless-userbar/headless-userbar.tsx
@@ -7,7 +7,9 @@ import React from 'react';
 // checks on the decoupled front-end (per the Wagtail headless docs). The CMS
 // may be on a different origin when API_ORIGIN is set (otherwise this is same-origin).
 const apiOrigin = process.env.API_ORIGIN ?? '';
-const userbarEndpoint = `${apiOrigin}/apps/cms/userbar/`;
+// Under /apps/cms/api/ because that is the only /apps/cms/ path the production
+// nginx routes to the CMS backend; other paths proxy to the front-end itself.
+const userbarEndpoint = `${apiOrigin}/apps/cms/api/userbar/`;
 const userbarScripts = [
     `${apiOrigin}/static/wagtailadmin/js/vendor.js`,
     `${apiOrigin}/static/wagtailadmin/js/userbar.js`

--- a/src/app/components/headless-userbar/headless-userbar.tsx
+++ b/src/app/components/headless-userbar/headless-userbar.tsx
@@ -34,13 +34,26 @@ function appendScript(parent: HTMLElement, src: string) {
 }
 
 export default function HeadlessUserbar() {
+    // Public traffic never previews, so don't mount the loader (or its effect
+    // and DOM node) at all outside preview. Gating here rather than inside the
+    // effect keeps the div off every public page. The hookless wrapper makes
+    // the early return safe: all hooks live in UserbarLoader, which is only
+    // mounted while previewing.
+    if (!isPreviewing()) {
+        return null;
+    }
+
+    return <UserbarLoader />;
+}
+
+function UserbarLoader() {
     const ref = React.useRef<HTMLDivElement>(null);
 
     React.useEffect(() => {
         const container = ref.current;
         let cancelled = false;
 
-        if (isPreviewing() && container) {
+        if (container) {
             fetch(userbarEndpoint, {credentials: 'include'})
                 .then((response) => (response.ok ? response.text() : ''))
                 .then((html) => {

--- a/src/app/components/headless-userbar/headless-userbar.tsx
+++ b/src/app/components/headless-userbar/headless-userbar.tsx
@@ -9,7 +9,12 @@ import React from 'react';
 const apiOrigin = process.env.API_ORIGIN ?? '';
 // Under /apps/cms/api/ because that is the only /apps/cms/ path the production
 // nginx routes to the CMS backend; other paths proxy to the front-end itself.
-const userbarEndpoint = `${apiOrigin}/apps/cms/api/userbar/`;
+// TEMPORARY: the dedicated /apps/cms/api/userbar/* CloudFront behavior (cookies
+// forwarded, no cache) isn't deployed yet, so /apps/cms/api/userbar/ strips the
+// session cookie and returns blank. Ride the already-deployed, now-unused
+// /apps/cms/api/salesforce/reviews/* behavior (cookies forwarded) to test.
+// Revert to `${apiOrigin}/apps/cms/api/userbar/` once the CloudFront change ships.
+const userbarEndpoint = `${apiOrigin}/apps/cms/api/salesforce/reviews/userbar/`;
 const userbarScripts = [
     `${apiOrigin}/static/wagtailadmin/js/vendor.js`,
     `${apiOrigin}/static/wagtailadmin/js/userbar.js`

--- a/src/app/components/headless-userbar/headless-userbar.tsx
+++ b/src/app/components/headless-userbar/headless-userbar.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+// While previewing a draft, Wagtail redirects the editor here with a `?preview`
+// query parameter (see the CMS `serve_preview`). Loading Wagtail's userbar on
+// the previewed page is what enables live-preview scroll restoration, the
+// accessibility/content checker, content metrics, and wagtail-ai's content
+// checks on the decoupled front-end (per the Wagtail headless docs). The CMS
+// and front-end share an origin, so the fetch is same-origin.
+const apiOrigin = process.env.API_ORIGIN ?? '';
+const userbarEndpoint = `${apiOrigin}/apps/cms/userbar/`;
+const userbarScripts = [
+    `${apiOrigin}/static/wagtailadmin/js/vendor.js`,
+    `${apiOrigin}/static/wagtailadmin/js/userbar.js`
+];
+
+function isPreviewing() {
+    return new URLSearchParams(window.location.search).has('preview');
+}
+
+function appendScript(parent: HTMLElement, src: string) {
+    const script = document.createElement('script');
+
+    script.src = src;
+    // Preserve order: vendor.js must run before userbar.js.
+    script.async = false;
+    parent.appendChild(script);
+}
+
+export default function HeadlessUserbar() {
+    const ref = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+        const container = ref.current;
+        let cancelled = false;
+
+        if (isPreviewing() && container) {
+            fetch(userbarEndpoint, {credentials: 'include'})
+                .then((response) => response.text())
+                .then((html) => {
+                    // Guard against double-injection (e.g. effect re-runs) and
+                    // the empty body the endpoint returns for non-admins.
+                    if (
+                        cancelled ||
+                        !html ||
+                        container.querySelector('wagtail-userbar')
+                    ) {
+                        return;
+                    }
+                    container.innerHTML = html;
+                    userbarScripts.forEach((src) =>
+                        appendScript(container, src)
+                    );
+                })
+                .catch(() => undefined);
+        }
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return <div ref={ref} className="headless-userbar" />;
+}

--- a/src/app/components/headless-userbar/headless-userbar.tsx
+++ b/src/app/components/headless-userbar/headless-userbar.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 // the previewed page is what enables live-preview scroll restoration, the
 // accessibility/content checker, content metrics, and wagtail-ai's content
 // checks on the decoupled front-end (per the Wagtail headless docs). The CMS
-// and front-end share an origin, so the fetch is same-origin.
+// may be on a different origin when API_ORIGIN is set (otherwise this is same-origin).
 const apiOrigin = process.env.API_ORIGIN ?? '';
 const userbarEndpoint = `${apiOrigin}/apps/cms/userbar/`;
 const userbarScripts = [
@@ -35,21 +35,20 @@ export default function HeadlessUserbar() {
 
         if (isPreviewing() && container) {
             fetch(userbarEndpoint, {credentials: 'include'})
-                .then((response) => response.text())
+                .then((response) => (response.ok ? response.text() : ''))
                 .then((html) => {
-                    // Guard against double-injection (e.g. effect re-runs) and
-                    // the empty body the endpoint returns for non-admins.
+                    // Guard against double-injection (e.g. effect re-runs), the empty body
+                    // the endpoint returns for non-admins, and unexpected responses.
                     if (
                         cancelled ||
                         !html ||
+                        !html.includes('wagtail-userbar') ||
                         container.querySelector('wagtail-userbar')
                     ) {
                         return;
                     }
                     container.innerHTML = html;
-                    userbarScripts.forEach((src) =>
-                        appendScript(container, src)
-                    );
+                    userbarScripts.forEach((src) => appendScript(container, src));
                 })
                 .catch(() => undefined);
         }

--- a/src/app/components/shell/shell.tsx
+++ b/src/app/components/shell/shell.tsx
@@ -7,6 +7,7 @@ import {SharedDataContextProvider} from '../../contexts/shared-data';
 import JITLoad from '~/helpers/jit-load';
 import {SalesforceContextProvider} from '~/contexts/salesforce';
 import {PortalContextProvider} from '~/contexts/portal';
+import HeadlessUserbar from '~/components/headless-userbar/headless-userbar';
 
 import Error404 from '~/pages/404/404';
 
@@ -44,6 +45,7 @@ const importRouter = () => import('./import-router.js');
 function App() {
     return (
         <AppContext>
+            <HeadlessUserbar />
             <BrowserRouter>
                 <Routes>
                     <Route path="/embedded/*" element={<EmbeddedApp />} />

--- a/test/src/components/headless-userbar.test.tsx
+++ b/test/src/components/headless-userbar.test.tsx
@@ -30,7 +30,9 @@ describe('HeadlessUserbar', () => {
 
         const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
 
-        expect(fetchUrl).toMatch('/apps/cms/api/userbar/');
+        // TEMP: riding the salesforce/reviews/* CloudFront behavior until the
+        // dedicated userbar behavior is deployed (see headless-userbar.tsx).
+        expect(fetchUrl).toMatch('/apps/cms/api/salesforce/reviews/userbar/');
 
         const scriptSrcs = Array.from(
             container.querySelectorAll('script')

--- a/test/src/components/headless-userbar.test.tsx
+++ b/test/src/components/headless-userbar.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {render, waitFor} from '@testing-library/preact';
+import HeadlessUserbar from '~/components/headless-userbar/headless-userbar';
+
+function setLocation(pathAndSearch: string) {
+    window.history.replaceState({}, '', pathAndSearch);
+}
+
+describe('HeadlessUserbar', () => {
+    beforeEach(() => {
+        setLocation('/');
+        (global.fetch as jest.Mock).mockClear();
+    });
+
+    it('fetches and injects the userbar when previewing a draft', async () => {
+        setLocation('/some-page/?preview=auto');
+        (global.fetch as jest.Mock).mockImplementation(() =>
+            Promise.resolve({
+                ok: true,
+                text: () =>
+                    Promise.resolve('<wagtail-userbar></wagtail-userbar>')
+            })
+        );
+
+        const {container} = render(<HeadlessUserbar />);
+
+        await waitFor(() =>
+            expect(container.querySelector('wagtail-userbar')).not.toBeNull()
+        );
+
+        const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
+
+        expect(fetchUrl).toMatch('/apps/cms/userbar/');
+
+        const scriptSrcs = Array.from(
+            container.querySelectorAll('script')
+        ).map((s) => s.getAttribute('src'));
+
+        expect(
+            scriptSrcs.some((s) => s?.includes('wagtailadmin/js/vendor.js'))
+        ).toBe(true);
+        expect(
+            scriptSrcs.some((s) => s?.includes('wagtailadmin/js/userbar.js'))
+        ).toBe(true);
+    });
+
+    it('does nothing when not previewing', () => {
+        setLocation('/some-page/');
+
+        const {container} = render(<HeadlessUserbar />);
+
+        expect(global.fetch as jest.Mock).not.toHaveBeenCalled();
+        expect(container.querySelector('wagtail-userbar')).toBeNull();
+    });
+});

--- a/test/src/components/headless-userbar.test.tsx
+++ b/test/src/components/headless-userbar.test.tsx
@@ -30,7 +30,7 @@ describe('HeadlessUserbar', () => {
 
         const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
 
-        expect(fetchUrl).toMatch('/apps/cms/userbar/');
+        expect(fetchUrl).toMatch('/apps/cms/api/userbar/');
 
         const scriptSrcs = Array.from(
             container.querySelectorAll('script')


### PR DESCRIPTION
This pull request introduces a new `HeadlessUserbar` React component that conditionally injects Wagtail's userbar into the page during content preview sessions. This enables live-preview features and content checks on the decoupled front-end. The component is integrated into the application shell and is accompanied by unit tests to verify its behavior.

**New HeadlessUserbar component and integration:**

* Added `HeadlessUserbar` component in `src/app/components/headless-userbar/headless-userbar.tsx`, which loads the Wagtail userbar and associated scripts when a `?preview` parameter is present in the URL. This supports live preview, accessibility checks, and content metrics during CMS draft previews.
* Integrated `HeadlessUserbar` into the main application shell by importing and rendering it in `src/app/components/shell/shell.tsx`, ensuring it is available across the app. [[1]](diffhunk://#diff-8878f5d2158b99ba0c3f18e7e4bb1e16066d715af1217862a65093e8fc9614b4R10) [[2]](diffhunk://#diff-8878f5d2158b99ba0c3f18e7e4bb1e16066d715af1217862a65093e8fc9614b4R48)

**Testing:**

* Added unit tests in `test/src/components/headless-userbar.test.tsx` to verify that the userbar is fetched and injected only during preview sessions and that it does nothing otherwise.