### PR TITLE
Bump flex-page-renderer to RC combining mobile/components + tables PRs (dev test)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.3.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@openstax/experiments": "^1.0.2",
-        "@openstax/flex-page-renderer": "^1.1.18",
+        "@openstax/flex-page-renderer": "https://github.com/openstax/flex-pages.git#renderer-1.1.19-rc.2",
         "@sentry/integrations": "^7.114.0",
         "@sentry/react": "^9.16.1",
         "@types/react-modal": "^3.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2894,10 +2894,9 @@
     "@openstax/ts-utils" "^1.2.3"
     js-cookie "^3.0.5"
 
-"@openstax/flex-page-renderer@^1.1.18":
-  version "1.1.18"
-  resolved "https://npm.pkg.github.com/download/@openstax/flex-page-renderer/1.1.18/6ae6d99edbc11a94a3be142d2f376535b4925b19#6ae6d99edbc11a94a3be142d2f376535b4925b19"
-  integrity sha512-TB5PLAui7qVafjW9/yJ1FY5T+JuvgO0nRssyS/u0o9WaMdQWS3Rmncz8CDOyAuImS3HOS00SiI9Vhn25xNgs0g==
+"@openstax/flex-page-renderer@https://github.com/openstax/flex-pages.git#renderer-1.1.19-rc.2":
+  version "1.1.19-rc.2"
+  resolved "https://github.com/openstax/flex-pages.git#96b165134a08ca7ece510395d46529ede2df9d25"
   dependencies:
     classnames "^2.5.1"
     color "^5.0.0"


### PR DESCRIPTION
## Summary
Points `@openstax/flex-page-renderer` at the `renderer-1.1.19-rc.2` git tag so this combined RC can be deployed to dev for Tom to review, without merging either underlying PR yet.

The RC combines two unmerged flex-pages PRs into one integration branch/tag (`rc/renderer-1.1.19-rc.2` in flex-pages):
- [openstax/flex-pages#27](https://github.com/openstax/flex-pages/pull/27) — mobile responsiveness + componentized page-specific CSS overrides (Well layout/heading style, Accordion accent + top border colors, Cards grid/masonry layout, color-token fixes)
- [openstax/flex-pages#22](https://github.com/openstax/flex-pages/pull/22) — new Table block

**Not a normal bump:** flex-pages switched os-webview's consumption to the GitHub Packages registry in #2936, but flex-pages itself has no publish path to GitHub Packages for RCs yet (only `1.1.18` has ever been published there). So this pins the git tag directly (the pre-#2936 mechanism) as a stopgap just for this dev test. Once whichever PRs land for real, this should go back through the registry (`^x.y.z` range) with a properly published version — don't merge this as-is.

## Test plan
- [x] `yarn lint` (js/ts/css) — clean
- [x] `CI=true ./script/build production` — compiles
- [x] `CI=true ./script/test` — 733/733 tests pass (coverage threshold flaked in 2 of 3 runs on an unrelated pre-existing toggle-focus-restore test, confirmed unrelated to this change — a clean run hits 100%)
- [ ] Deploy to dev and have Tom look at the combined pages