### PR TITLE
Bump flex-page-renderer to 1.1.19 for card border colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.3.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@openstax/experiments": "^1.0.2",
-        "@openstax/flex-page-renderer": "^1.1.18",
+        "@openstax/flex-page-renderer": "^1.1.19",
         "@sentry/integrations": "^7.114.0",
         "@sentry/react": "^9.16.1",
         "@types/react-modal": "^3.16.3",

--- a/test/src/pages/flex-page.test.tsx
+++ b/test/src/pages/flex-page.test.tsx
@@ -178,6 +178,16 @@ describe('flex-page', () => {
         expect(screen.getAllByText('1M+')).toHaveLength(1);
         expect(screen.getAllByText('learners')).toHaveLength(1);
     });
+    it('renders cardsBlock with per-card accent and divider colors', () => {
+        body = [cardsBlock(false, {accentColor: '#ff0000', dividerColor: '#00ff00'})];
+        render(<Component />);
+        expect(
+            document.querySelector('[style*="--card-accent: #ff0000"]')
+        ).not.toBe(null);
+        expect(
+            document.querySelector('[style*="--card-divider: #00ff00"]')
+        ).not.toBe(null);
+    });
 });
 
 function imageBlock(name: string) {
@@ -235,7 +245,7 @@ function ctaBlock(): BodyBlock {
     } as BodyBlock;
 }
 
-function cardsBlock(withStyle?: boolean): BodyBlock {
+function cardsBlock(withStyle?: boolean, cardColors?: {accentColor: string; dividerColor: string}): BodyBlock {
     return {
         id: 'cards-id',
         type: 'cards_block',
@@ -243,6 +253,7 @@ function cardsBlock(withStyle?: boolean): BodyBlock {
             cards: [
                 {
                     text: 'first card',
+                    ...cardColors,
                     ctaBlock: withStyle ? [{
                         config: [
                             {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2894,10 +2894,10 @@
     "@openstax/ts-utils" "^1.2.3"
     js-cookie "^3.0.5"
 
-"@openstax/flex-page-renderer@^1.1.18":
-  version "1.1.18"
-  resolved "https://npm.pkg.github.com/download/@openstax/flex-page-renderer/1.1.18/6ae6d99edbc11a94a3be142d2f376535b4925b19#6ae6d99edbc11a94a3be142d2f376535b4925b19"
-  integrity sha512-TB5PLAui7qVafjW9/yJ1FY5T+JuvgO0nRssyS/u0o9WaMdQWS3Rmncz8CDOyAuImS3HOS00SiI9Vhn25xNgs0g==
+"@openstax/flex-page-renderer@^1.1.19":
+  version "1.1.19"
+  resolved "https://npm.pkg.github.com/download/@openstax/flex-page-renderer/1.1.19/fab2ec9bb8d14379fdec044a7fd81b19211e3f0a#fab2ec9bb8d14379fdec044a7fd81b19211e3f0a"
+  integrity sha512-HR+0g6iahrB1KqK15zjzJ/CD+hf9FYNCdKGZ8TCrsXYnj0sXN/U1VAHYTM1KCpjPlp9103eD1DAftEpJVzJB0w==
   dependencies:
     classnames "^2.5.1"
     color "^5.0.0"


### PR DESCRIPTION
## Summary
- Bumps `@openstax/flex-page-renderer` from `^1.1.18` to `^1.1.19`.
- `1.1.19` folds in flex-pages [#5](https://github.com/openstax/flex-pages/pull/5) (cards block spacing/grid/border, per-card accent & divider colors), [#28](https://github.com/openstax/flex-pages/pull/28) (content-level tabs), and [#29](https://github.com/openstax/flex-pages/pull/29) (Section/Hero top/bottom border options) 
- Adds a render test asserting `cards_block` sets `--card-accent` / `--card-divider` custom properties when a card has `accentColor`/`dividerColor` configured.