### PR TITLE
fix(footer): restore link appearance for Manage cookies button

### DIFF
--- a/src/app/layouts/default/footer/footer.scss
+++ b/src/app/layouts/default/footer/footer.scss
@@ -102,7 +102,8 @@ $lower-footer: #3b3b3b;
             }
 
             button {
-                background-color: transparent;
+                @include button-reset();
+
                 color: inherit;
                 display: inline;
                 font-size: inherit;


### PR DESCRIPTION
## Problem

The **Manage cookies** link in the site footer renders with a native browser button border (`2px outset`) instead of the plain text-link styling of its siblings (Privacy Notice, Licensing, etc.):

![broken button](https://github.com/user-attachments/assets/placeholder)

This regressed in #2878, which removed the leaky global button styles that used to zero out `border`/`appearance` on every `<button>`. The footer's Manage-cookies toggle (`cookie-yes-toggle.tsx`) hands its styling to the `.column button` reset in `footer.scss`, and that reset was hand-rolled — it set `background-color: transparent` plus font/padding inherits but never touched `border` or `appearance`. With the global reset gone, the native button chrome reappeared.

It slipped past review/preview because the button only mounts after the CookieYes banner actually loads, which doesn't happen in most dev/preview contexts — we only caught it in prod.

## Fix

Swap the hand-rolled reset for the shared `button-reset()` mixin — the same migration the rest of the codebase made in #2878. It restores `appearance: none`, `border: 0`, `cursor: pointer`, and the standard focus indicator, while the existing link-style overrides (color/font/text-decoration inherit + hover underline) stay on top.

```scss
button {
    @include button-reset();

    color: inherit;
    display: inline;
    ...
}
```

## Verification

Confirmed on both prod (by injecting the mixin's declarations onto the live button) and the local dev server (by temporarily force-rendering the button): computed style becomes `border: 0px none` / `appearance: none`, and "Manage cookies" renders as a plain text link matching the other footer links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)