### PR TITLE
Give blank accordion titles a valid uuid

### DIFF
--- a/src/app/components/accordion-group/accordion-group.tsx
+++ b/src/app/components/accordion-group/accordion-group.tsx
@@ -75,9 +75,10 @@ function TitleBar({
 
 // A blank title cleans to '', which react-accessible-accordion rejects at
 // runtime ("uuid must be a valid HTML5 id"), so fall back to the item's
-// position. Mirrors the flex renderer's AccordionBlock `toAnchorId`.
+// position. Keep the fallback format consistent with the cleaning regex so
+// values returned from onChange can be passed back via preExpanded.
 function toUuid(name: string, index: number) {
-    return name.replace(/\W+/g, '_') || `item-${index}`;
+    return name.replace(/\W+/g, '_') || `item_${index}`;
 }
 
 function Item({

--- a/src/app/components/accordion-group/accordion-group.tsx
+++ b/src/app/components/accordion-group/accordion-group.tsx
@@ -73,8 +73,11 @@ function TitleBar({
     );
 }
 
-function toUuid(name: string) {
-    return name.replace(/\W+/g, '_');
+// A blank title cleans to '', which react-accessible-accordion rejects at
+// runtime ("uuid must be a valid HTML5 id"), so fall back to the item's
+// position. Mirrors the flex renderer's AccordionBlock `toAnchorId`.
+function toUuid(name: string, index: number) {
+    return name.replace(/\W+/g, '_') || `item-${index}`;
 }
 
 function Item({
@@ -82,12 +85,14 @@ function Item({
     titleTag,
     checkChevronDirection,
     contentComponent,
-    analytics
+    analytics,
+    index
 }: Omit<Parameters<typeof TitleBar>[0], 'chevronDirection'> & {
     contentComponent: React.ReactNode;
     checkChevronDirection: (u: string) => ChevronDirection;
+    index: number;
 }) {
-    const uuid = toUuid(title);
+    const uuid = toUuid(title, index);
     const chevronDirection = checkChevronDirection(uuid);
 
     return (
@@ -130,7 +135,7 @@ export default function AccordionGroup({
     'data-analytics-nav'?: string;
 }) {
     const root = React.useRef<HTMLDivElement>(null);
-    const preExpandedUuids = preExpanded.map(toUuid);
+    const preExpandedUuids = preExpanded.map((name, i) => toUuid(name, i));
     const [chevronDirection, onChange] = useChevronDirection(
         forwardOnChange,
         preExpandedUuids
@@ -163,11 +168,12 @@ export default function AccordionGroup({
                 data-analytics-nav={analyticsNav}
             >
                 {items.filter((i) => 'title' in i).map(
-                    (item) => (
+                    (item, index) => (
                         <Item
                             analytics={!!analyticsNav}
-                            key={item.title}
+                            key={item.title || index}
                             {...item}
+                            index={index}
                             checkChevronDirection={chevronDirection}
                         />
                     )

--- a/test/src/components/accordion-group.test.tsx
+++ b/test/src/components/accordion-group.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {render, screen} from '@testing-library/preact';
+import {describe, it, expect} from '@jest/globals';
+import AccordionGroup from '~/components/accordion-group/accordion-group';
+
+describe('components/accordion-group', () => {
+    it('gives blank titles a valid uuid', () => {
+        const error = jest.spyOn(console, 'error').mockImplementation(() => null);
+
+        render(
+            <AccordionGroup
+                items={[
+                    {title: '', contentComponent: <div>first answer</div>},
+                    {title: '', contentComponent: <div>second answer</div>}
+                ]}
+            />
+        );
+
+        // react-accessible-accordion console.errors on an empty uuid
+        expect(error).not.toHaveBeenCalled();
+        expect(screen.getAllByRole('button')).toHaveLength(2);
+        error.mockRestore();
+    });
+    it('derives uuids from titles', () => {
+        render(
+            <AccordionGroup
+                items={[{title: 'my cool accordion', contentComponent: <div>answer</div>}]}
+                preExpanded={['my cool accordion']}
+            />
+        );
+        expect(
+            screen.getByRole('button').getAttribute('aria-expanded')
+        ).toBe('true');
+    });
+});


### PR DESCRIPTION
Fixes the `uuid must be a valid HTML5 id but was given ""` console error seen on flex pages.

Based on `main` — independent of #2954 / #2956, so it can ship on its own.

## Root cause

`AccordionGroup` derives each item's uuid from its title:

```ts
name.replace(/\W+/g, '_')
```

Every non-empty title yields something usable — word characters survive, everything else collapses to `_`, so whitespace can never leak into the id. The one input that breaks is an **empty** title, which cleans to `''`. `react-accessible-accordion` validates the uuid and `console.error`s on an empty one ([`assertValidHtmlId`](https://github.com/springload/react-accessible-accordion/blob/master/src/helpers/uuid.ts)), once per affected item. Note it discards the validation result, so the item still renders — with an invalid id, and colliding with any other blank-titled item.

The path in practice: a flex-page FAQ block with a blank question. `FAQBlock` builds titles with `htmlToText(d.value.question)`, and `htmlToText` returns `''` for empty rich text.

## Fix

Fall back to `item-<index>`:

```ts
function toUuid(name: string, index: number) {
    return name.replace(/\W+/g, '_') || `item-${index}`;
}
```

This mirrors the flex renderer's own `AccordionBlock`, which solves the identical problem with `cleaned || \`item-${index}\`` in `toAnchorId` — same pattern, same reasoning.

Fixed in `AccordionGroup` rather than in `FAQBlock`, since every accordion on the site routes through this one function (team, subjects, press FAQ, research, partners, details phone view…). The cleaning algorithm itself is untouched, so the three callers that pass `preExpanded` keep matching as before.

Also keys blank-titled items by index — two of them previously collided on the same empty React key.

## Testing

New `test/src/components/accordion-group.test.tsx` (this component had no direct test before):
- **`gives blank titles a valid uuid`** — asserts no `console.error`. Verified it fails without the fallback, logging the exact production error twice, once per item.
- **`derives uuids from titles`** — pins the existing title→uuid behavior via `preExpanded`, so a future change to the cleaning regex can't silently break pre-expansion.

`yarn lint:ts` and `yarn lint:js` clean. Full suite green, and this closes the pre-existing coverage gap that had `global` sitting at 99.93%.

<sub>One note on local verification: my `node_modules` had renderer `1.1.22-rc.4` installed from the RC branch while `main` pins `^1.1.19`, which makes `flex-page.test.tsx › renders cardsBlock with per-card accent and divider colors` fail locally. I confirmed that failure reproduces on a clean `origin/main` checkout with the same `node_modules`, so it's an artifact of my install, not this change. CI installs main's pin.</sub>