### PR TITLE
Fix .text-orange/.text-green Draftail color tokens

### DIFF
--- a/src/app/pages/flex-page/flex-page.scss
+++ b/src/app/pages/flex-page/flex-page.scss
@@ -20,8 +20,10 @@
 
   // Brand text colors, applied to any run of text.
   .text-blue { color: os-color(blue); }
-  .text-green { color: os-color(green); }
-  .text-orange { color: os-color(orange); }
+  // Deep-green and CTA-primary read better as body text than the raw
+  // green/orange swatches, which are tuned for illustration, not text.
+  .text-green { color: os-color(deep-green); }
+  .text-orange { color: ui-color(primary); }
   .text-gray { color: os-color(gray); }
   .text-white { color: text-color(white); }
 }


### PR DESCRIPTION
Companion to flex-pages #25.

`.text-orange` `.text-green` (Draftail rich-text classes applied inside flex-page content) were resolving to the illustration-tuned `os-color(orange)` `os-color(green)` swatches. The site's custom-CSS override shows they should read as `ui-color(primary)` (#d4450c) and `os-color(deep-green)` (#0c9372) instead.