### PR TITLE
Core-1382: book tile links use portal path to details page

### DIFF
--- a/src/app/components/book-tile/book-tile-display.tsx
+++ b/src/app/components/book-tile/book-tile-display.tsx
@@ -4,6 +4,7 @@ import type {Item} from '~/models/book-titles';
 import {Book as BookInfo} from '~/pages/subjects/new/specific/context';
 import GetTheBookDropdown from './dropdown-menu';
 import cn from 'classnames';
+import usePortalContext from '~/contexts/portal';
 import './book-tile.scss';
 
 type AdditionalFields = Partial<{
@@ -16,6 +17,7 @@ export default function BookTile({book}: {book: BookInfo & AdditionalFields}) {
     const comingSoon = book.bookState === 'coming_soon';
     const snippets = book.promoteSnippet?.filter((s) => s.value.image);
     const promoteSnippet = snippets?.find((s) => s.value.image);
+    const {portalPrefix} = usePortalContext();
     const classes = cn({
         'book-tile': true,
         'coming-soon': comingSoon,
@@ -24,7 +26,7 @@ export default function BookTile({book}: {book: BookInfo & AdditionalFields}) {
 
     return (
         <div className={classes}>
-            <a href={`/details/${slug}`} aria-label={`${title} book`}>
+            <a href={`${portalPrefix}/details/${slug}`} aria-label={`${title} book`}>
                 <img
                     src={coverUrl}
                     role='presentation'

--- a/src/app/components/book-tile/book-tile-display.tsx
+++ b/src/app/components/book-tile/book-tile-display.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import {useLocation} from 'react-router-dom';
 import PromoteBadge from '~/components/promote-badge/promote-badge';
 import type {Item} from '~/models/book-titles';
 import {Book as BookInfo} from '~/pages/subjects/new/specific/context';
 import GetTheBookDropdown from './dropdown-menu';
 import cn from 'classnames';
 import usePortalContext from '~/contexts/portal';
+import {assertNotNull} from '~/helpers/data';
 import './book-tile.scss';
 
 type AdditionalFields = Partial<{
@@ -17,16 +19,29 @@ export default function BookTile({book}: {book: BookInfo & AdditionalFields}) {
     const comingSoon = book.bookState === 'coming_soon';
     const snippets = book.promoteSnippet?.filter((s) => s.value.image);
     const promoteSnippet = snippets?.find((s) => s.value.image);
-    const {portalPrefix} = usePortalContext();
+    const ref = React.useRef<HTMLDivElement>(null);
+    const {portalPrefix, rewriteLinks} = usePortalContext();
+    const {pathname} = useLocation();
     const classes = cn({
         'book-tile': true,
         'coming-soon': comingSoon,
         promote: Boolean(promoteSnippet)
     });
 
+    /* For a top-level Flex (portal) page, links are rewritten elsewhere
+     * Tiles in sub-pages need to rewrite their links
+     */
+    React.useLayoutEffect(() => {
+        const normalizedPathname = pathname.replace(/\/$/, '');
+
+        if (portalPrefix !== normalizedPathname) {
+            rewriteLinks(assertNotNull<HTMLElement>(ref.current));
+        }
+    }, [pathname, portalPrefix, rewriteLinks]);
+
     return (
-        <div className={classes}>
-            <a href={`${portalPrefix}/details/${slug}`} aria-label={`${title} book`}>
+        <div className={classes} ref={ref}>
+            <a href={`/details/${slug}`} aria-label={`${title} book`}>
                 <img
                     src={coverUrl}
                     role='presentation'

--- a/src/app/components/book-tile/dropdown-menu.tsx
+++ b/src/app/components/book-tile/dropdown-menu.tsx
@@ -14,6 +14,7 @@ import {faCaretUp} from '@fortawesome/free-solid-svg-icons/faCaretUp';
 import {faCaretDown} from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import type {Book as BookInfo} from '~/pages/subjects/new/specific/context';
 import { useRexPortalLinkOrNot } from '~/helpers/rex-portal';
+import usePortalContext from '~/contexts/portal';
 
 export default function GetTheBookDropdown({bookInfo}: {bookInfo: BookInfo}) {
     const ref = React.useRef<HTMLDivElement>(null);
@@ -23,6 +24,7 @@ export default function GetTheBookDropdown({bookInfo}: {bookInfo: BookInfo}) {
     const webviewLink = useRexPortalLinkOrNot(bookInfo.webviewRexLink ?? '');
     const pdfLink = bookInfo.pdfUrl ?? bookInfo.highResolutionPdfUrl;
     const warning = useWarning(bookInfo.id);
+    const {portalPrefix} = usePortalContext();
 
     return (
         <div
@@ -56,11 +58,11 @@ export default function GetTheBookDropdown({bookInfo}: {bookInfo: BookInfo}) {
                 <hr />
                 <MenuItem
                     defaultMessage="Instructor resources"
-                    url={`/details/${slug}?Instructor resources`}
+                    url={`${portalPrefix}/details/${slug}?Instructor resources`}
                 />
                 <MenuItem
                     defaultMessage="Student resources"
-                    url={`/details/${slug}?Student resources`}
+                    url={`${portalPrefix}/details/${slug}?Student resources`}
                 />
             </div>
         </div>

--- a/src/app/components/book-tile/dropdown-menu.tsx
+++ b/src/app/components/book-tile/dropdown-menu.tsx
@@ -14,7 +14,6 @@ import {faCaretUp} from '@fortawesome/free-solid-svg-icons/faCaretUp';
 import {faCaretDown} from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import type {Book as BookInfo} from '~/pages/subjects/new/specific/context';
 import { useRexPortalLinkOrNot } from '~/helpers/rex-portal';
-import usePortalContext from '~/contexts/portal';
 
 export default function GetTheBookDropdown({bookInfo}: {bookInfo: BookInfo}) {
     const ref = React.useRef<HTMLDivElement>(null);
@@ -24,7 +23,6 @@ export default function GetTheBookDropdown({bookInfo}: {bookInfo: BookInfo}) {
     const webviewLink = useRexPortalLinkOrNot(bookInfo.webviewRexLink ?? '');
     const pdfLink = bookInfo.pdfUrl ?? bookInfo.highResolutionPdfUrl;
     const warning = useWarning(bookInfo.id);
-    const {portalPrefix} = usePortalContext();
 
     return (
         <div
@@ -58,11 +56,11 @@ export default function GetTheBookDropdown({bookInfo}: {bookInfo: BookInfo}) {
                 <hr />
                 <MenuItem
                     defaultMessage="Instructor resources"
-                    url={`${portalPrefix}/details/${slug}?Instructor resources`}
+                    url={`/details/${slug}?Instructor resources`}
                 />
                 <MenuItem
                     defaultMessage="Student resources"
-                    url={`${portalPrefix}/details/${slug}?Student resources`}
+                    url={`/details/${slug}?Student resources`}
                 />
             </div>
         </div>

--- a/test/src/components/book-tile.test.tsx
+++ b/test/src/components/book-tile.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {describe, expect, it} from '@jest/globals';
 import {render, screen} from '@testing-library/preact';
+import MemoryRouter from '~/../../test/helpers/future-memory-router';
 import ShellContextProvider from '~/../../test/helpers/shell-context';
 import {Book as BookInfo} from '~/pages/subjects/new/specific/context';
 import BookTile from '~/components/book-tile/book-tile';
@@ -22,9 +23,11 @@ const bookData: BookInfo = {
 
 function Component({book}: {book: [BookInfo]}) {
     return (
-        <ShellContextProvider>
-            <BookTile book={book} />
-        </ShellContextProvider>
+        <MemoryRouter>
+            <ShellContextProvider>
+                <BookTile book={book} />
+            </ShellContextProvider>
+        </MemoryRouter>
     );
 }
 jest.mock('~/helpers/page-data-utils', () => ({

--- a/test/src/components/book-tile.test.tsx
+++ b/test/src/components/book-tile.test.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import {describe, expect, it} from '@jest/globals';
 import {render, screen} from '@testing-library/preact';
 import MemoryRouter from '~/../../test/helpers/future-memory-router';
 import ShellContextProvider from '~/../../test/helpers/shell-context';
+import {LanguageContextProvider} from '~/contexts/language';
 import {Book as BookInfo} from '~/pages/subjects/new/specific/context';
 import BookTile from '~/components/book-tile/book-tile';
+import BookTileDisplay from '~/components/book-tile/book-tile-display';
 import userEvent from '@testing-library/user-event';
 import * as CF from '~/helpers/cms-fetch';
+import usePortalContext, {PortalContextProvider} from '~/contexts/portal';
+import '@testing-library/jest-dom';
 
 const bookData: BookInfo = {
     id: 46,
@@ -161,5 +164,91 @@ describe('book-tile', () => {
 
         expect(menuItems.includes('View online')).toBe(false);
         expect(menuItems.includes('Order a print copy')).toBe(true);
+    });
+});
+
+describe('book-tile-display portal link rewriting', () => {
+    it('does not rewrite links when portalPrefix matches pathname', () => {
+        const ComponentWithMatchingPath = () => {
+            const {setPortal} = usePortalContext();
+
+            // Set portal to match the pathname
+            setPortal('k12');
+
+            return (
+                <LanguageContextProvider>
+                    <MemoryRouter initialEntries={['/k12']}>
+                        <BookTileDisplay book={bookData} />
+                    </MemoryRouter>
+                </LanguageContextProvider>
+            );
+        };
+
+        render(
+            <PortalContextProvider>
+                <ComponentWithMatchingPath />
+            </PortalContextProvider>
+        );
+
+        // The link should remain as-is (not double-prefixed)
+        const link = screen.getByRole('link', {name: /Sample Title book/i});
+
+        expect(link).toHaveAttribute('href', '/details/sample');
+    });
+
+    it('rewrites links when portalPrefix differs from pathname', () => {
+        const ComponentWithDifferentPath = () => {
+            const {setPortal} = usePortalContext();
+
+            // Set portal but use a different pathname (simulating a sub-page)
+            setPortal('k12');
+
+            return (
+                <LanguageContextProvider>
+                    <MemoryRouter initialEntries={['/k12/subjects/math']}>
+                        <BookTileDisplay book={bookData} />
+                    </MemoryRouter>
+                </LanguageContextProvider>
+            );
+        };
+
+        render(
+            <PortalContextProvider>
+                <ComponentWithDifferentPath />
+            </PortalContextProvider>
+        );
+
+        // The link should be prefixed with the portal
+        const link = screen.getByRole('link', {name: /Sample Title book/i});
+
+        expect(link).toHaveAttribute('href', '/k12/details/sample');
+    });
+
+    it('handles trailing slashes in pathname comparison', () => {
+        const ComponentWithTrailingSlash = () => {
+            const {setPortal} = usePortalContext();
+
+            // Set portal and use pathname with trailing slash
+            setPortal('k12');
+
+            return (
+                <MemoryRouter initialEntries={['/k12/']}>
+                    <BookTileDisplay book={bookData} />
+                </MemoryRouter>
+            );
+        };
+
+        render(
+            <LanguageContextProvider>
+                <PortalContextProvider>
+                    <ComponentWithTrailingSlash />
+                </PortalContextProvider>
+            </LanguageContextProvider>
+        );
+
+        // The link should remain as-is (pathname normalized, so /k12/ matches /k12)
+        const link = screen.getByRole('link', {name: /Sample Title book/i});
+
+        expect(link).toHaveAttribute('href', '/details/sample');
     });
 });

--- a/test/src/pages/k12/k12.test.tsx
+++ b/test/src/pages/k12/k12.test.tsx
@@ -30,13 +30,15 @@ jest.mock('~/pages/k12/import-subject', () => ({
     __esModule: true,
     default: () => mockImportSubject()
 }));
-jest.spyOn(PC, 'default').mockReturnValue({
+const portalSpy = jest.spyOn(PC, 'default').mockReturnValue({
     portalPrefix: '',
     setPortal: jest.fn(),
     rewriteLinks: jest.fn(),
     isK12Portal: false,
     setIsK12Portal: jest.fn()
 });
+
+afterAll(() => portalSpy.mockRestore());
 
 describe('k12 page', () => {
     const user = userEvent.setup();

--- a/test/src/pages/k12/k12.test.tsx
+++ b/test/src/pages/k12/k12.test.tsx
@@ -10,6 +10,7 @@ import Subject from '~/pages/k12/subject/subject';
 import subjectPageData from '../../data/k12-subject';
 import { transformData, camelCaseKeys } from '~/helpers/page-data-utils';
 import * as DH from '~/helpers/use-document-head';
+import * as PC from '~/contexts/portal';
 
 jest.setTimeout(8000);
 jest.spyOn(DH, 'setPageTitleAndDescriptionFromBookData').mockReturnValue();
@@ -29,6 +30,13 @@ jest.mock('~/pages/k12/import-subject', () => ({
     __esModule: true,
     default: () => mockImportSubject()
 }));
+jest.spyOn(PC, 'default').mockReturnValue({
+    portalPrefix: '',
+    setPortal: jest.fn(),
+    rewriteLinks: jest.fn(),
+    isK12Portal: false,
+    setIsK12Portal: jest.fn()
+});
 
 describe('k12 page', () => {
     const user = userEvent.setup();


### PR DESCRIPTION
[CORE-1382]

Some of these change were previously made, then undone because the links got rewritten, resulting in doubling the portal portion of the path.
The issue is that on top-level portal pages, the links are rewritten by the portal page renderer.
On portal sub-pages, links are not rewritten.
This PR addresses that for the book-tile component, which appears in both places.
It may be that the right thing to do is to rewrite links on all portal pages, but that needs some thinking through.

[CORE-1382]: https://openstax.atlassian.net/browse/CORE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ