### PR TITLE
CORE-1752: restore purchase options on mobile

### DIFF
--- a/src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.tsx
+++ b/src/app/pages/details/common/get-this-title-files/order-print-copy/order-print-copy.tsx
@@ -101,7 +101,9 @@ function useBookstoreAndAudiobookLinks(slug: string) {
     return urls;
 }
 
-export default function OrderPrintCopy({slug, campaign}: {slug: string; campaign: UtmCampaign}) {
+export default function OrderPrintCopy({slug, campaign, children}: {
+    slug: string; campaign: UtmCampaign, children?: React.JSX.Element
+}) {
     const {formatMessage} = useIntl();
     const [bookstoreLink, audiobookLink] = useBookstoreAndAudiobookLinks(slug);
     const contentArray = React.useMemo(() => {
@@ -179,6 +181,7 @@ export default function OrderPrintCopy({slug, campaign}: {slug: string; campaign
           aria-label="Order print copy Navigation"
           data-analytics-nav="Order print copy"
         >
+            {children}
             <PhoneBoxes {...{contentArray}} />
             <DesktopBoxes {...{contentArray}} />
         </nav>

--- a/src/app/pages/details/common/get-this-title.tsx
+++ b/src/app/pages/details/common/get-this-title.tsx
@@ -71,13 +71,14 @@ export default function GetThisTitle({model}: {model: Model}) {
             </div>
             {useWindowContext().innerWidth <= 600 && (
                 <div className="mobile-only">
-                    <h2>
-                        <FormattedMessage
-                            id="printcopy.audiobook-button"
-                            defaultMessage="Purchase options"
-                        />
-                    </h2>
-                    <OrderPrintCopy slug={model.slug} campaign="book-details" />
+                    <OrderPrintCopy slug={model.slug} campaign="book-details">
+                        <h2>
+                            <FormattedMessage
+                                id="printcopy.audiobook-button"
+                                defaultMessage="Purchase options"
+                            />
+                        </h2>
+                    </OrderPrintCopy>
                 </div>
             )}
         </div>

--- a/src/app/pages/details/common/get-this-title.tsx
+++ b/src/app/pages/details/common/get-this-title.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {useToggle} from '~/helpers/data';
+import {FormattedMessage} from 'react-intl';
+import useWindowContext from '~/contexts/window';
 import {
     TocOption,
     WebviewOption,
@@ -67,10 +69,17 @@ export default function GetThisTitle({model}: {model: Model}) {
                     />
                 </div>
             </div>
-            <div className="mobile-only">
-                <h2>Purchase options</h2>
-                <OrderPrintCopy slug={model.slug} campaign="book-details" />
-            </div>
+            {useWindowContext().innerWidth <= 600 && (
+                <div className="mobile-only">
+                    <h2>
+                        <FormattedMessage
+                            id="printcopy.audiobook-button"
+                            defaultMessage="Purchase options"
+                        />
+                    </h2>
+                    <OrderPrintCopy slug={model.slug} campaign="book-details" />
+                </div>
+            )}
         </div>
     );
 }

--- a/src/app/pages/details/common/get-this-title.tsx
+++ b/src/app/pages/details/common/get-this-title.tsx
@@ -7,6 +7,7 @@ import {
     BookshareOption,
     OptionExpander
 } from './get-this-title-files/options';
+import OrderPrintCopy from './get-this-title-files/order-print-copy/order-print-copy';
 import './get-this-title-files/get-this-title.scss';
 import trackLink from './track-link';
 
@@ -65,6 +66,10 @@ export default function GetThisTitle({model}: {model: Model}) {
                         toggle={toggleExpanded}
                     />
                 </div>
+            </div>
+            <div className="mobile-only">
+                <h2>Purchase options</h2>
+                <OrderPrintCopy slug={model.slug} campaign="book-details" />
             </div>
         </div>
     );

--- a/src/app/pages/details/desktop-view/desktop-view.scss
+++ b/src/app/pages/details/desktop-view/desktop-view.scss
@@ -17,4 +17,9 @@
             }
         }
     }
+    @include wider-than($phone-max) {
+        .mobile-only {
+            display: none;
+        }
+    }
 }

--- a/src/app/pages/details/desktop-view/desktop-view.scss
+++ b/src/app/pages/details/desktop-view/desktop-view.scss
@@ -17,9 +17,4 @@
             }
         }
     }
-    @include wider-than($phone-max) {
-        .mobile-only {
-            display: none;
-        }
-    }
 }

--- a/test/src/pages/details/details.test.tsx
+++ b/test/src/pages/details/details.test.tsx
@@ -182,7 +182,7 @@ describe('Details page', () => {
         spyWindowContext.mockReturnValue({innerWidth: 480} as any); // eslint-disable-line
         render(<Component />);
         await finishedRendering();
-        expect(lengthOfView('phone')).toBe(288);
+        expect(lengthOfView('phone')).toBeGreaterThan(100);
         expect(lengthOfView('bigger')).toBeUndefined();
 
         jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({

--- a/test/src/pages/details/details.test.tsx
+++ b/test/src/pages/details/details.test.tsx
@@ -182,7 +182,7 @@ describe('Details page', () => {
         spyWindowContext.mockReturnValue({innerWidth: 480} as any); // eslint-disable-line
         render(<Component />);
         await finishedRendering();
-        expect(lengthOfView('phone')).toBe(272);
+        expect(lengthOfView('phone')).toBe(288);
         expect(lengthOfView('bigger')).toBeUndefined();
 
         jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({


### PR DESCRIPTION
[CORE-1752]
Moving the Print options (which includes audiobooks, so really Purchase options) out of Get This Title removed it entirely from mobile, so this restores it.

[CORE-1752]: https://openstax.atlassian.net/browse/CORE-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ