### PR TITLE
Core 2372: Revise styling of book details sidebar

### DIFF
--- a/src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.scss
+++ b/src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.scss
@@ -86,10 +86,12 @@
         }
     }
 
-    .btn.btn {
+    .btn {
         @extend %button;
 
-        height: 4rem;
+        &.btn { // increase specificity
+            height: 4rem;
+        }
         padding: 1rem;
 
         &.primary {

--- a/src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.scss
+++ b/src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.scss
@@ -3,7 +3,7 @@
 .order-print-copy {
     @include set-font(helper-label);
 
-    background-color: ui-color(page-bg);
+    background-color: transparent;
     max-width: 26rem;
 
     .blurb {
@@ -86,9 +86,10 @@
         }
     }
 
-    .btn {
+    .btn.btn {
         @extend %button;
 
+        height: 4rem;
         padding: 1rem;
 
         &.primary {

--- a/src/app/pages/details/common/let-us-know/let-us-know.scss
+++ b/src/app/pages/details/common/let-us-know/let-us-know.scss
@@ -11,7 +11,7 @@ $icon-size: 5.5rem;
 
     .button-with-icon {
         align-items: center;
-        background-color: ui-color(page-bg);
+        background-color: transparent;
         border-radius: 0.5rem;
         color: inherit;
         display: grid;

--- a/src/app/pages/details/common/let-us-know/let-us-know.scss
+++ b/src/app/pages/details/common/let-us-know/let-us-know.scss
@@ -7,9 +7,11 @@ $icon-size: 5.5rem;
     display: grid;
     grid-gap: 2rem;
     margin-bottom: 4rem;
-    width: max-content;
+    width: 100%;
+    max-width: 26rem;
 
     .button-with-icon {
+        @include button();
         align-items: center;
         background-color: transparent;
         border-radius: 0.5rem;
@@ -17,6 +19,7 @@ $icon-size: 5.5rem;
         display: grid;
         grid-gap: $normal-margin;
         grid-template-columns: $icon-size auto;
+        height: auto;
         padding: 1rem;
         text-decoration: none;
     }
@@ -41,5 +44,6 @@ $icon-size: 5.5rem;
         @include set-font(body-large);
 
         line-height: normal;
+        text-align: start;
     }
 }


### PR DESCRIPTION
[CORE-2372]
Revise the layout in the order-print-copy and let-us-know sections of the Book Details page:

- Remove light gray background
- Add button styling to let-us-know links
- Make let-us-know links the same width as order-print-copy section
- Make order-print-copy button height normal (4rem) rather than large (5rem).


[CORE-2372]: https://openstax.atlassian.net/browse/CORE-2372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ