### PR TITLE
Add relevance and date sorting to webinars search [CORE-2376]

### DIFF
--- a/src/app/components/sort-toggle/sort-toggle.scss
+++ b/src/app/components/sort-toggle/sort-toggle.scss
@@ -1,0 +1,62 @@
+@import 'pattern-library/core/pattern-library/headers';
+
+$control-height: 3.6rem;
+$control-radius: 0.6rem;
+
+.sort-toggle-wrap {
+    align-items: center;
+    display: flex;
+    gap: 0.8rem;
+}
+
+.sort-toggle-label {
+    color: text-color(normal);
+    font-size: 1.5rem;
+    font-weight: bold;
+    white-space: nowrap;
+}
+
+.sort-toggle {
+    background-color: ui-color(form-bg);
+    border: 0.1rem solid ui-color(secondary);
+    border-radius: $control-radius;
+    display: inline-flex;
+    gap: 0.3rem;
+    padding: 0.3rem;
+
+    button {
+        align-items: center;
+        background-color: transparent;
+        border: 0;
+        border-radius: #{$control-radius - 0.2rem};
+        color: text-color(normal);
+        cursor: pointer;
+        display: inline-flex;
+        font-family: inherit;
+        font-size: 1.5rem;
+        justify-content: center;
+        line-height: 1;
+        min-height: #{$control-height - 0.8rem};
+        padding: 0 1.6rem;
+        transition: background-color 0.15s ease, color 0.15s ease;
+
+        &:hover {
+            color: text-color(link);
+        }
+
+        &[aria-checked='true'] {
+            background-color: text-color(link);
+            color: text-color(white);
+
+            &:hover {
+                color: text-color(white);
+            }
+        }
+    }
+}
+
+// Guarantee a visible keyboard focus indicator.
+.sort-toggle button:focus-visible {
+    outline: 0.2rem solid ui-color(focus-outline);
+    outline-offset: 0.2rem;
+}

--- a/src/app/components/sort-toggle/sort-toggle.tsx
+++ b/src/app/components/sort-toggle/sort-toggle.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import './sort-toggle.scss';
+
+const SORT_OPTIONS = [
+    {key: 'relevance', label: 'Relevance', value: undefined},
+    {key: 'newest', label: 'Newest', value: 'newest'}
+] as const;
+
+type SortValue = 'relevance' | 'newest';
+
+interface SortToggleProps {
+    sort: SortValue;
+    setSort: (value: string | undefined) => void;
+    labelId: string;
+    className?: string;
+}
+
+export default function SortToggle({sort, setSort, labelId, className = ''}: SortToggleProps) {
+    const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+        const delta = ({ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1} as
+            Record<string, number>)[e.key];
+
+        if (!delta) {
+            return;
+        }
+        e.preventDefault();
+        const current = SORT_OPTIONS.findIndex((o) => o.key === sort);
+        const nextIndex = (current + delta + SORT_OPTIONS.length) % SORT_OPTIONS.length;
+        const next = SORT_OPTIONS[nextIndex];
+
+        setSort(next.value);
+
+        const group = e.currentTarget.parentElement;
+        const buttons = Array.from(
+            group?.querySelectorAll<HTMLButtonElement>('button[role="radio"]') ?? []
+        );
+
+        buttons[nextIndex]?.focus();
+    };
+
+    return (
+        <div className={`sort-toggle-wrap ${className}`}>
+            <span className="sort-toggle-label" id={labelId}>Sort by</span>
+            {/* `custom` opts out of the site-wide [role=radiogroup] filter-bar
+                styling (see styles/components/filter-buttons.scss), which would
+                otherwise stretch this to full viewport width. */}
+            <div className="sort-toggle custom" role="radiogroup" aria-labelledby={labelId}>
+                {SORT_OPTIONS.map((o) => (
+                    <button
+                        key={o.key}
+                        type="button"
+                        role="radio"
+                        aria-checked={sort === o.key}
+                        tabIndex={sort === o.key ? 0 : -1}
+                        onClick={() => setSort(o.value)}
+                        onKeyDown={onKeyDown}
+                    >{o.label}</button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/app/components/sort-toggle/sort-toggle.tsx
+++ b/src/app/components/sort-toggle/sort-toggle.tsx
@@ -11,7 +11,7 @@ type SortValue = 'relevance' | 'newest';
 
 interface SortToggleProps {
     sort: SortValue;
-    setSort: (value: string | undefined) => void;
+    setSort: (value: 'newest' | undefined) => void;
     labelId: string;
     className?: string;
 }

--- a/src/app/components/sort-toggle/sort-toggle.tsx
+++ b/src/app/components/sort-toggle/sort-toggle.tsx
@@ -7,7 +7,7 @@ const SORT_OPTIONS = [
     {key: 'newest', label: 'Newest', value: 'newest'}
 ] as const;
 
-type SortValue = 'relevance' | 'newest';
+export type SortValue = typeof SORT_OPTIONS[number]['key'];
 
 interface SortToggleProps {
     sort: SortValue;

--- a/src/app/components/sort-toggle/sort-toggle.tsx
+++ b/src/app/components/sort-toggle/sort-toggle.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {assertNotNull} from '~/helpers/data';
 import './sort-toggle.scss';
 
 const SORT_OPTIONS = [
@@ -30,9 +31,9 @@ export default function SortToggle({sort, setSort, labelId, className = ''}: Sor
 
         setSort(next.value);
 
-        const group = e.currentTarget.parentElement;
+        const group = assertNotNull(e.currentTarget.parentElement);
         const buttons = Array.from(
-            group?.querySelectorAll<HTMLButtonElement>('button[role="radio"]') ?? []
+            group.querySelectorAll<HTMLButtonElement>('button[role="radio"]')
         );
 
         buttons[nextIndex]?.focus();

--- a/src/app/pages/blog/facet-controls/facet-controls.scss
+++ b/src/app/pages/blog/facet-controls/facet-controls.scss
@@ -95,56 +95,13 @@ $control-radius: 0.6rem;
     }
 }
 
-// --- Sort segmented control ---
-.facet-sort-wrap {
-    align-items: center;
-    display: flex;
-    gap: 0.8rem;
+// --- Sort positioning ---
+.facet-sort-position {
     margin-left: auto;
-}
-
-.facet-sort {
-    background-color: ui-color(form-bg);
-    border: 0.1rem solid ui-color(secondary);
-    border-radius: $control-radius;
-    display: inline-flex;
-    gap: 0.3rem;
-    padding: 0.3rem;
-
-    button {
-        align-items: center;
-        background-color: transparent;
-        border: 0;
-        border-radius: #{$control-radius - 0.2rem};
-        color: text-color(normal);
-        cursor: pointer;
-        display: inline-flex;
-        font-family: inherit;
-        font-size: 1.5rem;
-        justify-content: center;
-        line-height: 1;
-        min-height: #{$control-height - 0.8rem};
-        padding: 0 1.6rem;
-        transition: background-color 0.15s ease, color 0.15s ease;
-
-        &:hover {
-            color: text-color(link);
-        }
-
-        &[aria-checked='true'] {
-            background-color: text-color(link);
-            color: text-color(white);
-
-            &:hover {
-                color: text-color(white);
-            }
-        }
-    }
 }
 
 // Guarantee a visible keyboard focus indicator across every control.
 .facet-chip:focus-visible,
-.facet-sort button:focus-visible,
 .facet-select select:focus-visible {
     outline: 0.2rem solid ui-color(focus-outline);
     outline-offset: 0.2rem;

--- a/src/app/pages/blog/facet-controls/facet-controls.tsx
+++ b/src/app/pages/blog/facet-controls/facet-controls.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import useBlogSearchParams from '../use-blog-search-params';
-import {assertDefined} from '~/helpers/data';
+import SortToggle from '~/components/sort-toggle/sort-toggle';
 import './facet-controls.scss';
 
 type NamedSnippet = {id?: number; name: string};
@@ -52,68 +52,23 @@ function CollectionSelect({collections}: {collections: NamedSnippet[]}) {
     );
 }
 
-const SORT_OPTIONS = [
-    {key: 'relevance', label: 'Relevance', value: undefined},
-    {key: 'newest', label: 'Newest', value: 'newest'}
-] as const;
-
-function SortToggle() {
-    const {sort, setParam} = useBlogSearchParams();
-    const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-        const delta = ({ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1} as
-            Record<string, number>)[e.key];
-
-        if (!delta) {
-            return;
-        }
-        e.preventDefault();
-        const current = SORT_OPTIONS.findIndex((o) => o.key === sort);
-        const nextIndex = (current + delta + SORT_OPTIONS.length) % SORT_OPTIONS.length;
-        const next = SORT_OPTIONS[nextIndex];
-
-        setParam('sort', next.value);
-
-        const group = e.currentTarget.parentElement;
-        const buttons = Array.from(
-            assertDefined(group?.querySelectorAll<HTMLButtonElement>('button[role="radio"]'))
-        );
-
-        buttons[nextIndex]?.focus();
-    };
-
-    return (
-        <div className="facet-sort-wrap">
-            <span className="facet-label" id="blog-sort-label">Sort by</span>
-            {/* `custom` opts out of the site-wide [role=radiogroup] filter-bar
-                styling (see styles/components/filter-buttons.scss), which would
-                otherwise stretch this to full viewport width. */}
-            <div className="facet-sort custom" role="radiogroup" aria-labelledby="blog-sort-label">
-                {SORT_OPTIONS.map((o) => (
-                    <button
-                        key={o.key}
-                        type="button"
-                        role="radio"
-                        aria-checked={sort === o.key}
-                        tabIndex={sort === o.key ? 0 : -1}
-                        onClick={() => setParam('sort', o.value)}
-                        onKeyDown={onKeyDown}
-                    >{o.label}</button>
-                ))}
-            </div>
-        </div>
-    );
-}
-
 export default function FacetControls({subjects, collections}: {
     subjects: NamedSnippet[];
     collections: NamedSnippet[];
 }) {
+    const {sort, setParam} = useBlogSearchParams();
+
     return (
         <div className="facet-controls" role="group" aria-label="Filter and sort blog posts">
             <SubjectChips subjects={subjects} />
             <div className="facet-row">
                 <CollectionSelect collections={collections} />
-                <SortToggle />
+                <SortToggle
+                    sort={sort}
+                    setSort={(value?: string) => setParam('sort', value)}
+                    labelId="blog-sort-label"
+                    className="facet-sort-position"
+                />
             </div>
         </div>
     );

--- a/src/app/pages/webinars/search-controls/search-controls.scss
+++ b/src/app/pages/webinars/search-controls/search-controls.scss
@@ -1,0 +1,69 @@
+@import 'pattern-library/core/pattern-library/headers';
+
+$control-height: 3.6rem;
+$control-radius: 0.6rem;
+
+.webinar-search-controls {
+    display: flex;
+    justify-content: flex-end;
+    padding: $normal-margin 0 2rem;
+}
+
+.webinar-sort-label {
+    color: text-color(normal);
+    font-size: 1.5rem;
+    font-weight: bold;
+    white-space: nowrap;
+}
+
+// --- Sort segmented control ---
+.webinar-sort-wrap {
+    align-items: center;
+    display: flex;
+    gap: 0.8rem;
+}
+
+.webinar-sort {
+    background-color: ui-color(form-bg);
+    border: 0.1rem solid ui-color(secondary);
+    border-radius: $control-radius;
+    display: inline-flex;
+    gap: 0.3rem;
+    padding: 0.3rem;
+
+    button {
+        align-items: center;
+        background-color: transparent;
+        border: 0;
+        border-radius: #{$control-radius - 0.2rem};
+        color: text-color(normal);
+        cursor: pointer;
+        display: inline-flex;
+        font-family: inherit;
+        font-size: 1.5rem;
+        justify-content: center;
+        line-height: 1;
+        min-height: #{$control-height - 0.8rem};
+        padding: 0 1.6rem;
+        transition: background-color 0.15s ease, color 0.15s ease;
+
+        &:hover {
+            color: text-color(link);
+        }
+
+        &[aria-checked='true'] {
+            background-color: text-color(link);
+            color: text-color(white);
+
+            &:hover {
+                color: text-color(white);
+            }
+        }
+    }
+}
+
+// Guarantee a visible keyboard focus indicator.
+.webinar-sort button:focus-visible {
+    outline: 0.2rem solid ui-color(focus-outline);
+    outline-offset: 0.2rem;
+}

--- a/src/app/pages/webinars/search-controls/search-controls.scss
+++ b/src/app/pages/webinars/search-controls/search-controls.scss
@@ -1,69 +1,7 @@
 @import 'pattern-library/core/pattern-library/headers';
 
-$control-height: 3.6rem;
-$control-radius: 0.6rem;
-
 .webinar-search-controls {
     display: flex;
     justify-content: flex-end;
     padding: $normal-margin 0 2rem;
-}
-
-.webinar-sort-label {
-    color: text-color(normal);
-    font-size: 1.5rem;
-    font-weight: bold;
-    white-space: nowrap;
-}
-
-// --- Sort segmented control ---
-.webinar-sort-wrap {
-    align-items: center;
-    display: flex;
-    gap: 0.8rem;
-}
-
-.webinar-sort {
-    background-color: ui-color(form-bg);
-    border: 0.1rem solid ui-color(secondary);
-    border-radius: $control-radius;
-    display: inline-flex;
-    gap: 0.3rem;
-    padding: 0.3rem;
-
-    button {
-        align-items: center;
-        background-color: transparent;
-        border: 0;
-        border-radius: #{$control-radius - 0.2rem};
-        color: text-color(normal);
-        cursor: pointer;
-        display: inline-flex;
-        font-family: inherit;
-        font-size: 1.5rem;
-        justify-content: center;
-        line-height: 1;
-        min-height: #{$control-height - 0.8rem};
-        padding: 0 1.6rem;
-        transition: background-color 0.15s ease, color 0.15s ease;
-
-        &:hover {
-            color: text-color(link);
-        }
-
-        &[aria-checked='true'] {
-            background-color: text-color(link);
-            color: text-color(white);
-
-            &:hover {
-                color: text-color(white);
-            }
-        }
-    }
-}
-
-// Guarantee a visible keyboard focus indicator.
-.webinar-sort button:focus-visible {
-    outline: 0.2rem solid ui-color(focus-outline);
-    outline-offset: 0.2rem;
 }

--- a/src/app/pages/webinars/search-controls/search-controls.tsx
+++ b/src/app/pages/webinars/search-controls/search-controls.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import useWebinarSearchParams from '../use-webinar-search-params';
+import './search-controls.scss';
+
+const SORT_OPTIONS = [
+    {key: 'relevance', label: 'Relevance', value: undefined},
+    {key: 'newest', label: 'Newest', value: 'newest'}
+] as const;
+
+function SortToggle() {
+    const {sort, setParam} = useWebinarSearchParams();
+    const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+        const delta = ({ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1} as
+            Record<string, number>)[e.key];
+
+        if (!delta) {
+            return;
+        }
+        e.preventDefault();
+        const current = SORT_OPTIONS.findIndex((o) => o.key === sort);
+        const nextIndex = (current + delta + SORT_OPTIONS.length) % SORT_OPTIONS.length;
+        const next = SORT_OPTIONS[nextIndex];
+
+        setParam('sort', next.value);
+
+        const group = e.currentTarget.parentElement;
+        const buttons = Array.from(
+            group?.querySelectorAll<HTMLButtonElement>('button[role="radio"]') ?? []
+        );
+
+        buttons[nextIndex]?.focus();
+    };
+
+    return (
+        <div className="webinar-sort-wrap">
+            <span className="webinar-sort-label" id="webinar-sort-label">Sort by</span>
+            <div className="webinar-sort custom" role="radiogroup" aria-labelledby="webinar-sort-label">
+                {SORT_OPTIONS.map((o) => (
+                    <button
+                        key={o.key}
+                        type="button"
+                        role="radio"
+                        aria-checked={sort === o.key}
+                        tabIndex={sort === o.key ? 0 : -1}
+                        onClick={() => setParam('sort', o.value)}
+                        onKeyDown={onKeyDown}
+                    >{o.label}</button>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default function SearchControls() {
+    return (
+        <div className="webinar-search-controls">
+            <SortToggle />
+        </div>
+    );
+}

--- a/src/app/pages/webinars/search-controls/search-controls.tsx
+++ b/src/app/pages/webinars/search-controls/search-controls.tsx
@@ -1,60 +1,18 @@
 import React from 'react';
 import useWebinarSearchParams from '../use-webinar-search-params';
+import SortToggle from '~/components/sort-toggle/sort-toggle';
 import './search-controls.scss';
 
-const SORT_OPTIONS = [
-    {key: 'relevance', label: 'Relevance', value: undefined},
-    {key: 'newest', label: 'Newest', value: 'newest'}
-] as const;
-
-function SortToggle() {
-    const {sort, setParam} = useWebinarSearchParams();
-    const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-        const delta = ({ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1} as
-            Record<string, number>)[e.key];
-
-        if (!delta) {
-            return;
-        }
-        e.preventDefault();
-        const current = SORT_OPTIONS.findIndex((o) => o.key === sort);
-        const nextIndex = (current + delta + SORT_OPTIONS.length) % SORT_OPTIONS.length;
-        const next = SORT_OPTIONS[nextIndex];
-
-        setParam('sort', next.value);
-
-        const group = e.currentTarget.parentElement;
-        const buttons = Array.from(
-            group?.querySelectorAll<HTMLButtonElement>('button[role="radio"]') ?? []
-        );
-
-        buttons[nextIndex]?.focus();
-    };
-
-    return (
-        <div className="webinar-sort-wrap">
-            <span className="webinar-sort-label" id="webinar-sort-label">Sort by</span>
-            <div className="webinar-sort custom" role="radiogroup" aria-labelledby="webinar-sort-label">
-                {SORT_OPTIONS.map((o) => (
-                    <button
-                        key={o.key}
-                        type="button"
-                        role="radio"
-                        aria-checked={sort === o.key}
-                        tabIndex={sort === o.key ? 0 : -1}
-                        onClick={() => setParam('sort', o.value)}
-                        onKeyDown={onKeyDown}
-                    >{o.label}</button>
-                ))}
-            </div>
-        </div>
-    );
-}
-
 export default function SearchControls() {
+    const {sort, setParam} = useWebinarSearchParams();
+
     return (
         <div className="webinar-search-controls">
-            <SortToggle />
+            <SortToggle
+                sort={sort}
+                setSort={(value?: string) => setParam('sort', value)}
+                labelId="webinar-sort-label"
+            />
         </div>
     );
 }

--- a/src/app/pages/webinars/search-page/search-page.tsx
+++ b/src/app/pages/webinars/search-page/search-page.tsx
@@ -11,6 +11,8 @@ import SimplePaginator, {
 } from '~/components/paginator/simple-paginator';
 import WebinarGrid from '../webinar-cards/webinar-grid';
 import NoResults from './no-results';
+import SearchControls from '../search-controls/search-controls';
+import useWebinarSearchParams from '../use-webinar-search-params';
 
 const perPage = 9;
 
@@ -21,6 +23,7 @@ export default function SearchPage() {
         <div className='search-page boxed left'>
             <Breadcrumb name='Webinars page' />
             <SearchBar searchFor={searchFor} amongWhat='webinars' />
+            <SearchControls />
             <SearchResults />
         </div>
     );
@@ -60,10 +63,17 @@ function SearchResults() {
 
 function useSearchResults() {
     const term = useCurrentSearchParameter();
+    const {sort} = useWebinarSearchParams();
+    const params = new URLSearchParams();
+
+    params.set('q', term);
+    if (sort === 'newest') {
+        params.set('sort', 'newest');
+    }
 
     return useFetchedData<Webinar[] | undefined>(
         {
-            slug: `webinars/search?q=${encodeURIComponent(term)}`,
+            slug: `webinars/search?${params.toString()}`,
             resolveTo: 'json',
             camelCase: true,
             postProcess(wRaw) {

--- a/src/app/pages/webinars/use-webinar-search-params.ts
+++ b/src/app/pages/webinars/use-webinar-search-params.ts
@@ -1,0 +1,35 @@
+import {useCallback, useMemo} from 'react';
+import {useSearchParams} from 'react-router-dom';
+
+export type WebinarSearchState = {
+    q?: string;
+    sort: 'relevance' | 'newest';
+};
+
+type ParamValue = string | undefined;
+
+export default function useWebinarSearchParams() {
+    const [params, setParams] = useSearchParams();
+    const state = useMemo<WebinarSearchState>(() => {
+        return {
+            q: params.get('q') || undefined,
+            sort: params.get('sort') === 'newest' ? 'newest' : 'relevance'
+        };
+    }, [params]);
+
+    const setParam = useCallback(
+        (key: keyof WebinarSearchState, value: ParamValue) => {
+            const next = new window.URLSearchParams(params);
+
+            if (!value) {
+                next.delete(key);
+            } else {
+                next.set(key, value);
+            }
+            setParams(next);
+        },
+        [params, setParams]
+    );
+
+    return {...state, setParam};
+}

--- a/src/app/pages/webinars/use-webinar-search-params.ts
+++ b/src/app/pages/webinars/use-webinar-search-params.ts
@@ -1,9 +1,10 @@
 import {useCallback, useMemo} from 'react';
 import {useSearchParams} from 'react-router-dom';
+import type {SortValue} from '~/components/sort-toggle/sort-toggle';
 
 export type WebinarSearchState = {
     q?: string;
-    sort: 'relevance' | 'newest';
+    sort: SortValue;
 };
 
 type ParamValue = string | undefined;

--- a/test/src/components/sort-toggle.test.tsx
+++ b/test/src/components/sort-toggle.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import {render, screen} from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import SortToggle from '~/components/sort-toggle/sort-toggle';
+import '@testing-library/jest-dom';
+
+describe('components/sort-toggle', () => {
+    const user = userEvent.setup();
+
+    it('renders with relevance selected by default', () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="relevance"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        expect(relevanceButton).toHaveAttribute('aria-checked', 'true');
+        expect(newestButton).toHaveAttribute('aria-checked', 'false');
+        expect(relevanceButton).toHaveAttribute('tabIndex', '0');
+        expect(newestButton).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('renders with newest selected', () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="newest"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        expect(relevanceButton).toHaveAttribute('aria-checked', 'false');
+        expect(newestButton).toHaveAttribute('aria-checked', 'true');
+        expect(relevanceButton).toHaveAttribute('tabIndex', '-1');
+        expect(newestButton).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('calls setSort with undefined when clicking relevance', async () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="newest"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+
+        await user.click(relevanceButton);
+        expect(setSort).toHaveBeenCalledWith(undefined);
+    });
+
+    it('calls setSort with "newest" when clicking newest', async () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="relevance"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        await user.click(newestButton);
+        expect(setSort).toHaveBeenCalledWith('newest');
+    });
+
+    it('navigates forward with ArrowRight key', async () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="relevance"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        relevanceButton.focus();
+        await user.keyboard('{ArrowRight}');
+
+        expect(setSort).toHaveBeenCalledWith('newest');
+        expect(newestButton).toHaveFocus();
+    });
+
+    it('navigates forward with ArrowDown key', async () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="relevance"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        relevanceButton.focus();
+        await user.keyboard('{ArrowDown}');
+
+        expect(setSort).toHaveBeenCalledWith('newest');
+        expect(newestButton).toHaveFocus();
+    });
+
+    it('navigates backward with ArrowLeft key', async () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="newest"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        newestButton.focus();
+        await user.keyboard('{ArrowLeft}');
+
+        expect(setSort).toHaveBeenCalledWith(undefined);
+        expect(relevanceButton).toHaveFocus();
+    });
+
+    it('navigates backward with ArrowUp key', async () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="newest"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        newestButton.focus();
+        await user.keyboard('{ArrowUp}');
+
+        expect(setSort).toHaveBeenCalledWith(undefined);
+        expect(relevanceButton).toHaveFocus();
+    });
+
+    it('wraps navigation from end to beginning', async () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="newest"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        newestButton.focus();
+        await user.keyboard('{ArrowRight}');
+
+        expect(setSort).toHaveBeenCalledWith(undefined);
+        expect(relevanceButton).toHaveFocus();
+    });
+
+    it('wraps navigation from beginning to end', async () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="relevance"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const relevanceButton = screen.getByRole('radio', {name: 'Relevance'});
+        const newestButton = screen.getByRole('radio', {name: 'Newest'});
+
+        relevanceButton.focus();
+        await user.keyboard('{ArrowLeft}');
+
+        expect(setSort).toHaveBeenCalledWith('newest');
+        expect(newestButton).toHaveFocus();
+    });
+
+    it('applies custom className when provided', () => {
+        const setSort = jest.fn();
+
+        const {container} = render(
+            <SortToggle
+                sort="relevance"
+                setSort={setSort}
+                labelId="test-sort-label"
+                className="custom-class"
+            />
+        );
+
+        const wrapper = container.querySelector('.sort-toggle-wrap');
+
+        expect(wrapper).toHaveClass('sort-toggle-wrap');
+        expect(wrapper).toHaveClass('custom-class');
+    });
+
+    it('has proper ARIA labeling', () => {
+        const setSort = jest.fn();
+
+        render(
+            <SortToggle
+                sort="relevance"
+                setSort={setSort}
+                labelId="test-sort-label"
+            />
+        );
+
+        const radiogroup = screen.getByRole('radiogroup');
+        const label = screen.getByText('Sort by');
+
+        expect(label).toHaveAttribute('id', 'test-sort-label');
+        expect(radiogroup).toHaveAttribute('aria-labelledby', 'test-sort-label');
+    });
+});

--- a/test/src/pages/webinars/search-controls.test.tsx
+++ b/test/src/pages/webinars/search-controls.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
-import {MemoryRouter} from 'react-router-dom';
+import MemoryRouter from '../../../helpers/future-memory-router';
 import SearchControls from '~/pages/webinars/search-controls/search-controls';
 
 it('sort is a radiogroup that updates aria-checked from relevance to newest', async () => {
@@ -45,7 +45,7 @@ it('clicking Newest then Relevance clears sort param (round-trip)', async () => 
 });
 
 it('setSort callback properly updates URL params when toggling sort', async () => {
-    const {container} = render(
+    render(
         <MemoryRouter initialEntries={['/webinars/search?q=test']}>
             <SearchControls />
         </MemoryRouter>

--- a/test/src/pages/webinars/search-controls.test.tsx
+++ b/test/src/pages/webinars/search-controls.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import {MemoryRouter} from 'react-router-dom';
+import SearchControls from '~/pages/webinars/search-controls/search-controls';
+
+it('sort is a radiogroup that updates aria-checked from relevance to newest', async () => {
+    render(
+        <MemoryRouter initialEntries={['/webinars/search?q=test']}>
+            <SearchControls />
+        </MemoryRouter>
+    );
+    expect(screen.getByRole('radiogroup', {name: 'Sort by'})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Relevance'})).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', {name: 'Newest'})).toHaveAttribute('aria-checked', 'false');
+    await userEvent.click(screen.getByRole('radio', {name: 'Newest'}));
+    expect(screen.getByRole('radio', {name: 'Newest'})).toHaveAttribute('aria-checked', 'true');
+});
+
+it('arrow keys move selection within the sort radiogroup', async () => {
+    render(
+        <MemoryRouter initialEntries={['/webinars/search?q=test']}>
+            <SearchControls />
+        </MemoryRouter>
+    );
+    screen.getByRole('radio', {name: 'Relevance'}).focus();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(screen.getByRole('radio', {name: 'Newest'})).toHaveAttribute('aria-checked', 'true');
+    await userEvent.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('radio', {name: 'Relevance'})).toHaveAttribute('aria-checked', 'true');
+});
+
+it('clicking Newest then Relevance clears sort param (round-trip)', async () => {
+    render(
+        <MemoryRouter initialEntries={['/webinars/search?q=test']}>
+            <SearchControls />
+        </MemoryRouter>
+    );
+    await userEvent.click(screen.getByRole('radio', {name: 'Newest'}));
+    expect(screen.getByRole('radio', {name: 'Newest'})).toHaveAttribute('aria-checked', 'true');
+    await userEvent.click(screen.getByRole('radio', {name: 'Relevance'}));
+    expect(screen.getByRole('radio', {name: 'Relevance'})).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', {name: 'Newest'})).toHaveAttribute('aria-checked', 'false');
+});
+
+it('setSort callback properly updates URL params when toggling sort', async () => {
+    const {container} = render(
+        <MemoryRouter initialEntries={['/webinars/search?q=test']}>
+            <SearchControls />
+        </MemoryRouter>
+    );
+
+    // Click Newest - should add sort=newest to URL
+    await userEvent.click(screen.getByRole('radio', {name: 'Newest'}));
+    expect(screen.getByRole('radio', {name: 'Newest'})).toHaveAttribute('aria-checked', 'true');
+
+    // Click back to Relevance - should remove sort param from URL
+    await userEvent.click(screen.getByRole('radio', {name: 'Relevance'}));
+    expect(screen.getByRole('radio', {name: 'Relevance'})).toHaveAttribute('aria-checked', 'true');
+});
+
+it('setSort handles undefined value when reverting to relevance', async () => {
+    render(
+        <MemoryRouter initialEntries={['/webinars/search?q=test&sort=newest']}>
+            <SearchControls />
+        </MemoryRouter>
+    );
+
+    // Initial state should be "newest" based on URL
+    expect(screen.getByRole('radio', {name: 'Newest'})).toHaveAttribute('aria-checked', 'true');
+
+    // Click Relevance - should call setSort with undefined
+    await userEvent.click(screen.getByRole('radio', {name: 'Relevance'}));
+    expect(screen.getByRole('radio', {name: 'Relevance'})).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', {name: 'Newest'})).toHaveAttribute('aria-checked', 'false');
+});
+
+it('renders sort controls with correct ARIA label', () => {
+    render(
+        <MemoryRouter initialEntries={['/webinars/search?q=test']}>
+            <SearchControls />
+        </MemoryRouter>
+    );
+
+    const radiogroup = screen.getByRole('radiogroup', {name: 'Sort by'});
+    expect(radiogroup).toBeInTheDocument();
+    expect(radiogroup).toHaveAttribute('aria-labelledby', 'webinar-sort-label');
+});

--- a/test/src/pages/webinars/search-page.test.tsx
+++ b/test/src/pages/webinars/search-page.test.tsx
@@ -29,6 +29,10 @@ jest.mock('~/helpers/use-data', () => jest.fn());
 const mockUseFetchedData = jest.spyOn(UFD, 'default');
 
 describe('webinar search page', () => {
+    beforeEach(() => {
+        mockUseFetchedData.mockClear();
+    });
+
     it('short circuits while waiting for webinars to return', () => {
         mockUseFetchedData.mockReturnValue(undefined);
         render(<Component term='waiting' />);
@@ -62,7 +66,8 @@ describe('webinar search page', () => {
         expect(mockUseFetchedData).toHaveBeenCalledWith(
             expect.objectContaining({
                 slug: 'webinars/search?q=test'
-            })
+            }),
+            undefined
         );
     });
     it('requests webinars with sort=newest param when specified in URL', () => {
@@ -76,7 +81,8 @@ describe('webinar search page', () => {
         expect(mockUseFetchedData).toHaveBeenCalledWith(
             expect.objectContaining({
                 slug: 'webinars/search?q=test&sort=newest'
-            })
+            }),
+            undefined
         );
     });
 });

--- a/test/src/pages/webinars/search-page.test.tsx
+++ b/test/src/pages/webinars/search-page.test.tsx
@@ -51,4 +51,32 @@ describe('webinar search page', () => {
 
         expect(screen.queryByText('No matching webinars found')).toBeNull();
     });
+    it('requests webinars without sort param when sort=relevance (default)', () => {
+        mockUseFetchedData.mockReturnValue([]);
+        render(
+            <MemoryRouter initialEntries={['/webinars/search?q=test']}>
+                <SearchPage />
+            </MemoryRouter>
+        );
+
+        expect(mockUseFetchedData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                slug: 'webinars/search?q=test'
+            })
+        );
+    });
+    it('requests webinars with sort=newest param when specified in URL', () => {
+        mockUseFetchedData.mockReturnValue([]);
+        render(
+            <MemoryRouter initialEntries={['/webinars/search?q=test&sort=newest']}>
+                <SearchPage />
+            </MemoryRouter>
+        );
+
+        expect(mockUseFetchedData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                slug: 'webinars/search?q=test&sort=newest'
+            })
+        );
+    });
 });

--- a/test/src/pages/webinars/use-webinar-search-params.test.tsx
+++ b/test/src/pages/webinars/use-webinar-search-params.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {ComponentType} from 'preact';
 import {renderHook, act} from '@testing-library/preact';
-import {MemoryRouter} from 'react-router-dom';
+import MemoryRouter from '../../../helpers/future-memory-router';
 import useWebinarSearchParams from '~/pages/webinars/use-webinar-search-params';
 
 type RenderHookWrapper = ComponentType<{children: Element}>;

--- a/test/src/pages/webinars/use-webinar-search-params.test.tsx
+++ b/test/src/pages/webinars/use-webinar-search-params.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {ComponentType} from 'preact';
+import {renderHook, act} from '@testing-library/preact';
+import {MemoryRouter} from 'react-router-dom';
+import useWebinarSearchParams from '~/pages/webinars/use-webinar-search-params';
+
+type RenderHookWrapper = ComponentType<{children: Element}>;
+
+function wrapperFor(initialUrl: string) {
+    function Wrapper({children}: {children: React.ReactNode}) {
+        return <MemoryRouter initialEntries={[initialUrl]}>{children}</MemoryRouter>;
+    }
+
+    return Wrapper;
+}
+
+describe('useWebinarSearchParams', () => {
+    it('parses q and sort from the URL', () => {
+        const wrapper = wrapperFor('/webinars/search?q=physics&sort=newest') as unknown as RenderHookWrapper;
+        const {result} = renderHook(() => useWebinarSearchParams(), {
+            wrapper
+        });
+
+        expect(result.current.q).toBe('physics');
+        expect(result.current.sort).toBe('newest');
+    });
+
+    it('defaults to relevance when sort param is missing', () => {
+        const wrapper = wrapperFor('/webinars/search?q=biology') as unknown as RenderHookWrapper;
+        const {result} = renderHook(() => useWebinarSearchParams(), {
+            wrapper
+        });
+
+        expect(result.current.q).toBe('biology');
+        expect(result.current.sort).toBe('relevance');
+    });
+
+    it('defaults to relevance when sort param is invalid', () => {
+        const wrapper = wrapperFor('/webinars/search?q=math&sort=invalid') as unknown as RenderHookWrapper;
+        const {result} = renderHook(() => useWebinarSearchParams(), {
+            wrapper
+        });
+
+        expect(result.current.q).toBe('math');
+        expect(result.current.sort).toBe('relevance');
+    });
+
+    it('returns undefined for q when not present', () => {
+        const wrapper = wrapperFor('/webinars/search') as unknown as RenderHookWrapper;
+        const {result} = renderHook(() => useWebinarSearchParams(), {
+            wrapper
+        });
+
+        expect(result.current.q).toBeUndefined();
+        expect(result.current.sort).toBe('relevance');
+    });
+
+    it('setParam updates sort to newest', () => {
+        const wrapper = wrapperFor('/webinars/search?q=chemistry') as unknown as RenderHookWrapper;
+        const {result} = renderHook(() => useWebinarSearchParams(), {
+            wrapper
+        });
+
+        act(() => result.current.setParam('sort', 'newest'));
+        expect(result.current.q).toBe('chemistry');
+        expect(result.current.sort).toBe('newest');
+    });
+
+    it('setParam removes sort when set to undefined (relevance)', () => {
+        const wrapper = wrapperFor('/webinars/search?q=algebra&sort=newest') as unknown as RenderHookWrapper;
+        const {result} = renderHook(() => useWebinarSearchParams(), {
+            wrapper
+        });
+
+        expect(result.current.sort).toBe('newest');
+
+        act(() => result.current.setParam('sort', undefined));
+        expect(result.current.sort).toBe('relevance');
+        expect(result.current.q).toBe('algebra');
+    });
+
+    it('setParam updates q and preserves sort', () => {
+        const wrapper = wrapperFor('/webinars/search?sort=newest') as unknown as RenderHookWrapper;
+        const {result} = renderHook(() => useWebinarSearchParams(), {
+            wrapper
+        });
+
+        act(() => result.current.setParam('q', 'biology'));
+        expect(result.current.q).toBe('biology');
+        expect(result.current.sort).toBe('newest');
+    });
+
+    it('setParam removes q when set to undefined', () => {
+        const wrapper = wrapperFor('/webinars/search?q=test&sort=newest') as unknown as RenderHookWrapper;
+        const {result} = renderHook(() => useWebinarSearchParams(), {
+            wrapper
+        });
+
+        expect(result.current.q).toBe('test');
+
+        act(() => result.current.setParam('q', undefined));
+        expect(result.current.q).toBeUndefined();
+        expect(result.current.sort).toBe('newest');
+    });
+});


### PR DESCRIPTION
## Summary

This PR adds sorting functionality to the webinars search page to match the blog search behavior. Users can now toggle between sorting by relevance (default) and newest.

Relates to: https://openstax.atlassian.net/browse/CORE-2376

## Changes

### Frontend (os-webview)
- **Created** `use-webinar-search-params.ts` - Hook to manage webinar search URL parameters (mirrors blog's pattern)
- **Made reusable** `search-controls/search-controls.tsx` - Component with sort toggle UI using segmented control design that was attached to the blog (in facet-controls), extracted to separate component to also used for webinar search results
- **Created** `search-controls/search-controls.scss` - Styles matching the blog's facet controls
- **Modified** `search-page/search-page.tsx` - Integrated sort controls and updated API call to include sort parameter

## Implementation Details

- The sort parameter defaults to "relevance" when not specified
- When "newest" is selected, the `sort=newest` parameter is added to the API request
- The UI follows the same segmented control pattern used in blog search
- Keyboard navigation (arrow keys) is supported following ARIA best practices
- The implementation is ready for backend support

## Test Plan

- [ ] Verify sort toggle appears on webinars search page
- [ ] Verify default sort is "relevance" (no sort param in URL)
- [ ] Verify clicking "Newest" adds `sort=newest` to URL and API request
- [ ] Verify clicking "Relevance" removes sort param from URL
- [ ] Test keyboard navigation with arrow keys
- [ ] Verify accessible focus indicators
- [ ] Once backend is deployed, verify results are sorted correctly

## Notes

- Backend work (openstax-cms) is handled separately and not in scope for this PR
- The frontend is ready to work with the backend once the `/apps/cms/api/webinars/search/` endpoint accepts the `sort` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)