### PR TITLE
Run JavaScript in flex-page HTML blocks

### DIFF
--- a/src/app/components/jsx-helpers/raw-html.tsx
+++ b/src/app/components/jsx-helpers/raw-html.tsx
@@ -57,7 +57,10 @@ export default function RawHTML({
         if (embed && ref.current) {
             activateScripts(ref.current);
         }
-    });
+        // Only when the markup itself changes; React leaves the DOM (and the
+        // already-activated scripts) alone on re-renders with the same html,
+        // so re-running would execute embedded scripts a second time.
+    }, [embed, html]);
     React.useLayoutEffect(() => rewriteLinks?.(ref.current as HTMLElement), [rewriteLinks]);
 
     return React.createElement(Tag, {

--- a/src/app/components/jsx-helpers/raw-html.tsx
+++ b/src/app/components/jsx-helpers/raw-html.tsx
@@ -61,7 +61,7 @@ export default function RawHTML({
         // already-activated scripts) alone on re-renders with the same html,
         // so re-running would execute embedded scripts a second time.
     }, [embed, html]);
-    React.useLayoutEffect(() => rewriteLinks?.(ref.current as HTMLElement), [rewriteLinks]);
+React.useLayoutEffect(() => rewriteLinks?.(ref.current as HTMLElement), [rewriteLinks, html]);
 
     return React.createElement(Tag, {
         ref,

--- a/src/app/pages/flex-page/block-map.ts
+++ b/src/app/pages/flex-page/block-map.ts
@@ -1,13 +1,22 @@
 /* eslint-disable camelcase */
+import React from 'react';
 import * as blocks from '@openstax/flex-page-renderer/blocks/index';
+import RawHTML from '~/components/jsx-helpers/raw-html';
 import {FAQBlock} from './blocks/FAQBlock';
 import {BookListBlock} from './blocks/BookListBlock';
+
+// The renderer's html block sets the markup with dangerouslySetInnerHTML, and
+// innerHTML never executes <script> tags. RawHTML's `embed` mode re-creates them
+// as fresh nodes so JavaScript authored in an html block actually runs.
+const HTMLBlock = ({data}: {data: {value: string}}) =>
+    React.createElement(RawHTML, {embed: true, html: data.value});
 
 // flex-page-renderer >=1.1.5 expects each block as a {Component, config} pair
 // (it reads def.Component at render time). Our local custom blocks still use the
 // older "component function + static .blockConfig" shape, so wrap them here.
 export const blockMap = {
     ...blocks,
+    html: {Component: HTMLBlock, config: blocks.html.config},
     faq: {Component: FAQBlock, config: FAQBlock.blockConfig},
     book_list: {Component: BookListBlock, config: BookListBlock.blockConfig}
 } as const;

--- a/test/src/pages/flex-page.test.tsx
+++ b/test/src/pages/flex-page.test.tsx
@@ -141,10 +141,15 @@ describe('flex-page', () => {
     });
     it('runs scripts in htmlBlock', async () => {
         const w = window as unknown as {flexScriptRan?: boolean};
+        w.flexScriptRan = false;
 
-        body = [htmlBlock('<script>window.flexScriptRan = true;</script>')];
-        render(<Component />);
-        await waitFor(() => expect(w.flexScriptRan).toBe(true));
+        try {
+            body = [htmlBlock('<script>window.flexScriptRan = true;</script>')];
+            render(<Component />);
+            await waitFor(() => expect(w.flexScriptRan).toBe(true));
+        } finally {
+            w.flexScriptRan = undefined;
+        }
     });
     it('renders linksBlock and sectionBlock', async () => {
         jest.spyOn(window, 'scrollBy').mockImplementation(() => null);

--- a/test/src/pages/flex-page.test.tsx
+++ b/test/src/pages/flex-page.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ShellContextProvider from '~/../../test/helpers/shell-context';
-import {render, screen} from '@testing-library/preact';
+import {render, screen, waitFor} from '@testing-library/preact';
 import {describe, it} from '@jest/globals';
 import userEvent from '@testing-library/user-event';
 import MemoryRouter from '~/../../test/helpers/future-memory-router';
@@ -138,6 +138,13 @@ describe('flex-page', () => {
         body = [htmlBlock()];
         render(<Component />);
         expect(screen.getAllByText('Some html')).toHaveLength(1);
+    });
+    it('runs scripts in htmlBlock', async () => {
+        const w = window as unknown as {flexScriptRan?: boolean};
+
+        body = [htmlBlock('<script>window.flexScriptRan = true;</script>')];
+        render(<Component />);
+        await waitFor(() => expect(w.flexScriptRan).toBe(true));
     });
     it('renders linksBlock and sectionBlock', async () => {
         jest.spyOn(window, 'scrollBy').mockImplementation(() => null);
@@ -322,11 +329,11 @@ function faqBlock(content: Array<Record<string, unknown>> = []): BodyBlock {
     } as BodyBlock;
 }
 
-function htmlBlock(): BodyBlock {
+function htmlBlock(value = '<p>Some html</p>'): BodyBlock {
     return {
         id: 'html-id',
         type: 'html',
-        value: '<p>Some html</p>'
+        value
     } as BodyBlock;
 }
 


### PR DESCRIPTION
Branches off #2954 (`bump-flex-renderer-1.1.22-rc.4`), so review that one first.

## Problem

JavaScript in a flex-page HTML block never runs.

Sanitization is not the cause. `HTMLBlock.component.tsx` renders `<Html sanitize={false} …>`, so DOMPurify never sees the markup and the `<script>` tag does land in the DOM. But `Html` sets it with `dangerouslySetInnerHTML`, and [per the HTML spec](https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model) a `<script>` inserted via `innerHTML` is flagged non-executable. It sits there inert.

Other suspects checked and cleared: `openstax-cms` doesn't sanitize flex-page block JSON, `mapPageNodes` deliberately doesn't sanitize, and os-webview ships no CSP.

## Change

**`block-map.ts`** — override the `html` entry to route through the existing `RawHTML` `embed` component, which walks the container and re-creates each `<script>` as a fresh node (external scripts chained in order). Non-flex CMS pages (`general.tsx`, blog video embeds) have used that path for years, and `block-map.ts` is already the sanctioned override point for local blocks (`faq`, `book_list`). One map entry plus a four-line component.

**`raw-html.tsx`** — scope the activate-scripts effect to `[embed, html]`. It had no dep array, so it re-ran on every render and re-executed embedded scripts. Barely visible on a mostly-static general page; on a flex page, which re-renders on layout/portal context changes, an analytics or embed script would fire repeatedly. Fixed in the shared component, so all four callers benefit.

## Testing

- New test `runs scripts in htmlBlock` in `test/src/pages/flex-page.test.tsx`. Verified it fails with the `block-map` override removed and passes with it in place.
- `yarn test` — 732 passed. Coverage reports 99.93% global against the 100% threshold; that shortfall is **pre-existing** (identical numbers on a stashed tree — offenders are `school-selector`, `toggle`, and several `types.ts` files). Both changed source files are at 100%.
- `yarn lint:ts` and `yarn lint:js` clean.

## Two things to know

**`document.write` embeds still won't work.** Some older third-party snippets call it after load, which blows away the document. Not fixable here — those need an iframe.

**This makes the html block a real JS execution surface for CMS editors.** The block was already `sanitize={false}`, so the trust decision predates this PR, but it's worth flagging to whoever owns CMS permissions: a compromised editor account goes from "inject inert markup" to "run anything on openstax.org." The block's author-facing description already says *"Avoid using it as an escape hatch for unsupported designs — reach out to the developers instead."*

## Alternative considered

Fixing it upstream in `flex-pages` so every consumer benefits. `Html.tsx` there is a deliberately zero-JS server component, so it would need a `'use client'` sibling (the pattern `RawHtmlWithLinks` uses) plus a renderer tag and a version bump — and os-webview is the renderer's only production consumer. Happy to move it upstream instead if that's preferred.