### PR TITLE
only trigger playwright tests on a push to main

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,8 @@
 name: Playwright
 
-on: [pull_request]
+on:
+  push:
+    branches: [main]
 
 defaults:
   run:


### PR DESCRIPTION
This pull request updates the Playwright GitHub Actions workflow to trigger on pushes to the `main` branch instead of pull requests.

Workflow trigger update:

* [`.github/workflows/playwright.yml`](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3L3-R5): Changed the workflow trigger from `pull_request` to `push` events on the `main` branch.