### PR TITLE
perf(chat): defer Salesforce chat widget load until browser idle

### DIFF
--- a/src/app/components/chat/chat.tsx
+++ b/src/app/components/chat/chat.tsx
@@ -8,6 +8,8 @@ type VisibleFieldArg = {
     isEditableByEndUser: boolean
 }
 
+const IDLE_CALLBACK_FALLBACK_DELAY = 200;
+
 declare global {
     interface Window {
         embeddedservice_bootstrap?: {
@@ -36,6 +38,29 @@ const SALESFORCE_CONFIG = {
     scrt2URL: 'https://openstax.my.salesforce-scrt.com',
     bootstrapScript: 'https://openstax.my.site.com/ESWWebMessagingDeployme1716235390398/assets/js/bootstrap.min.js'
 };
+
+function requestIdle(callback: () => void): () => void {
+    if (typeof window.requestIdleCallback === 'function') {
+        const id = window.requestIdleCallback(callback);
+
+        return () => window.cancelIdleCallback(id);
+    }
+    const id = window.setTimeout(callback, IDLE_CALLBACK_FALLBACK_DELAY);
+
+    return () => window.clearTimeout(id);
+}
+
+function preconnect(href: string) {
+    if (document.querySelector(`link[rel="preconnect"][href="${href}"]`)) {
+        return;
+    }
+    const link = document.createElement('link');
+
+    link.rel = 'preconnect';
+    link.href = href;
+    link.crossOrigin = 'anonymous';
+    document.head.appendChild(link);
+}
 
 function initEmbeddedMessaging(): boolean {
     // Value is guaranteed present by the caller
@@ -73,7 +98,17 @@ export default function Chat() {
         // Short-circuit if bootstrap is already available from a previous mount
         if (window.embeddedservice_bootstrap) {
             setScriptLoaded(true);
-        } else {
+
+            return undefined;
+        }
+
+        // Warm the connection now so it's ready by the time the idle-deferred script loads
+        preconnect(SALESFORCE_CONFIG.baseUrl);
+        preconnect(SALESFORCE_CONFIG.scrt2URL);
+
+        // Defer the heavy Salesforce bundle until the browser is idle so it doesn't
+        // compete with the page's own rendering and data fetching
+        const cancelIdle = requestIdle(() => {
             script = document.createElement('script');
 
             script.src = SALESFORCE_CONFIG.bootstrapScript;
@@ -89,10 +124,11 @@ export default function Chat() {
             };
 
             document.body.appendChild(script);
-        }
+        });
 
         // Always return cleanup function to hide widget on unmount
         return () => {
+            cancelIdle();
             if (script && document.body.contains(script)) {
                 // Clear handlers to prevent setState on unmounted component
                 script.onload = null;

--- a/test/src/components/chat.test.tsx
+++ b/test/src/components/chat.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, waitFor} from '@testing-library/preact';
+import {act, render, waitFor} from '@testing-library/preact';
 import Chat from '~/components/chat/chat';
 import * as UserContext from '~/contexts/user';
 
@@ -7,12 +7,21 @@ import * as UserContext from '~/contexts/user';
 jest.mock('~/contexts/user');
 jest.mock('~/components/chat/chat.scss', () => ({}));
 
+// The bootstrap script load is deferred until idle (jsdom has no requestIdleCallback,
+// so it falls back to a 200ms timeout) - advance past that before asserting on the script
+function flushIdleCallback() {
+    act(() => {
+        jest.advanceTimersByTime(200);
+    });
+}
+
 describe('Chat', () => {
     let mockEmbeddedService: any;
 
     beforeEach(() => {
         // Clean up any existing scripts and global objects
         document.querySelectorAll('script[src*="bootstrap.min.js"]').forEach((el) => el.remove());
+        document.querySelectorAll('link[rel="preconnect"]').forEach((el) => el.remove());
         delete (window as any).embeddedservice_bootstrap;
         delete (window as any).__salesforceChatInitialized;
 
@@ -41,6 +50,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         render(<Chat />);
+        flushIdleCallback();
 
         const scripts = document.querySelectorAll('script[src*="bootstrap.min.js"]');
         expect(scripts.length).toBe(1);
@@ -52,6 +62,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -73,6 +84,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -107,6 +119,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue(mockUserContext);
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -146,6 +159,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue(mockUserContext);
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -174,6 +188,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         const {unmount} = render(<Chat />);
+        flushIdleCallback();
 
         expect(document.querySelectorAll('script[src*="bootstrap.min.js"]').length).toBe(1);
 
@@ -187,6 +202,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
         script.onerror?.(new Event('error'));
@@ -207,6 +223,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue(mockUserContext);
 
         const {rerender} = render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -237,6 +254,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         const {rerender} = render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -301,6 +319,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         const {unmount} = render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -379,6 +398,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -401,6 +421,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -442,6 +463,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue(mockUserContext);
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 
@@ -490,6 +512,7 @@ describe('Chat', () => {
         (UserContext.default as jest.Mock).mockReturnValue(mockUserContext);
 
         render(<Chat />);
+        flushIdleCallback();
 
         const script = document.querySelector('script[src*="bootstrap.min.js"]') as HTMLScriptElement;
 

--- a/test/src/components/chat.test.tsx
+++ b/test/src/components/chat.test.tsx
@@ -58,6 +58,42 @@ describe('Chat', () => {
         expect(scripts[0].getAttribute('type')).toBe('text/javascript');
     });
 
+    it('uses requestIdleCallback when available and cancels on unmount', () => {
+        (UserContext.default as jest.Mock).mockReturnValue({});
+        const requestIdleCallback = jest.fn((cb: any) => {
+            cb();
+            return 123;
+        });
+        const cancelIdleCallback = jest.fn();
+
+        (window as any).requestIdleCallback = requestIdleCallback;
+        (window as any).cancelIdleCallback = cancelIdleCallback;
+
+        const {unmount} = render(<Chat />);
+
+        expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('script[src*="bootstrap.min.js"]').length).toBe(1);
+
+        unmount();
+        expect(cancelIdleCallback).toHaveBeenCalledWith(123);
+
+        delete (window as any).requestIdleCallback;
+        delete (window as any).cancelIdleCallback;
+    });
+
+    it('does not duplicate preconnect links when they already exist', () => {
+        (UserContext.default as jest.Mock).mockReturnValue({});
+        const baseUrl = 'https://openstax.my.site.com/ESWWebMessagingDeployme1716235390398';
+        const baseUrlLink = document.createElement('link');
+
+        baseUrlLink.rel = 'preconnect';
+        baseUrlLink.setAttribute('href', baseUrl);
+        document.head.appendChild(baseUrlLink);
+        render(<Chat />);
+
+        expect(document.querySelectorAll(`link[rel="preconnect"][href="${baseUrl}"]`).length).toBe(1);
+    });
+
     it('initializes embeddedservice_bootstrap when script loads', async () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 


### PR DESCRIPTION
## Summary
- Traced the subjects/book-details pages with Chrome DevTools and confirmed the Salesforce Embedded Messaging widget (`chat_subjects`/`chat_book_details` flags, gated to logged-in users) pulls in a ~17-request Lightning Web Runtime chain that fired synchronously the moment the `Chat` component mounted, racing the page's own render/data fetching.
- Defer the bootstrap script load with `requestIdleCallback` (falling back to a 200ms timeout for browsers without it) so it only starts once the browser is idle, and add `rel="preconnect"` hints for the Salesforce origins so the connection is warm by the time it loads. The already-loaded short-circuit path is unchanged (still synchronous).

## Test plan
- [x] `yarn jest test/src/components/chat.test.tsx` — all 16 tests pass (updated to flush the idle-deferred timer before asserting on the script)
- [x] `yarn lint:ts` / `yarn lint:js` — clean
- [x] Deploy to dev and re-run a Chrome DevTools performance trace on `/subjects` and `/details/*` while logged in to confirm the LWR chain no longer fires on initial mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)