### PR TITLE
Render FAQ content (table/image/text) in FAQBlock

### DIFF
--- a/src/app/pages/flex-page/blocks/FAQBlock.tsx
+++ b/src/app/pages/flex-page/blocks/FAQBlock.tsx
@@ -19,7 +19,11 @@ type FAQImageBlockConfig = {
     value: FAQImageValue;
 }
 
-type FAQContentItem = TableBlockConfig | RichTextBlockConfig | FAQImageBlockConfig
+type FAQContentItem =
+    | TableBlockConfig
+    | RichTextBlockConfig
+    | FAQImageBlockConfig
+    | {id: string; type: Exclude<string, 'table' | 'text' | 'image'>; value: unknown}
 
 export interface FAQBlockConfig {
     id: string;

--- a/src/app/pages/flex-page/blocks/FAQBlock.tsx
+++ b/src/app/pages/flex-page/blocks/FAQBlock.tsx
@@ -13,11 +13,13 @@ interface FAQImageValue {
     alt_text: string;
 }
 
-interface FAQContentItem {
+type FAQImageBlockConfig = {
     id: string;
-    type: string;
-    value: unknown;
+    type: 'image';
+    value: FAQImageValue;
 }
+
+type FAQContentItem = TableBlockConfig | RichTextBlockConfig | FAQImageBlockConfig
 
 export interface FAQBlockConfig {
     id: string;
@@ -37,9 +39,9 @@ export interface FAQBlockConfig {
 function FAQContent({item}: {item: FAQContentItem}): React.ReactElement | null {
     switch (item.type) {
         case 'table':
-            return <blocks.table.Component data={item as unknown as TableBlockConfig} />;
+            return <blocks.table.Component data={item as TableBlockConfig} />;
         case 'text':
-            return <blocks.text.Component data={item as unknown as RichTextBlockConfig} />;
+            return <blocks.text.Component data={item as RichTextBlockConfig} />;
         case 'image': {
             const {image, alt_text: altText} = item.value as FAQImageValue;
 

--- a/src/app/pages/flex-page/blocks/FAQBlock.tsx
+++ b/src/app/pages/flex-page/blocks/FAQBlock.tsx
@@ -15,7 +15,7 @@ interface FAQImageValue {
 
 interface FAQContentItem {
     id: string;
-    type: 'table' | 'image' | 'text';
+    type: string;
     value: unknown;
 }
 
@@ -29,7 +29,7 @@ export interface FAQBlockConfig {
             slug: string;
             answer: string;
             document: unknown;
-            content: FAQContentItem[];
+            content?: FAQContentItem[];
         }
     }>;
 }

--- a/src/app/pages/flex-page/blocks/FAQBlock.tsx
+++ b/src/app/pages/flex-page/blocks/FAQBlock.tsx
@@ -2,7 +2,22 @@ import React from 'react';
 import {htmlToText} from '~/helpers/data';
 import RawHTML from '~/components/jsx-helpers/raw-html';
 import AccordionGroup from '~/components/accordion-group/accordion-group';
+import * as blocks from '@openstax/flex-page-renderer/blocks/index';
+import {Image} from '@openstax/flex-page-renderer/components/Image';
+import type {TableBlockConfig} from '@openstax/flex-page-renderer/blocks/TableBlock.config';
+import type {RichTextBlockConfig} from '@openstax/flex-page-renderer/blocks/RichTextBlock.component';
 import './FAQBlock.scss';
+
+interface FAQImageValue {
+    image: {file: string; width: number; height: number};
+    alt_text: string;
+}
+
+interface FAQContentItem {
+    id: string;
+    type: 'table' | 'image' | 'text';
+    value: unknown;
+}
 
 export interface FAQBlockConfig {
     id: string;
@@ -14,15 +29,35 @@ export interface FAQBlockConfig {
             slug: string;
             answer: string;
             document: unknown;
+            content: FAQContentItem[];
         }
     }>;
+}
+
+function FAQContent({item}: {item: FAQContentItem}): React.ReactElement | null {
+    switch (item.type) {
+        case 'table':
+            return <blocks.table.Component data={item as unknown as TableBlockConfig} />;
+        case 'text':
+            return <blocks.text.Component data={item as unknown as RichTextBlockConfig} />;
+        case 'image': {
+            const {image, alt_text: altText} = item.value as FAQImageValue;
+
+            return <Image image={image} alt={altText} />;
+        }
+        default:
+            return null;
+    }
 }
 
 export function FAQBlock({data}: {data: FAQBlockConfig}): React.ReactElement {
     const accordionItems = React.useMemo(() =>
         data.value.map((d) => ({
             title: htmlToText(d.value.question),
-            contentComponent: <RawHTML html={d.value.answer} />
+            contentComponent: <>
+                <RawHTML html={d.value.answer} />
+                {(d.value.content ?? []).map((item) => <FAQContent key={item.id} item={item} />)}
+            </>
         }))
     , [data]);
 

--- a/test/src/pages/flex-page.test.tsx
+++ b/test/src/pages/flex-page.test.tsx
@@ -117,6 +117,48 @@ describe('flex-page', () => {
         expect(screen.getAllByRole('heading')).toHaveLength(1);
         expect(screen.getAllByRole('button')).toHaveLength(1);
     });
+    it('renders faqBlock with table content', () => {
+        body = [faqBlock([
+            {
+                id: 'table-1',
+                type: 'table',
+                value: {
+                    caption: 'Formats',
+                    columns: [{header: 'Format', type: 'text'}],
+                    rows: [{cells: [{content: '<p>PDF</p>', cta: []}]}],
+                    config: []
+                }
+            }
+        ])];
+        render(<Component />);
+        expect(document.querySelector('table')).not.toBe(null);
+        expect(screen.getAllByText('Format')).toHaveLength(1);
+    });
+    it('renders faqBlock with image, text, and unrecognized content', () => {
+        body = [faqBlock([
+            {
+                id: 'image-1',
+                type: 'image',
+                value: {
+                    image: {file: '/foo/faq-image.jpg', width: 100, height: 50},
+                    alt_text: 'an faq image'
+                }
+            },
+            {
+                id: 'text-1',
+                type: 'text',
+                value: '<p>Some faq rich text</p>'
+            },
+            {
+                id: 'unknown-1',
+                type: 'unrecognized',
+                value: null
+            }
+        ])];
+        render(<Component />);
+        expect(screen.getByAltText('an faq image')).not.toBe(null);
+        expect(screen.getAllByText('Some faq rich text')).toHaveLength(1);
+    });
     it('renders htmlBlock', () => {
         body = [htmlBlock()];
         render(<Component />);
@@ -280,7 +322,7 @@ function dividerBlock(aligned: boolean): BodyBlock {
     } as BodyBlock;
 }
 
-function faqBlock(): BodyBlock {
+function faqBlock(content: Array<Record<string, unknown>> = []): BodyBlock {
     return {
         id: 'faq-id',
         type: 'faq',
@@ -291,7 +333,8 @@ function faqBlock(): BodyBlock {
                     question: 'what?',
                     slug: 'q1',
                     answer: 'hush',
-                    document: ''
+                    document: '',
+                    content
                 }
             }
         ]


### PR DESCRIPTION
## Summary
- `FAQBlock.tsx` now renders the CMS's new `content` array on each FAQ entry (table/image/text), in addition to the existing question/answer. Reuses `@openstax/flex-page-renderer`'s existing `table`/`text` block components and `Image` component — no new rendering logic.
- Targets this RC branch (not `main`) because it depends on the `@openstax/flex-page-renderer` bump here (`renderer-1.1.19-rc.1`, openstax/flex-pages#22) for the table renderer. Should not merge to `main` ahead of that RC landing as a stable release.

Companion CMS change (adds the `content` field this renders): openstax/openstax-cms#1734

## Test plan
- [x] `npm test` — 178/178 suites, 728/728 tests passing
- [x] New tests in `test/src/pages/flex-page.test.tsx` render real DOM (table, image alt text, rich text) through the actual FlexPage → block-map → FAQBlock pipeline
- [x] `tsc --skipLibCheck --noEmit` clean
- [x] Reviewed (subagent-driven development, task + final whole-branch review), no blocking findings