### PR TITLE
Preview: flex-page-renderer 1.1.17-rc.2 (CORE-2301 cards block)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.3.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@openstax/experiments": "^1.0.2",
-        "@openstax/flex-page-renderer": "https://github.com/openstax/flex-pages.git#renderer-1.1.16",
+        "@openstax/flex-page-renderer": "https://github.com/openstax/flex-pages.git#renderer-1.1.17-rc.2",
         "@sentry/integrations": "^7.114.0",
         "@sentry/react": "^9.16.1",
         "@types/react-modal": "^3.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2894,9 +2894,9 @@
     "@openstax/ts-utils" "^1.2.3"
     js-cookie "^3.0.5"
 
-"@openstax/flex-page-renderer@https://github.com/openstax/flex-pages.git#renderer-1.1.16":
-  version "1.1.16"
-  resolved "https://github.com/openstax/flex-pages.git#8dff79f90653d7ffa81cd4e9cd0712f188c1bbcd"
+"@openstax/flex-page-renderer@https://github.com/openstax/flex-pages.git#renderer-1.1.17-rc.2":
+  version "1.1.17-rc.2"
+  resolved "https://github.com/openstax/flex-pages.git#0c1ecb940b45b6b552046c122d8412b87d4e1181"
   dependencies:
     classnames "^2.5.1"
     color "^5.0.0"


### PR DESCRIPTION
## What

Bumps `@openstax/flex-page-renderer` from `renderer-1.1.16` to the preview tag **`renderer-1.1.17-rc.2`**.

This rc tag is a preview build of [flex-pages PR #5](https://github.com/openstax/flex-pages/pull/5) (CORE-2301 — cards block spacing, grid, and border/accent configs), built off `d677e8f` with the new `CardsBlock` compiled into `dist/`.

## Why

Lets us test the CORE-2301 cards block changes live in os-webview before the renderer change is merged and a real renderer version is cut.

## Notes

- ⚠️ **Not for merge as-is.** `renderer-1.1.17-rc.2` is a throwaway preview tag and will be deleted after testing. Once the renderer change lands, this should be re-pointed to the real released version (or this PR closed).
- Diff is limited to `package.json` + `yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)