### PR TITLE
Switch flex-page-renderer to GitHub Packages registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,12 @@ jobs:
           cache: yarn
       -
         name: "Auth to GitHub Packages"
-        run: echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}' >> ~/.npmrc
       -
         name: "Setup environment"
         run: ./script/setup
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
         name: "Lint osweb"
         run: yarn lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@
 jobs:
   osweb:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: read
     steps:
       -
         name: "Checkout release tag"
@@ -12,6 +15,11 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: yarn
+      -
+        name: "Auth to GitHub Packages"
+        run: echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
         name: "Setup environment"
         run: ./script/setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ jobs:
     permissions:
       contents: read
       packages: read
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       -
         name: "Checkout release tag"
@@ -21,8 +23,6 @@ jobs:
       -
         name: "Setup environment"
         run: ./script/setup
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
         name: "Lint osweb"
         run: yarn lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@openstax:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.3.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@openstax/experiments": "^1.0.2",
-        "@openstax/flex-page-renderer": "https://github.com/openstax/flex-pages.git#renderer-1.1.16",
+        "@openstax/flex-page-renderer": "^1.1.18",
         "@sentry/integrations": "^7.114.0",
         "@sentry/react": "^9.16.1",
         "@types/react-modal": "^3.16.3",

--- a/test/src/pages/flex-page.test.tsx
+++ b/test/src/pages/flex-page.test.tsx
@@ -154,6 +154,13 @@ describe('flex-page', () => {
         render(<Component />);
         expect(screen.getAllByText('book title')).toHaveLength(1);
     });
+    it('renders bigNumberBlock', () => {
+        body = [bigNumberBlock(), bigNumberBlock('1M+', 'learners', 'blue')];
+        render(<Component />);
+        expect(screen.getAllByText('42')).toHaveLength(1);
+        expect(screen.getAllByText('1M+')).toHaveLength(1);
+        expect(screen.getAllByText('learners')).toHaveLength(1);
+    });
 });
 
 function imageBlock(name: string) {
@@ -393,5 +400,13 @@ function bookListBlock(): BodyBlock {
                 }
             ]
         }
+    } as BodyBlock;
+}
+
+function bigNumberBlock(number = '42', caption?: string, color?: string): BodyBlock {
+    return {
+        id: 'big-number-id',
+        type: 'big_number',
+        value: {number, caption, color}
     } as BodyBlock;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2894,9 +2894,10 @@
     "@openstax/ts-utils" "^1.2.3"
     js-cookie "^3.0.5"
 
-"@openstax/flex-page-renderer@https://github.com/openstax/flex-pages.git#renderer-1.1.16":
-  version "1.1.16"
-  resolved "https://github.com/openstax/flex-pages.git#8dff79f90653d7ffa81cd4e9cd0712f188c1bbcd"
+"@openstax/flex-page-renderer@^1.1.18":
+  version "1.1.18"
+  resolved "https://npm.pkg.github.com/download/@openstax/flex-page-renderer/1.1.18/6ae6d99edbc11a94a3be142d2f376535b4925b19#6ae6d99edbc11a94a3be142d2f376535b4925b19"
+  integrity sha512-TB5PLAui7qVafjW9/yJ1FY5T+JuvgO0nRssyS/u0o9WaMdQWS3Rmncz8CDOyAuImS3HOS00SiI9Vhn25xNgs0g==
   dependencies:
     classnames "^2.5.1"
     color "^5.0.0"


### PR DESCRIPTION
## Summary
- flex-pages now publishes to `npm.pkg.github.com` instead of git-tag dist branches (per Tom's new setup, demoed in `assessment-components` PR [#114](https://github.com/openstax/assessment-components/pull/114))
- Adds `.npmrc` mapping `@openstax` scope to the GitHub Packages registry
- CI (`build.yml`) gets `packages: read` permission and an auth step using `GITHUB_TOKEN` before install
- Bumps `@openstax/flex-page-renderer` from the old `renderer-1.1.16` git tag to `^1.1.18`, the version currently published to the registry

## Setup required (one-time, per developer)
```
npm config set -g //npm.pkg.github.com/:_authToken $(gh auth token)
```
Without this, `yarn install` will fail to fetch `@openstax/*` packages.

## Test plan
- [x] `yarn install` resolves `@openstax/flex-page-renderer@1.1.18` from `npm.pkg.github.com`
- [x] `yarn lint:js` / `yarn lint:ts` pass
- [x] `./script/build` succeeds
- [x] `./script/test` — 178 suites / 725 tests pass (pre-existing coverage gap in 3 unrelated files, not caused by this change)
- [ ] Confirm CI's `GITHUB_TOKEN` actually has read access to packages published under the `flex-pages` repo (cross-repo package visibility can be restrictive by default — flag to Tom if the workflow 404s)