### PR TITLE
Core-2377: restyle webinar tile CTAs and make tiles clickable

### DIFF
--- a/src/app/pages/webinars/webinar-cards/webinar-grid.scss
+++ b/src/app/pages/webinars/webinar-cards/webinar-grid.scss
@@ -31,6 +31,21 @@
         &.past {
             gap: $normal-margin;
             grid-template-rows: auto auto 1fr auto;
+            color: inherit;
+            text-decoration: none;
+        }
+
+        .register-button {
+            @include button();
+            @extend %primary;
+
+            &.register-button {
+                background-color: os-color(deep-green);
+                &:hover,
+                &:focus {
+                    background-color: darken(os-color(deep-green), 2%);
+                }
+            }
         }
 
         &.upcoming {

--- a/src/app/pages/webinars/webinar-cards/webinar-grid.scss
+++ b/src/app/pages/webinars/webinar-cards/webinar-grid.scss
@@ -39,7 +39,10 @@
             @include button();
             @extend %primary;
 
-            background-color: os-color(deep-green);
+            // Override color from %primary
+            &.register-button {
+                background-color: os-color(deep-green);
+            }
 
             &:hover,
             &:focus {
@@ -47,8 +50,11 @@
             }
         }
 
-        &.past:focus-visible .register-button {
-            background-color: darken(os-color(deep-green), 2%);
+        &.past:focus-visible,
+        &.past:hover {
+            .register-button {
+                background-color: darken(os-color(deep-green), 2%);
+            }
         }
 
         &.upcoming {

--- a/src/app/pages/webinars/webinar-cards/webinar-grid.scss
+++ b/src/app/pages/webinars/webinar-cards/webinar-grid.scss
@@ -39,13 +39,16 @@
             @include button();
             @extend %primary;
 
-            &.register-button {
-                background-color: os-color(deep-green);
-                &:hover,
-                &:focus {
-                    background-color: darken(os-color(deep-green), 2%);
-                }
+            background-color: os-color(deep-green);
+
+            &:hover,
+            &:focus {
+                background-color: darken(os-color(deep-green), 2%);
             }
+        }
+
+        &.past:focus-visible .register-button {
+            background-color: darken(os-color(deep-green), 2%);
         }
 
         &.upcoming {

--- a/src/app/pages/webinars/webinar-cards/webinar-grid.tsx
+++ b/src/app/pages/webinars/webinar-cards/webinar-grid.tsx
@@ -30,14 +30,14 @@ function PastWebinar({data}: {data: Webinar}) {
     const linkText = !isZoom ? 'Watch now!' : data.registrationLinkText;
 
     return (
-        <div className="card past">
+        <a href={data.registrationUrl} className="card past">
             <h3>{data.title}</h3>
             <Byline author={data.speakers} date={data.start.toDateString()} />
             <div>{data.description}</div>
-            <LinkWithChevron href={data.registrationUrl}>
+            <div className="register-button">
                 {linkText}
-            </LinkWithChevron>
-        </div>
+            </div>
+        </a>
     );
 }
 
@@ -77,9 +77,9 @@ function UpcomingWebinar({data}: {data: Webinar}) {
                     {data.speakers}
                 </div>
             </div>
-            <LinkWithChevron href={data.registrationUrl}>
+            <a className="register-button" href={data.registrationUrl}>
                 {data.registrationLinkText}
-            </LinkWithChevron>
+            </a>
             <AddToCalendarButton
                 name={data.title}
                 options={['Apple', 'Google']}

--- a/src/app/pages/webinars/webinar-cards/webinar-grid.tsx
+++ b/src/app/pages/webinars/webinar-cards/webinar-grid.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {Webinar} from '../types';
-import LinkWithChevron from '~/components/link-with-chevron/link-with-chevron';
 import Byline from '~/components/byline/byline';
 import {AddToCalendarButton} from 'add-to-calendar-button-react';
 import './webinar-grid.scss';

--- a/test/src/pages/webinars/webinar-grid-section.test.tsx
+++ b/test/src/pages/webinars/webinar-grid-section.test.tsx
@@ -25,11 +25,12 @@ describe('webinar grid', () => {
             ...pastWebinar,
             registrationLinkText: 'Sign up here!'
         };
+
         render(
             <WebinarGridSection webinars={[on24Webinar]} heading={heading} />
         );
         expect(
-            screen.queryAllByRole('link', {name: 'Watch now!'})
+            screen.queryAllByText('Watch now!')
         ).toHaveLength(1);
     });
     it('does not update CTA to Watch now! for past Zoom webinars', () => {
@@ -38,11 +39,12 @@ describe('webinar grid', () => {
             registrationUrl: 'https://rice.zoom.us/webinar/register/123',
             registrationLinkText: 'Join the meeting'
         };
+
         render(
             <WebinarGridSection webinars={[zoomWebinar]} heading={heading} />
         );
         expect(
-            screen.queryAllByRole('link', {name: 'Join the meeting'})
+            screen.queryAllByText('Join the meeting')
         ).toHaveLength(1);
     });
 });


### PR DESCRIPTION
[CORE-2377]
Restyle CTAs to be more prominent
Make past webinar tiles links to watch the webinar.

[CORE-2377]: https://openstax.atlassian.net/browse/CORE-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ