### PR TITLE
Add streamlined_nav CMS flag for header nav

### DIFF
--- a/src/app/contexts/shared-data.ts
+++ b/src/app/contexts/shared-data.ts
@@ -9,7 +9,8 @@ type FlagName =
     | 'chat_book_details'
     | 'chat_subjects'
     | 'chat_contact'
-    | 'chat_logged_in_only';
+    | 'chat_logged_in_only'
+    | 'streamlined_nav';
 
 type Flag = {
     name: FlagName;
@@ -38,4 +39,14 @@ function useContextValue() {
 
 const {useContext, ContextProvider} = buildContext({useContextValue});
 
-export {useContext as default, ContextProvider as SharedDataContextProvider};
+function useStreamlinedNav() {
+    const {flags} = useContext();
+
+    return Boolean(flags && flags.streamlined_nav);
+}
+
+export {
+    useContext as default,
+    ContextProvider as SharedDataContextProvider,
+    useStreamlinedNav
+};

--- a/src/app/contexts/shared-data.ts
+++ b/src/app/contexts/shared-data.ts
@@ -42,7 +42,7 @@ const {useContext, ContextProvider} = buildContext({useContextValue});
 function useStreamlinedNav() {
     const {flags} = useContext();
 
-    return Boolean(flags && flags.streamlined_nav);
+    return Boolean(flags?.streamlined_nav);
 }
 
 export {

--- a/src/app/contexts/shared-data.ts
+++ b/src/app/contexts/shared-data.ts
@@ -42,7 +42,7 @@ const {useContext, ContextProvider} = buildContext({useContextValue});
 function useStreamlinedNav() {
     const {flags} = useContext();
 
-    return Boolean(flags?.streamlined_nav);
+    return Boolean(flags && flags.streamlined_nav);
 }
 
 export {

--- a/src/app/layouts/default/default.tsx
+++ b/src/app/layouts/default/default.tsx
@@ -8,17 +8,28 @@ import useMainClassContext, {
     MainClassContextProvider
 } from '~/contexts/main-class';
 import useLanguageContext from '~/contexts/language';
+import {useStreamlinedNav} from '~/contexts/shared-data';
 import ReactModal from 'react-modal';
 import TakeoverDialog from './takeover-dialog/takeover-dialog';
 import cn from 'classnames';
 import './default.scss';
 
 export default function DefaultLayout({children}: React.PropsWithChildren<object>) {
+    const streamlined = useStreamlinedNav();
+    const headerRef = React.useRef<HTMLElement>(null);
+
+    // Toggle imperatively rather than via `className` so we don't take over the
+    // element's class list from `over-mobile-dialog`, which the takeover dialog
+    // adds/removes on #header directly (see takeover-dialog/content-mobile).
+    React.useEffect(() => {
+        headerRef.current?.classList.toggle('streamlined', streamlined);
+    }, [streamlined]);
+
     // BrowserRouter has to include everything that uses useLocation
     return (
         <React.Fragment>
             <Microsurvey />
-            <header id="header">
+            <header id="header" ref={headerRef}>
                 <Header />
             </header>
             <div id="lower-sticky-note">

--- a/src/app/layouts/default/header/menus/give-button/give-button.scss
+++ b/src/app/layouts/default/header/menus/give-button/give-button.scss
@@ -16,3 +16,9 @@
         color: text-color(normal);
     }
 }
+
+// Streamlined nav shows the gold button as a standard contained button,
+// so restore the pattern-library radius our base rule zeroes out.
+.give-button-item.streamlined .give-button {
+    border-radius: 0.5rem;
+}

--- a/src/app/layouts/default/header/menus/give-item/give-item.tsx
+++ b/src/app/layouts/default/header/menus/give-item/give-item.tsx
@@ -11,7 +11,13 @@ export default function GiveItem() {
     return showButton ? (
         <GiveButton />
     ) : (
-        <a target="_blank" rel="noopener noreferrer" href={GIVE_HEADER_URL} data-analytics-link>
+        <a
+            className="give-button medium"
+            target="_blank"
+            rel="noopener noreferrer"
+            href={GIVE_HEADER_URL}
+            data-analytics-link
+        >
             Give
         </a>
     );

--- a/src/app/layouts/default/header/menus/give-item/give-item.tsx
+++ b/src/app/layouts/default/header/menus/give-item/give-item.tsx
@@ -11,7 +11,7 @@ export default function GiveItem() {
     return showButton ? (
         <GiveButton />
     ) : (
-        <a target="_blank" rel="noreferrer" href={GIVE_HEADER_URL} data-analytics-link>
+        <a target="_blank" rel="noopener noreferrer" href={GIVE_HEADER_URL} data-analytics-link>
             Give
         </a>
     );

--- a/src/app/layouts/default/header/menus/give-item/give-item.tsx
+++ b/src/app/layouts/default/header/menus/give-item/give-item.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import useGiveToday from '~/models/give-today';
+import GiveButton from '../give-button/give-button';
+
+const GIVE_HEADER_URL =
+    'https://riceconnect.rice.edu/donation/support-openstax-header';
+
+export default function GiveItem() {
+    const {showButton} = useGiveToday();
+
+    return showButton ? (
+        <GiveButton />
+    ) : (
+        <a target="_blank" rel="noreferrer" href={GIVE_HEADER_URL} data-analytics-link>
+            Give
+        </a>
+    );
+}

--- a/src/app/layouts/default/header/menus/logo/logo.scss
+++ b/src/app/layouts/default/header/menus/logo/logo.scss
@@ -67,6 +67,38 @@
         }
     }
 
+    &.streamlined {
+        @include wider-than($tablet-max) {
+            align-items: center;
+            grid-template-columns: repeat(3, min-content);
+            width: auto;
+        }
+    }
+
+    .logo-divider {
+        background-color: ui-color(form-border);
+        display: block;
+        height: 2.8rem;
+        width: 0.1rem;
+
+        @include width-up-to($tablet-max) {
+            display: none;
+        }
+    }
+
+    .rice-logo {
+        display: none;
+
+        @include wider-than($tablet-max) {
+            align-items: center;
+            display: inline-flex;
+
+            img {
+                height: 2.4rem;
+            }
+        }
+    }
+
     .logo-quote {
         color: os-color(gray);
         display: inline-block;

--- a/src/app/layouts/default/header/menus/logo/logo.scss
+++ b/src/app/layouts/default/header/menus/logo/logo.scss
@@ -68,6 +68,31 @@
     }
 
     &.streamlined {
+        .logo {
+            height: 2.4rem;
+        }
+
+        img {
+            vertical-align: middle;
+        }
+
+        @include width-up-to($tablet-max) {
+            column-gap: 1rem;
+
+            .logo-divider {
+                display: block;
+            }
+
+            .rice-logo {
+                align-items: center;
+                display: inline-flex;
+
+                img {
+                    height: 2.4rem;
+                }
+            }
+        }
+
         @include wider-than($tablet-max) {
             align-items: center;
             grid-template-columns: repeat(3, min-content);

--- a/src/app/layouts/default/header/menus/logo/logo.tsx
+++ b/src/app/layouts/default/header/menus/logo/logo.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import cn from 'classnames';
+import {useStreamlinedNav} from '~/contexts/shared-data';
+import useOptimizedImage from '~/helpers/use-optimized-image';
 import './logo.scss';
 
+const riceLogoSrc =
+    'https://assets.openstax.org/oscms-prodcms/media/images/rice-logo-blue.original.webp';
+
 export default function Logo() {
+    const streamlined = useStreamlinedNav();
+    const riceLogo = useOptimizedImage(riceLogoSrc, 80);
+
     return (
-        <span className="logo-wrapper">
+        <span className={cn('logo-wrapper', {streamlined})}>
             <span className="logo">
                 <a href="/" aria-label="Openstax" data-analytics-link>
                     <img
@@ -13,8 +22,18 @@ export default function Logo() {
                     <img className="logo-white" src="/dist/images/logo-white.svg" alt="OpenStax logo" />
                 </a>
             </span>
-
-            <span className="logo-quote">Access. The future of education.</span>
+            {streamlined ? (
+                <React.Fragment>
+                    <span className="logo-divider" aria-hidden="true" />
+                    <span className="rice-logo">
+                        <a href="https://www.rice.edu">
+                            <img src={riceLogo} alt="Rice University logo" height="30" width="79" />
+                        </a>
+                    </span>
+                </React.Fragment>
+            ) : (
+                <span className="logo-quote">Access. The future of education.</span>
+            )}
         </span>
     );
 }

--- a/src/app/layouts/default/header/menus/main-menu/main-menu.scss
+++ b/src/app/layouts/default/header/menus/main-menu/main-menu.scss
@@ -52,6 +52,12 @@
             @include width-up-to($tablet-max) {
                 display: none;
             }
+
+            &.streamlined {
+                @include width-up-to($tablet-max) {
+                    display: block;
+                }
+            }
         }
     }
 

--- a/src/app/layouts/default/header/menus/main-menu/main-menu.scss
+++ b/src/app/layouts/default/header/menus/main-menu/main-menu.scss
@@ -57,6 +57,10 @@
                 @include width-up-to($tablet-max) {
                     display: block;
                 }
+
+                @at-root .menus.mobile .give-button-item.streamlined {
+                    display: block;
+                }
             }
         }
     }

--- a/src/app/layouts/default/header/menus/main-menu/main-menu.tsx
+++ b/src/app/layouts/default/header/menus/main-menu/main-menu.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import cn from 'classnames';
 import useSubjectCategoryContext from '~/contexts/subject-category';
 import useLanguageContext from '~/contexts/language';
+import {useStreamlinedNav} from '~/contexts/shared-data';
 import {
     LanguageSelectorWrapper,
     LanguageLink
@@ -11,6 +13,7 @@ import {useDataFromSlug} from '~/helpers/page-data-utils';
 import Dropdown, {MenuItem} from './dropdown/dropdown';
 import LoginMenu from './login-menu/login-menu';
 import GiveButton from '../give-button/give-button';
+import GiveItem from '../give-item/give-item';
 import {treatSpaceOrEnterAsClick} from '~/helpers/events';
 import './main-menu.scss';
 
@@ -146,12 +149,14 @@ function navigateWithArrows(event: React.KeyboardEvent<HTMLUListElement>) {
 }
 
 export function MainMenuItems() {
+    const streamlined = useStreamlinedNav();
+
     return (
         <React.Fragment>
             <SubjectsMenu />
             <MenusFromCMS />
-            <li className="give-button-item">
-                <GiveButton />
+            <li className={cn('give-button-item', {streamlined})}>
+                {streamlined ? <GiveItem /> : <GiveButton />}
             </li>
             <LoginMenu />
         </React.Fragment>

--- a/src/app/layouts/default/header/menus/menus.scss
+++ b/src/app/layouts/default/header/menus/menus.scss
@@ -62,6 +62,7 @@
             .dropdown-menu {
                 box-shadow: none;
                 font-size: 1.4rem;
+                grid-row-gap: 0;
                 line-height: 4.4rem;
             }
         }

--- a/src/app/layouts/default/header/menus/menus.tsx
+++ b/src/app/layouts/default/header/menus/menus.tsx
@@ -5,12 +5,14 @@ import UpperMenu from './upper-menu/upper-menu';
 import Logo from './logo/logo';
 import MainMenu, {MainMenuItems} from './main-menu/main-menu';
 import {useToggle} from '~/helpers/data';
+import {useStreamlinedNav} from '~/contexts/shared-data';
 import cn from 'classnames';
 import trapTab from '~/helpers/trap-tab';
 import './menus.scss';
 import { treatSpaceOrEnterAsClick } from '~/helpers/events';
 
 export default function Menus() {
+    const streamlined = useStreamlinedNav();
     const ref = React.useRef<HTMLDivElement>(null);
     const [active, toggleActive] = useToggle();
     const clickOverlay = React.useCallback(
@@ -45,9 +47,11 @@ export default function Menus() {
         <React.Fragment>
             <DropdownContextProvider>
                 <div className='menus desktop'>
-                    <nav className='meta-nav' aria-label='Upper Menu'>
-                        <UpperMenu />
-                    </nav>
+                    {!streamlined && (
+                        <nav className='meta-nav' aria-label='Upper Menu'>
+                            <UpperMenu />
+                        </nav>
+                    )}
                     <nav className='nav' aria-label='Main'>
                         <div className='container'>
                             <Logo />
@@ -74,7 +78,7 @@ export default function Menus() {
                             <div className='menu-title'>Menu</div>
                             <ul className='no-bullets' onKeyDown={treatSpaceOrEnterAsClick}>
                                 <MainMenuItems />
-                                <UpperMenu />
+                                {!streamlined && <UpperMenu />}
                             </ul>
                         </div>
                     </div>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -186,6 +186,14 @@ sup {
         top: -5rem;
     }
 
+    // Streamlined nav drops the 5rem utility bar, so there is no bar to tuck
+    // out of view on scroll. Pin the main nav flush to the top instead.
+    &.streamlined {
+        @include wider-than($tablet-max) {
+            top: 0;
+        }
+    }
+
     @media print {
         display: none;
     }

--- a/test/src/contexts/streamlined-nav.test.tsx
+++ b/test/src/contexts/streamlined-nav.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {render, screen, waitFor} from '@testing-library/preact';
+
+/* eslint-disable camelcase */
+jest.mock('~/helpers/cms-fetch', () => ({
+    __esModule: true,
+    default: jest.fn(() =>
+        Promise.resolve({all_flags: [{name: 'streamlined_nav', feature_active: true}]})
+    )
+}));
+
+import {
+    SharedDataContextProvider,
+    useStreamlinedNav
+} from '~/contexts/shared-data';
+
+function Probe() {
+    return <span>{useStreamlinedNav() ? 'on' : 'off'}</span>;
+}
+
+describe('useStreamlinedNav', () => {
+    it('is true once the streamlined_nav flag resolves active', async () => {
+        render(
+            <SharedDataContextProvider>
+                <Probe />
+            </SharedDataContextProvider>
+        );
+
+        await waitFor(() => expect(screen.getByText('on')).toBeTruthy());
+    });
+});

--- a/test/src/layouts/default/default.test.tsx
+++ b/test/src/layouts/default/default.test.tsx
@@ -44,10 +44,16 @@ const mockUseSharedDataContext = jest
     .fn()
     .mockReturnValue({});
 
-jest.mock('~/contexts/shared-data', () => ({
-    __esModule: true,
-    default: () => mockUseSharedDataContext()
-}));
+jest.mock('~/contexts/shared-data', () => {
+    const actual = jest.requireActual('~/contexts/shared-data');
+
+    return {
+        __esModule: true,
+        ...actual,
+        default: jest.fn(() => mockUseSharedDataContext()),
+        useStreamlinedNav: jest.fn().mockReturnValue(false)
+    };
+});
 
 const user = userEvent.setup();
 const basicImplementation = (path: string) => {

--- a/test/src/layouts/default/give-item.test.tsx
+++ b/test/src/layouts/default/give-item.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {render, screen} from '@testing-library/preact';
+import useGiveToday from '~/models/give-today';
+import GiveItem from '~/layouts/default/header/menus/give-item/give-item';
+
+jest.mock('~/models/give-today', () => jest.fn());
+
+const RICECONNECT = 'https://riceconnect.rice.edu/donation/support-openstax-header';
+
+describe('GiveItem', () => {
+    it('renders a Give text link to RiceConnect when no campaign is active', () => {
+        (useGiveToday as jest.Mock).mockReturnValue({showButton: false});
+        render(<GiveItem />);
+
+        const link = screen.getByRole('link', {name: 'Give'});
+
+        expect(link.getAttribute('href')).toBe(RICECONNECT);
+        expect(link.getAttribute('target')).toBe('_blank');
+    });
+
+    it('renders the gold Give button during an active campaign', () => {
+        (useGiveToday as jest.Mock).mockReturnValue({
+            showButton: true,
+            give_link: 'https://example.test/campaign'
+        });
+        render(<GiveItem />);
+
+        const link = screen.getByRole('link', {name: 'Give'});
+
+        expect(link.classList.contains('give-button')).toBe(true);
+        expect(link.getAttribute('href')).toBe('https://example.test/campaign');
+    });
+});

--- a/test/src/layouts/default/logo.test.tsx
+++ b/test/src/layouts/default/logo.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {render, screen} from '@testing-library/preact';
+import {useStreamlinedNav} from '~/contexts/shared-data';
+import Logo from '~/layouts/default/header/menus/logo/logo';
+
+jest.mock('~/contexts/shared-data', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({flags: false})),
+    useStreamlinedNav: jest.fn()
+}));
+
+describe('logo', () => {
+    it('shows the quote and no Rice logo when not streamlined', () => {
+        (useStreamlinedNav as jest.Mock).mockReturnValue(false);
+        render(<Logo />);
+
+        expect(screen.getByText('Access. The future of education.')).toBeTruthy();
+        expect(screen.queryByRole('link', {name: 'Rice University logo'})).toBeNull();
+    });
+
+    it('shows the Rice logo and no quote when streamlined', () => {
+        (useStreamlinedNav as jest.Mock).mockReturnValue(true);
+        render(<Logo />);
+
+        expect(
+            screen.getByRole('link', {name: 'Rice University logo'}).getAttribute('href')
+        ).toBe('https://www.rice.edu');
+        expect(screen.queryByText('Access. The future of education.')).toBeNull();
+    });
+});

--- a/test/src/layouts/default/main-menu.test.tsx
+++ b/test/src/layouts/default/main-menu.test.tsx
@@ -4,8 +4,15 @@ import ShellContextProvider from '../../../helpers/shell-context';
 import MainMenu from '~/layouts/default/header/menus/main-menu/main-menu';
 import MemoryRouter from '../../../helpers/future-memory-router';
 import * as ULC from '~/contexts/language';
+import {useStreamlinedNav} from '~/contexts/shared-data';
 
 jest.mock('~/models/give-today', () => jest.fn().mockReturnValue({}));
+
+jest.mock('~/contexts/shared-data', () => {
+    const actual = jest.requireActual('~/contexts/shared-data');
+
+    return {__esModule: true, ...actual, useStreamlinedNav: jest.fn()};
+});
 
 function Component({path = '/'}) {
     return <ShellContextProvider>
@@ -37,5 +44,35 @@ describe('main-menu', () => {
         await screen.findByRole('link', {name: 'Math'});
         expect(screen.queryByRole('link', {name: '🍎 For K12 Teachers'})).toBeNull();
         spyLang.mockReset();
+    });
+});
+
+describe('main-menu streamlined Give', () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('renders a Give link before Log in when streamlined', async () => {
+        (useStreamlinedNav as jest.Mock).mockReturnValue(true);
+        render(<Component />);
+
+        await screen.findByRole('link', {name: 'Math'});
+        const give = screen.getByRole('link', {name: 'Give'});
+        const login = screen.getByRole('link', {name: 'Log out'});
+
+        expect(give).toBeTruthy();
+        // Give appears before Log out in DOM order
+        expect(
+            give.compareDocumentPosition(login) & Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy();
+    });
+
+    it('does not render the persistent Give link when not streamlined', async () => {
+        (useStreamlinedNav as jest.Mock).mockReturnValue(false);
+        render(<Component />);
+
+        await screen.findByRole('link', {name: 'Math'});
+        // give-today mock returns {} (showButton falsy) so GiveButton renders null
+        expect(screen.queryByRole('link', {name: 'Give'})).toBeNull();
     });
 });

--- a/test/src/layouts/default/streamlined-nav-menus.test.tsx
+++ b/test/src/layouts/default/streamlined-nav-menus.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {render, screen} from '@testing-library/preact';
+import MemoryRouter from '~/../../test/helpers/future-memory-router';
+import * as CF from '~/helpers/cms-fetch';
+import {useStreamlinedNav} from '~/contexts/shared-data';
+import Menus from '~/layouts/default/header/menus/menus';
+
+/* eslint-disable camelcase */
+// Menus consumes only useStreamlinedNav (not the provider), so fully stub the
+// module — this avoids loading the real flags promise / cms-fetch.
+jest.mock('~/contexts/shared-data', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({flags: false})),
+    useStreamlinedNav: jest.fn()
+}));
+
+jest.spyOn(CF, 'default').mockReturnValue(Promise.resolve({all_flags: []}));
+
+function renderMenus() {
+    render(
+        <MemoryRouter initialEntries={['/']}>
+            <Menus />
+        </MemoryRouter>
+    );
+}
+
+describe('streamlined nav — utility bar', () => {
+    it('shows the Upper Menu bar when not streamlined', () => {
+        (useStreamlinedNav as jest.Mock).mockReturnValue(false);
+        renderMenus();
+
+        expect(screen.getByRole('navigation', {name: 'Upper Menu'})).toBeTruthy();
+    });
+
+    it('hides the Upper Menu bar when streamlined', () => {
+        (useStreamlinedNav as jest.Mock).mockReturnValue(true);
+        renderMenus();
+
+        expect(screen.queryByRole('navigation', {name: 'Upper Menu'})).toBeNull();
+    });
+});


### PR DESCRIPTION
## What

Adds a CMS feature flag **`streamlined_nav`** (support-chat style, surfaced via a new `useStreamlinedNav()` hook in `shared-data.ts`) that toggles a streamlined header nav.

When the flag is **active**:
- The utility bar (`UpperMenu` / `meta-nav`) is hidden — desktop and mobile drawer.
- The Rice logo sits beside the OpenStax logo (with a divider) instead of the "Access. The future of education." quote.
- A persistent **Give** item lives in the main nav, in the existing slot between the CMS menu and Log in: a plain text link to RiceConnect normally, swapping to the gold Give button during an active give campaign (mirrors the old bar behavior).

When **inactive** (default, while flags load, or no provider): the header is unchanged — today's nav (switch this when we finalize).

## How

Single flag derivation (`useStreamlinedNav()`) read consistently by the three consumers: `menus.tsx` (gates the bar), `logo.tsx` (Rice logos vs. quote), and `main-menu.tsx` (`GiveItem` vs. campaign-only `GiveButton` + mobile visibility). New reusable `GiveItem` component encapsulates the two-state Give.