### PR TITLE
Render nested content blocks inside FAQ accordion items

### DIFF
--- a/src/app/pages/flex-page/blocks/FAQBlock.tsx
+++ b/src/app/pages/flex-page/blocks/FAQBlock.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import {htmlToText} from '~/helpers/data';
 import RawHTML from '~/components/jsx-helpers/raw-html';
 import AccordionGroup from '~/components/accordion-group/accordion-group';
-import {ContentBlockRoot, BlockData} from '@openstax/flex-page-renderer/ContentBlockRoot';
+import {ContentBlockRoot, type BlockData} from '@openstax/flex-page-renderer/ContentBlockRoot';
 import * as blocks from '@openstax/flex-page-renderer/blocks/index';
-import {Image, ImageFields} from '@openstax/flex-page-renderer/components/Image';
+import {Image, type ImageFields} from '@openstax/flex-page-renderer/components/Image';
 import './FAQBlock.scss';
 
 // The CMS's faq.content field is a closed StreamBlock: table, image, or text.

--- a/src/app/pages/flex-page/blocks/FAQBlock.tsx
+++ b/src/app/pages/flex-page/blocks/FAQBlock.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {htmlToText} from '~/helpers/data';
 import RawHTML from '~/components/jsx-helpers/raw-html';
 import AccordionGroup from '~/components/accordion-group/accordion-group';
+import {ContentBlockRoot, BlockData} from '@openstax/flex-page-renderer/ContentBlockRoot';
+import * as blocks from '@openstax/flex-page-renderer/blocks/index';
 import './FAQBlock.scss';
 
 export interface FAQBlockConfig {
@@ -14,6 +16,7 @@ export interface FAQBlockConfig {
             slug: string;
             answer: string;
             document: unknown;
+            content?: BlockData<typeof blocks>;
         }
     }>;
 }
@@ -22,7 +25,12 @@ export function FAQBlock({data}: {data: FAQBlockConfig}): React.ReactElement {
     const accordionItems = React.useMemo(() =>
         data.value.map((d) => ({
             title: htmlToText(d.value.question),
-            contentComponent: <RawHTML html={d.value.answer} />
+            contentComponent: <>
+                <RawHTML html={d.value.answer} />
+                {d.value.content?.length
+                    ? <ContentBlockRoot data={d.value.content} blocks={blocks} />
+                    : null}
+            </>
         }))
     , [data]);
 

--- a/src/app/pages/flex-page/blocks/FAQBlock.tsx
+++ b/src/app/pages/flex-page/blocks/FAQBlock.tsx
@@ -4,7 +4,16 @@ import RawHTML from '~/components/jsx-helpers/raw-html';
 import AccordionGroup from '~/components/accordion-group/accordion-group';
 import {ContentBlockRoot, BlockData} from '@openstax/flex-page-renderer/ContentBlockRoot';
 import * as blocks from '@openstax/flex-page-renderer/blocks/index';
+import {Image, ImageFields} from '@openstax/flex-page-renderer/components/Image';
 import './FAQBlock.scss';
+
+// The CMS's faq.content field is a closed StreamBlock: table, image, or text.
+// table/text are registered renderer blocks (delegate to ContentBlockRoot);
+// image isn't a block type in the renderer's registry, so it needs its own case.
+type FAQImageItem = {id: string; type: 'image'; value: {image: ImageFields; alt_text: string}};
+type FAQContentItem = FAQImageItem | BlockData<typeof blocks>[number];
+
+const isFAQImage = (item: FAQContentItem): item is FAQImageItem => item.type === 'image';
 
 export interface FAQBlockConfig {
     id: string;
@@ -16,7 +25,7 @@ export interface FAQBlockConfig {
             slug: string;
             answer: string;
             document: unknown;
-            content?: BlockData<typeof blocks>;
+            content?: FAQContentItem[];
         }
     }>;
 }
@@ -27,9 +36,9 @@ export function FAQBlock({data}: {data: FAQBlockConfig}): React.ReactElement {
             title: htmlToText(d.value.question),
             contentComponent: <>
                 <RawHTML html={d.value.answer} />
-                {d.value.content?.length
-                    ? <ContentBlockRoot data={d.value.content} blocks={blocks} />
-                    : null}
+                {(d.value.content ?? []).map((item) => isFAQImage(item)
+                    ? <Image key={item.id} image={item.value.image} alt={item.value.alt_text} />
+                    : <ContentBlockRoot key={item.id} data={[item]} blocks={blocks} />)}
             </>
         }))
     , [data]);

--- a/test/src/pages/flex-page.test.tsx
+++ b/test/src/pages/flex-page.test.tsx
@@ -117,6 +117,11 @@ describe('flex-page', () => {
         expect(screen.getAllByRole('heading')).toHaveLength(1);
         expect(screen.getAllByRole('button')).toHaveLength(1);
     });
+    it('renders faqBlock with nested content blocks', () => {
+        body = [faqBlock(true)];
+        render(<Component />);
+        expect(screen.getAllByText('Some text with')).toHaveLength(1);
+    });
     it('renders htmlBlock', () => {
         body = [htmlBlock()];
         render(<Component />);
@@ -271,7 +276,7 @@ function dividerBlock(aligned: boolean): BodyBlock {
     } as BodyBlock;
 }
 
-function faqBlock(): BodyBlock {
+function faqBlock(withContent?: boolean): BodyBlock {
     return {
         id: 'faq-id',
         type: 'faq',
@@ -282,7 +287,8 @@ function faqBlock(): BodyBlock {
                     question: 'what?',
                     slug: 'q1',
                     answer: 'hush',
-                    document: ''
+                    document: '',
+                    content: withContent ? [rtBlock()] : undefined
                 }
             }
         ]

--- a/test/src/pages/flex-page.test.tsx
+++ b/test/src/pages/flex-page.test.tsx
@@ -118,9 +118,21 @@ describe('flex-page', () => {
         expect(screen.getAllByRole('button')).toHaveLength(1);
     });
     it('renders faqBlock with nested content blocks', () => {
-        body = [faqBlock(true)];
+        body = [faqBlock([rtBlock()])];
         render(<Component />);
         expect(screen.getAllByText('Some text with')).toHaveLength(1);
+    });
+    it('renders faqBlock with nested image content', () => {
+        body = [faqBlock([{
+            id: 'faq-image-id',
+            type: 'image',
+            value: {
+                image: {file: '/foo/faq-image.jpg', width: 100, height: 50},
+                alt_text: 'faq image alt'
+            }
+        }])];
+        render(<Component />);
+        expect(screen.getByAltText('faq image alt')).not.toBe(null);
     });
     it('renders htmlBlock', () => {
         body = [htmlBlock()];
@@ -276,7 +288,7 @@ function dividerBlock(aligned: boolean): BodyBlock {
     } as BodyBlock;
 }
 
-function faqBlock(withContent?: boolean): BodyBlock {
+function faqBlock(content: Array<Record<string, unknown>> = []): BodyBlock {
     return {
         id: 'faq-id',
         type: 'faq',
@@ -288,7 +300,7 @@ function faqBlock(withContent?: boolean): BodyBlock {
                     slug: 'q1',
                     answer: 'hush',
                     document: '',
-                    content: withContent ? [rtBlock()] : undefined
+                    content
                 }
             }
         ]


### PR DESCRIPTION
## Summary
- `FAQBlock` (`src/app/pages/flex-page/blocks/FAQBlock.tsx`) is a local os-webview override for the CMS's `faq` block type — it's not part of `@openstax/flex-page-renderer`. It only ever read `question`/`answer` off each FAQ item and silently dropped anything in the newer `content` field (a list of nested flex-page blocks — e.g. a Table).
- Routes `content` through `ContentBlockRoot` (from the renderer package) with the base block registry, so nested blocks actually render inside FAQ/accordion items, alongside the existing rich-text answer.

## How this was found
Locally testing flex-pages PR #22 (new Table block) against a CMS test page (`di-tables`) that has tables nested inside FAQ items. The tables never appeared — no error, nothing in the console — because this component never looked at the `content` field at all. Confirmed the bug is independent of PR #22: a table nested in a *tabs* block (a different, renderer-owned block type) rendered fine; only FAQ-nested content was silently dropped.

## Test plan
- [x] Added a test case (`renders faqBlock with nested content blocks`) exercising the new `content` branch — `FAQBlock.tsx` is at 100% branch coverage
- [x] `yarn lint` (js/ts/css) passes
- [x] `./script/test` — 178 suites / 726 tests pass (pre-existing coverage gap in 3 unrelated files, same as before this change)
- [x] Verified locally against a real CMS page with nested table content — renders correctly against a renderer build that has the Table block; on the currently-released renderer (`1.1.16`, no Table block yet) the nested block correctly falls through to the renderer's existing "unknown block type" JSON fallback rather than silently vanishing