### PR TITLE
fix(nav): keep sticky header pinned when streamlined_nav is active

### DIFF
--- a/src/app/layouts/default/default.tsx
+++ b/src/app/layouts/default/default.tsx
@@ -16,12 +16,20 @@ import './default.scss';
 
 export default function DefaultLayout({children}: React.PropsWithChildren<object>) {
     const streamlined = useStreamlinedNav();
+    const headerRef = React.useRef<HTMLElement>(null);
+
+    // Toggle imperatively rather than via `className` so we don't take over the
+    // element's class list from `over-mobile-dialog`, which the takeover dialog
+    // adds/removes on #header directly (see takeover-dialog/content-mobile).
+    React.useEffect(() => {
+        headerRef.current?.classList.toggle('streamlined', streamlined);
+    }, [streamlined]);
 
     // BrowserRouter has to include everything that uses useLocation
     return (
         <React.Fragment>
             <Microsurvey />
-            <header id="header" className={cn({streamlined})}>
+            <header id="header" ref={headerRef}>
                 <Header />
             </header>
             <div id="lower-sticky-note">

--- a/src/app/layouts/default/default.tsx
+++ b/src/app/layouts/default/default.tsx
@@ -8,17 +8,20 @@ import useMainClassContext, {
     MainClassContextProvider
 } from '~/contexts/main-class';
 import useLanguageContext from '~/contexts/language';
+import {useStreamlinedNav} from '~/contexts/shared-data';
 import ReactModal from 'react-modal';
 import TakeoverDialog from './takeover-dialog/takeover-dialog';
 import cn from 'classnames';
 import './default.scss';
 
 export default function DefaultLayout({children}: React.PropsWithChildren<object>) {
+    const streamlined = useStreamlinedNav();
+
     // BrowserRouter has to include everything that uses useLocation
     return (
         <React.Fragment>
             <Microsurvey />
-            <header id="header">
+            <header id="header" className={cn({streamlined})}>
                 <Header />
             </header>
             <div id="lower-sticky-note">

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -186,6 +186,14 @@ sup {
         top: -5rem;
     }
 
+    // Streamlined nav drops the 5rem utility bar, so there is no bar to tuck
+    // out of view on scroll. Pin the main nav flush to the top instead.
+    &.streamlined {
+        @include wider-than($tablet-max) {
+            top: 0;
+        }
+    }
+
     @media print {
         display: none;
     }


### PR DESCRIPTION
## Problem

When the `streamlined_nav` flag is on, the sticky header no longer stays pinned to the top of the screen — it scrolls almost entirely out of view.

## Root cause

The desktop sticky header (`#header` in `src/styles/main.scss`) uses:

```scss
@include wider-than($tablet-max) {
    position: sticky;
    top: -5rem;
}
```

That `-5rem` is exactly the height of the utility bar / meta-nav (`upper-menu.scss` → `height: 5rem` on desktop). The intent is the classic "tuck the utility bar out of view on scroll, keep the main nav pinned" pattern: the header stacks as meta-nav (5rem) + main nav (6rem), and sticking at `-5rem` pulls the 5rem bar above the viewport while leaving the main nav flush at the top.

When `streamlined_nav` is active, `menus.tsx` doesn't render the meta-nav at all — but `top: -5rem` is unchanged, so the same offset now pulls the **main nav itself** ~5rem above the viewport. Since the main nav is only ~6rem tall, almost all of it disappears on scroll.

## Fix

Add a `streamlined` class to `#header` (following the existing `{streamlined}` class pattern already used in `logo.tsx` / `main-menu.tsx`) and reset the offset to `top: 0` on desktop when the flag is on — there's no utility bar left to hide.

- Mobile (`position: fixed; top: 0`) is unaffected.
- `#lower-sticky-note` (`top: 5.5rem`) stays correct — the main nav pins to viewport-top identically in both modes.

## Base branch

Targets `streamlined-nav-flag` rather than `main`, because the `streamlined_nav` feature itself hasn't merged to `main` yet — the fix belongs with the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)