### PR TITLE
Style flex-page rich-text features (eyebrow, brand colors)

### DIFF
--- a/src/app/pages/flex-page/flex-page.scss
+++ b/src/app/pages/flex-page/flex-page.scss
@@ -1,4 +1,27 @@
+@import 'pattern-library/core/pattern-library/headers';
 
 .page.flex-page {
   overflow: visible;
+}
+
+// CORE-2302 rich-text editor features. These are openstax-cms / Draftail
+// classes, so they're styled here rather than in the flex-page renderer.
+.flex-page.page div.content-block-rich-text {
+  // Small label above a heading.
+  .eyebrow {
+    @include set-font(body-regular);
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: bold;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: os-color(gray);
+  }
+
+  // Brand text colors, applied to any run of text.
+  .text-blue { color: os-color(blue); }
+  .text-green { color: os-color(green); }
+  .text-orange { color: os-color(orange); }
+  .text-gray { color: os-color(gray); }
+  .text-white { color: text-color(white); }
 }


### PR DESCRIPTION
## What
Styles the CORE-2302 rich-text editor features for flex pages — the `eyebrow` label and the `text-blue/green/orange/gray/white` brand colors — under the fully-qualified `.flex-page.page div.content-block-rich-text` selector.

## Why here
Per Tom's review on openstax/flex-pages#10: these are openstax-cms / Draftail-specific classes, so they belong in the consuming app rather than the generic flex-page renderer. The renderer keeps only generic styling (default heading color, `figcaption`); big number became its own block (flex-pages #10 + openstax-cms #1703).

## Companions
- openstax-cms #1698 registers these Draftail features (already merged).
- flex-pages #10 removed this styling from the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)