### PR TITLE
Make Sentry actually useful: source maps, context, stale-chunk recovery, SDK v10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
         name: "Build osweb"
         run: ./script/build production
       -
+        name: "Read osweb version"
+        id: osweb_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      -
         name: "Run tests"
         run: ./script/test
       -
@@ -46,6 +50,28 @@ jobs:
           directory: dist
           project-id: ${{ secrets.POSTHOG_PROJECT_ID }}
           api-key: ${{ secrets.POSTHOG_CLI_API_KEY }}
+      -
+        # Uploads the .map files to Sentry under the same release name sentry.js
+        # reports (osweb@<package.json version>), so exceptions resolve to real
+        # source instead of minified bundles. Runs after the PostHog upload so
+        # Sentry's debug IDs are injected into the assets we actually ship.
+        # Symbolication is a diagnostic aid, so a failure here should never
+        # block a release.
+        name: "Upload source maps to Sentry"
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        continue-on-error: true
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          release: "osweb@${{ steps.osweb_version.outputs.version }}"
+          sourcemaps: ./dist
+          url_prefix: "~/dist"
+          # actions/checkout is shallow here, so commit association would fail
+          # before the upload ever runs.
+          set_commits: skip
       -
         name: Install SSH key
         uses: shimataro/ssh-key-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ coverage/
 yarn-error.log
 .idea
 Brewfile.lock.json
+
+# Local tooling and secrets, never committed
+.env
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,12 @@ Main routes in `router.tsx`:
 - Noise filtering lives in three lists there: `ignoreErrors` (exact messages), `ignoreMessages`
   (substring match, applied in `beforeSend`), and `denyUrls` (script origin). Use `denyUrls`,
   not `ignoreUrls` — the latter was removed in SDK v7 and silently does nothing.
-- Integrations come from `@sentry/react` (v9). Do not add `@sentry/integrations`; it pulls a
+- Integrations come from `@sentry/react` (v10). Do not add `@sentry/integrations`; it pulls a
   second copy of the SDK core into the bundle. `dedupe` is already on by default.
+- Errors only — no tracing, replay, or feedback. `browserTracingIntegration` is deliberately
+  absent, and the production webpack config defines `__SENTRY_TRACING__` and `__SENTRY_DEBUG__`
+  as `false` so that code is stripped rather than merely unused. Adding a tracing integration
+  back without removing those defines will silently not work.
 - Render errors surface through `useErrorBoundary` in `shell/router-context.tsx`. That hook
   swallows the error unless a handler is passed, so the `Sentry.captureException` callback
   there is load-bearing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,6 @@ Main routes in `router.tsx`:
 - Strict mode enabled, target ES6, module ES2020
 - Gradually migrating from JS/JSX to TS/TSX
 
-## Planning docs
-
-Planning and spec docs for this repo live in the Obsidian vault at `Hubs/OpenStax/os-webview/plans/` (and `specs/`), not in this repo.
-
 ## Error reporting (Sentry)
 
 - `src/app/sentry.js` is the only `Sentry.init` — imported first by `main.js`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,3 +99,25 @@ Main routes in `router.tsx`:
 ### TypeScript
 - Strict mode enabled, target ES6, module ES2020
 - Gradually migrating from JS/JSX to TS/TSX
+
+## Planning docs
+
+Planning and spec docs for this repo live in the Obsidian vault at `Hubs/OpenStax/os-webview/plans/` (and `specs/`), not in this repo.
+
+## Error reporting (Sentry)
+
+- `src/app/sentry.js` is the only `Sentry.init` — imported first by `main.js`.
+- `beforeSend` drops everything except `openstax.org`, so dev/staging errors never reach Sentry.
+- Noise filtering lives in three lists there: `ignoreErrors` (exact messages), `ignoreMessages`
+  (substring match, applied in `beforeSend`), and `denyUrls` (script origin). Use `denyUrls`,
+  not `ignoreUrls` — the latter was removed in SDK v7 and silently does nothing.
+- Integrations come from `@sentry/react` (v9). Do not add `@sentry/integrations`; it pulls a
+  second copy of the SDK core into the bundle. `dedupe` is already on by default.
+- Render errors surface through `useErrorBoundary` in `shell/router-context.tsx`. That hook
+  swallows the error unless a handler is passed, so the `Sentry.captureException` callback
+  there is load-bearing.
+- User context (uuid, `logged_in`, `user_role`) is attached in `contexts/user.ts`. Keep names
+  and emails out of it.
+- Source maps upload from `build.yml` on `main` and tags, under release `osweb@<package.json
+  version>` — that must stay in sync with `release` in `sentry.js`. Needs the
+  `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` repo secrets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,9 @@ All state management uses React Context (no Redux). Key contexts in `src/app/con
 ### Code Splitting
 - `src/app/helpers/jit-load.tsx` — lazy loading wrapper using `React.lazy` + `Suspense`
 - Webpack splits vendor chunks per-package
+- Production chunk names are content-hashed, so a deploy invalidates all ~500 of them. A tab
+  opened before a deploy 404s on the next chunk it requests; `src/app/helpers/stale-chunk.ts`
+  detects that and reloads (at most twice per tab, tracked in sessionStorage).
 
 ### Routing
 Main routes in `router.tsx`:
@@ -118,6 +121,8 @@ Planning and spec docs for this repo live in the Obsidian vault at `Hubs/OpenSta
   there is load-bearing.
 - User context (uuid, `logged_in`, `user_role`) is attached in `contexts/user.ts`. Keep names
   and emails out of it.
+- Chunk-load failures are recovered from rather than reported — see `stale-chunk.ts`. They stay
+  in the ignore lists because Sentry's own global handlers capture them before the reload runs.
 - Source maps upload from `build.yml` on `main` and tags, under release `osweb@<package.json
   version>` — that must stay in sync with `release` in `sentry.js`. Needs the
   `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` repo secrets.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@openstax/experiments": "^1.0.2",
         "@openstax/flex-page-renderer": "^1.1.19",
-        "@sentry/integrations": "^7.114.0",
         "@sentry/react": "^9.16.1",
         "@types/react-modal": "^3.16.3",
         "add-to-calendar-button-react": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@openstax/experiments": "^1.0.2",
         "@openstax/flex-page-renderer": "https://github.com/openstax/flex-pages.git#renderer-1.1.24",
-        "@sentry/react": "^9.16.1",
+        "@sentry/react": "^10",
         "@types/react-modal": "^3.16.3",
         "add-to-calendar-button-react": "^2.14.0",
         "babel-plugin-formatjs": "^10.4.0",

--- a/src/app/components/shell/router-context.tsx
+++ b/src/app/components/shell/router-context.tsx
@@ -1,8 +1,13 @@
 import {useErrorBoundary} from 'preact/hooks';
+import * as Sentry from '@sentry/react';
 import buildContext from '~/components/jsx-helpers/build-context';
 
 function useContextValue() {
-    useErrorBoundary();
+    // Without a handler, useErrorBoundary swallows every render error in the
+    // route tree and Sentry never sees it.
+    useErrorBoundary((error) => {
+        Sentry.captureException(error);
+    });
 
     return {};
 }

--- a/src/app/components/shell/router-context.tsx
+++ b/src/app/components/shell/router-context.tsx
@@ -1,12 +1,15 @@
 import {useErrorBoundary} from 'preact/hooks';
 import * as Sentry from '@sentry/react';
+import recoverFromStaleChunk from '~/helpers/stale-chunk';
 import buildContext from '~/components/jsx-helpers/build-context';
 
 function useContextValue() {
     // Without a handler, useErrorBoundary swallows every render error in the
     // route tree and Sentry never sees it.
     useErrorBoundary((error) => {
-        Sentry.captureException(error);
+        if (!recoverFromStaleChunk(error)) {
+            Sentry.captureException(error);
+        }
     });
 
     return {};

--- a/src/app/contexts/user.ts
+++ b/src/app/contexts/user.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as Sentry from '@sentry/react';
 import buildContext from '~/components/jsx-helpers/build-context';
 import {useUserModel, UserModelType} from '~/models/usermodel';
 import useMyOpenStaxUser from '~/models/myopenstax-user';
@@ -38,6 +39,14 @@ function getUserStatus(user: Partial<UserModelType>) {
         uuid: user.uuid,
         trackDownloads
     };
+}
+
+function roleTag({isInstructor, isStudent}: UserStatus) {
+    if (isInstructor) {
+        return 'instructor';
+    }
+
+    return isStudent ? 'student' : 'anonymous';
 }
 
 function useContextValue() {
@@ -80,6 +89,13 @@ function useContextValue() {
             w.pi?.('identify_client', model.id);
         }
     }, [model]);
+
+    React.useEffect(() => {
+        // uuid only -- name and email would put PII in every Sentry event
+        Sentry.setUser(userStatus.uuid ? {id: userStatus.uuid} : null);
+        Sentry.setTag('logged_in', isLoggedIn);
+        Sentry.setTag('user_role', roleTag(userStatus));
+    }, [userStatus, isLoggedIn]);
 
     return value;
 }

--- a/src/app/helpers/cms-fetch.ts
+++ b/src/app/helpers/cms-fetch.ts
@@ -5,7 +5,8 @@ export default async function cmsFetch(path: string) {
     const url = path.replace(/[^?]+/, urlFromSlug);
 
     try {
-        return (await retry(() => fetch(url))).json();
+        // `await` is required: without it .json() rejects outside the try
+        return await (await retry(() => fetch(url))).json();
     } catch (err) {
         return Promise.reject(new Error(`Failed to fetch ${path}: ${err}`));
     }

--- a/src/app/helpers/page-data-utils.ts
+++ b/src/app/helpers/page-data-utils.ts
@@ -156,12 +156,29 @@ export function useDataFromPromise<T = Json>(
     const [data, setData] = React.useState<T | null | undefined>(defaultValue);
 
     React.useEffect(() => {
+        let cancelled = false;
+
         if (promise) {
             // Swallow rejections; a failed fetch reads the same as "no data"
-            promise.then(setData, () => setData(null));
+            promise.then(
+                (resolved) => {
+                    if (!cancelled) {
+                        setData(resolved);
+                    }
+                },
+                () => {
+                    if (!cancelled) {
+                        setData(null);
+                    }
+                }
+            );
         } else {
             setData(null);
         }
+
+        return () => {
+            cancelled = true;
+        };
     }, [promise]);
 
     return data;

--- a/src/app/helpers/page-data-utils.ts
+++ b/src/app/helpers/page-data-utils.ts
@@ -157,7 +157,8 @@ export function useDataFromPromise<T = Json>(
 
     React.useEffect(() => {
         if (promise) {
-            promise.then(setData);
+            // Swallow rejections; a failed fetch reads the same as "no data"
+            promise.then(setData, () => setData(null));
         } else {
             setData(null);
         }

--- a/src/app/helpers/stale-chunk.ts
+++ b/src/app/helpers/stale-chunk.ts
@@ -1,0 +1,68 @@
+// A production deploy renames every content-hashed chunk, so a tab that was
+// opened before it 404s on the next chunk it asks for. Reloading picks up the
+// new index.html and its new chunk names; the counter stops a genuinely broken
+// deploy from spinning the tab.
+const RELOAD_KEY = 'osweb-stale-chunk-reloads';
+const MAX_RELOADS = 2;
+
+function reloadsSoFar() {
+    try {
+        return Number(window.sessionStorage.getItem(RELOAD_KEY)) || 0;
+    } catch {
+        // Storage is blocked (Safari private browsing); without a counter we
+        // cannot rule out a reload loop, so decline to reload at all.
+        return MAX_RELOADS;
+    }
+}
+
+function isChunkLoadError(error: unknown) {
+    const {name, message} = (error ?? {}) as Partial<Error>;
+
+    return name === 'ChunkLoadError' || (/Loading chunk \S+ failed/i).test(message ?? '');
+}
+
+// A missing chunk that the server answers with an HTML page parses as markup,
+// not script. That surfaces as a SyntaxError against the chunk's own url.
+function isOurScript(url: string) {
+    try {
+        const {origin, pathname} = new URL(url);
+
+        return origin === window.location.origin && pathname.startsWith('/dist/');
+    } catch {
+        return false;
+    }
+}
+
+function reload() {
+    try {
+        window.sessionStorage.setItem(RELOAD_KEY, String(reloadsSoFar() + 1));
+    } catch {
+        return false;
+    }
+    window.location.reload();
+
+    return true;
+}
+
+function reloadOnce() {
+    return reloadsSoFar() < MAX_RELOADS && reload();
+}
+
+// Returns true when it has taken over recovery, so callers know not to also
+// report the error.
+export default function recoverFromStaleChunk(error: unknown) {
+    return isChunkLoadError(error) && reloadOnce();
+}
+
+export function handleScriptError(event: ErrorEvent) {
+    if (event.error instanceof SyntaxError && isOurScript(event.filename)) {
+        reloadOnce();
+    }
+}
+
+export function listenForStaleChunks() {
+    window.addEventListener('error', handleScriptError);
+    window.addEventListener('unhandledrejection', (event) =>
+        recoverFromStaleChunk(event.reason)
+    );
+}

--- a/src/app/helpers/use-data.ts
+++ b/src/app/helpers/use-data.ts
@@ -64,8 +64,18 @@ export function usePromise<T>(promise: Promise<T>, defaultValue: T) {
     const [data, setData] = React.useState(defaultValue);
 
     React.useEffect(() => {
+        let cancelled = false;
+
         // Swallow rejections; callers keep the last good value (or the default)
-        promise.then(setData, () => null);
+        promise.then((value) => {
+            if (!cancelled) {
+                setData(value);
+            }
+        }, () => null);
+
+        return () => {
+            cancelled = true;
+        };
     }, [promise]);
 
     return data;

--- a/src/app/helpers/use-data.ts
+++ b/src/app/helpers/use-data.ts
@@ -64,7 +64,8 @@ export function usePromise<T>(promise: Promise<T>, defaultValue: T) {
     const [data, setData] = React.useState(defaultValue);
 
     React.useEffect(() => {
-        promise.then(setData);
+        // Swallow rejections; callers keep the last good value (or the default)
+        promise.then(setData, () => null);
     }, [promise]);
 
     return data;

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,10 +1,13 @@
 import './sentry';
+import {listenForStaleChunks} from '~/helpers/stale-chunk';
 import cmsFetch from '~/helpers/cms-fetch';
 import {render} from 'preact';
 
 const GLOBAL_SETTINGS = ['piAId', 'piCId', 'piHostname'];
 
 window.SETTINGS = {};
+
+listenForStaleChunks();
 
 (async () => {
     const settings = (await cmsFetch('webview-settings')).settings;

--- a/src/app/pages/faq/faq.tsx
+++ b/src/app/pages/faq/faq.tsx
@@ -20,11 +20,15 @@ function useDocModel(docId: string) {
 
         fetch(url, {credentials: 'include'})
             .then((r) => r.json())
-            .then((r) =>
-                setDocData({
-                    title: r.title,
-                    file: r.meta.download_url
-                })
+            .then(
+                (r) =>
+                    setDocData({
+                        title: r.title,
+                        file: r.meta.download_url
+                    }),
+                // A document that will not load renders as no download link,
+                // which is what a missing title already does.
+                () => setDocData({})
             );
     }, [docId]);
 

--- a/src/app/sentry.js
+++ b/src/app/sentry.js
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-import * as Integrations from '@sentry/integrations';
 import isSupported from '~/helpers/device';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -55,7 +54,7 @@ const ignoreMessages = [
     't.behaviors.embed.embed'
 ];
 
-const ignoreUrls = [
+const denyUrls = [
     'https://www.google-analytics.com/analytics.js',
     'https://js.pulseinsights.com'
 ];
@@ -98,13 +97,12 @@ Sentry.init({
     dsn: 'https://68df3e19624c434eb975dafa316c03ff@o484761.ingest.sentry.io/5691260',
     release: `osweb@${packageVersion}`,
     integrations: [
-        Integrations.extraErrorDataIntegration(),
-        Integrations.dedupeIntegration(),
+        Sentry.extraErrorDataIntegration(),
         Sentry.browserTracingIntegration()
     ],
     tracesSampleRate: 0.05,
     environment: window.location.hostname,
     ignoreErrors,
-    ignoreUrls,
+    denyUrls,
     beforeSend
 });

--- a/src/app/sentry.js
+++ b/src/app/sentry.js
@@ -96,11 +96,7 @@ function beforeSend(event, hint) {
 Sentry.init({
     dsn: 'https://68df3e19624c434eb975dafa316c03ff@o484761.ingest.sentry.io/5691260',
     release: `osweb@${packageVersion}`,
-    integrations: [
-        Sentry.extraErrorDataIntegration(),
-        Sentry.browserTracingIntegration()
-    ],
-    tracesSampleRate: 0.05,
+    integrations: [Sentry.extraErrorDataIntegration()],
     environment: window.location.hostname,
     ignoreErrors,
     denyUrls,

--- a/test/src/components/shell/router-context.test.tsx
+++ b/test/src/components/shell/router-context.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {render, screen} from '@testing-library/preact';
+import * as Sentry from '@sentry/react';
+import {RouterContextProvider} from '~/components/shell/router-context';
+
+jest.mock('@sentry/react', () => ({captureException: jest.fn()}));
+
+const captureException = Sentry.captureException as jest.Mock;
+
+// Throws once and then renders. A component that throws on every attempt
+// re-throws past the boundary instead of being caught.
+function Boom({error}: {error: Error}) {
+    const thrown = React.useRef(false);
+
+    if (!thrown.current) {
+        thrown.current = true;
+        throw error;
+    }
+
+    return <div>recovered</div>;
+}
+
+function renderWithBoundary(error: Error) {
+    return render(
+        <RouterContextProvider>
+            <Boom error={error} />
+        </RouterContextProvider>
+    );
+}
+
+describe('shell/router-context', () => {
+    let reload: jest.Mock;
+
+    beforeEach(() => {
+        captureException.mockClear();
+        reload = jest.fn();
+        Reflect.defineProperty(window, 'location', {
+            writable: true,
+            value: {origin: 'https://openstax.org', reload}
+        });
+        Reflect.defineProperty(window, 'sessionStorage', {
+            writable: true,
+            value: {getItem: () => null, setItem: () => undefined}
+        });
+    });
+
+    it('reports a render error to Sentry', async () => {
+        renderWithBoundary(new Error('render blew up'));
+        await screen.findByText('recovered');
+        expect(captureException).toHaveBeenCalledWith(
+            expect.objectContaining({message: 'render blew up'})
+        );
+    });
+
+    it('reloads instead of reporting when a chunk went stale', async () => {
+        const staleChunk = new Error('Loading chunk 47 failed.');
+
+        staleChunk.name = 'ChunkLoadError';
+        renderWithBoundary(staleChunk);
+        await screen.findByText('recovered');
+        expect(reload).toHaveBeenCalled();
+        expect(captureException).not.toHaveBeenCalled();
+    });
+});

--- a/test/src/data/faq.js
+++ b/test/src/data/faq.js
@@ -45,7 +45,7 @@ export default {
                     '<p data-block-key="eobsd">How do I get started? <br/></p>',
                 slug: 'why-use-openstax-textbooks',
                 answer: '<p data-block-key="ri8i3">As a first step, browse our free peer-reviewed <a href="https://openstax.org/subjects">digital library</a> and choose the resource(s) that fit your needs. From there, you can choose the OpenStax format that works best for your course, which students can easily access with a direct link from your syllabus or LMS. If you prefer to keep students learning within your learning management system (LMS), we also offer free course cartridge downloads. If you are an instructor who likes to provide students with custom assessments, assignments, and interactive features, consider using OpenStax <a href="https://openstax.org/assignable">Assignable</a>. No matter what you choose, you and your students can always access your books online version, download a free PDF, access a customizable .docx, or purchase a <a href="https://he.kendallhunt.com/openstax"> low-cost print version</a> of any OpenStax textbook.</p><p data-block-key="6jslc">For access to instructional resources, educators do need to create a free OpenStax instructor account and have their status verified. Finally, if you decide to use OpenStax resources in any way, please <a href="https://openstax.org/adoption">let us know</a> so we can update you on new resources and continue to help others! </p>',
-                document: null
+                document: 'this-one-fails'
             },
             id: 'c985605f-cc41-4758-84dc-a5e42098814c'
         },

--- a/test/src/helpers/cms-fetch.test.ts
+++ b/test/src/helpers/cms-fetch.test.ts
@@ -1,8 +1,11 @@
 import cmsFetch, {cmsPost} from '~/helpers/cms-fetch';
+import retry from '~/helpers/retry';
 
 jest.mock('~/helpers/retry', () => ({
     __esModule: true,
-    default() {throw new Error('retry failed');}
+    default: jest.fn(() => {
+        throw new Error('retry failed');
+    })
 }));
 
 const mockFetch = jest.fn().mockResolvedValue({
@@ -12,7 +15,21 @@ const mockFetch = jest.fn().mockResolvedValue({
 global.fetch = mockFetch;
 
 describe('cms-fetch', () => {
+    it('rejects when response json parsing fails', async () => {
+        (retry as jest.Mock).mockResolvedValueOnce({
+            json() {
+                return Promise.reject(new Error('json failed'));
+            }
+        });
+
+        await expect(cmsFetch('anything')).rejects.toThrow(
+            'Failed to fetch anything: Error: json failed'
+        );
+    });
     it('rejects when retry throws', async () => {
+        (retry as jest.Mock).mockImplementationOnce(() => {
+            throw new Error('retry failed');
+        });
         await expect(cmsFetch('anything')).rejects.toThrow();
     });
 });

--- a/test/src/helpers/page-data-utils.test.tsx
+++ b/test/src/helpers/page-data-utils.test.tsx
@@ -104,6 +104,27 @@ describe('page-data-utils', () => {
             await stalePromise.catch(() => null);
             screen.getByText('fresh');
         });
+        it('ignores stale resolution after promise changes', async () => {
+            let resolveStale: (value: string) => void;
+            const stalePromise = new Promise<string>((resolve) => {
+                resolveStale = resolve;
+            });
+
+            function Component({promise}: {promise: Promise<string> | null}) {
+                const data = useDataFromPromise(promise, 'default');
+
+                return <div>{String(data)}</div>;
+            }
+
+            const {rerender} = render(<Component promise={stalePromise} />);
+
+            rerender(<Component promise={null} />);
+            await screen.findByText('null');
+
+            resolveStale!('stale');
+            await stalePromise;
+            screen.getByText('null');
+        });
     });
     describe('useTextFromSlug', () => {
         function Component() {

--- a/test/src/helpers/page-data-utils.test.tsx
+++ b/test/src/helpers/page-data-utils.test.tsx
@@ -79,6 +79,31 @@ describe('page-data-utils', () => {
             render(<Component />);
             await screen.findByText('null');
         });
+        it('ignores stale rejection after promise changes', async () => {
+            let resolveCurrent: (value: string) => void;
+            let rejectStale: (reason?: Error) => void;
+            const stalePromise = new Promise<string>((_, reject) => {
+                rejectStale = reject;
+            });
+            const currentPromise = new Promise<string>((resolve) => {
+                resolveCurrent = resolve;
+            });
+
+            function Component({promise}: {promise: Promise<string> | null}) {
+                const data = useDataFromPromise(promise, 'default');
+
+                return <div>{String(data)}</div>;
+            }
+
+            const {rerender} = render(<Component promise={stalePromise} />);
+            rerender(<Component promise={currentPromise} />);
+            resolveCurrent!('fresh');
+            await screen.findByText('fresh');
+
+            rejectStale!(new Error('late error'));
+            await stalePromise.catch(() => null);
+            screen.getByText('fresh');
+        });
     });
     describe('useTextFromSlug', () => {
         function Component() {

--- a/test/src/helpers/page-data-utils.test.tsx
+++ b/test/src/helpers/page-data-utils.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, screen} from '@testing-library/preact';
+import {act, render, screen} from '@testing-library/preact';
 import {
     fetchFromCMS,
     getUrlFor,
@@ -121,8 +121,11 @@ describe('page-data-utils', () => {
             rerender(<Component promise={null} />);
             await screen.findByText('null');
 
-            resolveStale!('stale');
-            await stalePromise;
+            await act(async () => {
+                resolveStale!('stale');
+                await stalePromise;
+            });
+
             screen.getByText('null');
         });
     });

--- a/test/src/helpers/page-data-utils.test.tsx
+++ b/test/src/helpers/page-data-utils.test.tsx
@@ -60,6 +60,15 @@ describe('page-data-utils', () => {
         });
     });
     describe('useDataFromPromise', () => {
+        it('sets data to null when promise is missing', async () => {
+            function Component() {
+                const data = useDataFromPromise(null, 'default');
+
+                return <div>{String(data)}</div>;
+            }
+            render(<Component />);
+            await screen.findByText('null');
+        });
         it('sets data to null on rejection', async () => {
             const rejected = Promise.reject(new Error('test error'));
             function Component() {

--- a/test/src/helpers/page-data-utils.test.tsx
+++ b/test/src/helpers/page-data-utils.test.tsx
@@ -3,6 +3,7 @@ import {render, screen} from '@testing-library/preact';
 import {
     fetchFromCMS,
     getUrlFor,
+    useDataFromPromise,
     useTextFromSlug
 } from '~/helpers/page-data-utils';
 
@@ -56,6 +57,18 @@ describe('page-data-utils', () => {
 
             expect(url).toContain('draft=');
             window.history.replaceState({}, '', '/');
+        });
+    });
+    describe('useDataFromPromise', () => {
+        it('sets data to null on rejection', async () => {
+            const rejected = Promise.reject(new Error('test error'));
+            function Component() {
+                const data = useDataFromPromise(rejected, 'default');
+
+                return <div>{String(data)}</div>;
+            }
+            render(<Component />);
+            await screen.findByText('null');
         });
     });
     describe('useTextFromSlug', () => {

--- a/test/src/helpers/stale-chunk.test.ts
+++ b/test/src/helpers/stale-chunk.test.ts
@@ -1,0 +1,163 @@
+import recoverFromStaleChunk, {
+    handleScriptError,
+    listenForStaleChunks
+} from '~/helpers/stale-chunk';
+
+const RELOAD_KEY = 'osweb-stale-chunk-reloads';
+
+function chunkError() {
+    const error = new Error('Loading chunk 47 failed.');
+
+    error.name = 'ChunkLoadError';
+
+    return error;
+}
+
+function mockStorage(store: Record<string, string>, overrides = {}) {
+    Reflect.defineProperty(window, 'sessionStorage', {
+        writable: true,
+        value: {
+            getItem: (k: string) => store[k] ?? null,
+            setItem: (k: string, v: string) => {
+                store[k] = v;
+            },
+            ...overrides
+        }
+    });
+}
+
+describe('stale-chunk', () => {
+    let reload: jest.Mock;
+
+    beforeEach(() => {
+        reload = jest.fn();
+        Reflect.defineProperty(window, 'location', {
+            writable: true,
+            value: {origin: 'https://openstax.org', reload}
+        });
+        mockStorage({});
+    });
+
+    describe('recoverFromStaleChunk', () => {
+        it('reloads on a ChunkLoadError', () => {
+            expect(recoverFromStaleChunk(chunkError())).toBe(true);
+            expect(reload).toHaveBeenCalled();
+        });
+        it('reloads on the message alone, without the error name', () => {
+            expect(
+                recoverFromStaleChunk(new Error('Loading chunk 3 failed.'))
+            ).toBe(true);
+        });
+        it('ignores an unrelated error', () => {
+            expect(recoverFromStaleChunk(new TypeError('nope'))).toBe(false);
+            expect(reload).not.toHaveBeenCalled();
+        });
+        it('ignores a thrown non-error', () => {
+            expect(recoverFromStaleChunk(null)).toBe(false);
+        });
+        it('ignores an error with no message', () => {
+            expect(recoverFromStaleChunk({})).toBe(false);
+        });
+        it('gives up once the reload budget is spent', () => {
+            mockStorage({[RELOAD_KEY]: '2'});
+            expect(recoverFromStaleChunk(chunkError())).toBe(false);
+            expect(reload).not.toHaveBeenCalled();
+        });
+        it('counts each reload', () => {
+            const store = {};
+
+            mockStorage(store);
+            recoverFromStaleChunk(chunkError());
+            expect(store).toEqual({[RELOAD_KEY]: '1'});
+        });
+        it('declines to reload when storage cannot be read', () => {
+            mockStorage({}, {
+                getItem: () => {
+                    throw new Error('denied');
+                }
+            });
+            expect(recoverFromStaleChunk(chunkError())).toBe(false);
+            expect(reload).not.toHaveBeenCalled();
+        });
+        it('declines to reload when the counter cannot be written', () => {
+            mockStorage({}, {
+                setItem: () => {
+                    throw new Error('quota');
+                }
+            });
+            expect(recoverFromStaleChunk(chunkError())).toBe(false);
+            expect(reload).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('handleScriptError', () => {
+        function errorEvent(error: Error, filename: string) {
+            return {error, filename} as ErrorEvent;
+        }
+
+        it('reloads when one of our chunks parses as markup', () => {
+            handleScriptError(
+                errorEvent(
+                    new SyntaxError("Unexpected token '<'"),
+                    'https://openstax.org/dist/chunk-abc.js'
+                )
+            );
+            expect(reload).toHaveBeenCalled();
+        });
+        it('ignores a script outside dist', () => {
+            handleScriptError(
+                errorEvent(
+                    new SyntaxError("Unexpected token '<'"),
+                    'https://openstax.org/other/thing.js'
+                )
+            );
+            expect(reload).not.toHaveBeenCalled();
+        });
+        it('ignores a third-party script', () => {
+            handleScriptError(
+                errorEvent(
+                    new SyntaxError("Unexpected token '<'"),
+                    'https://js.pulseinsights.com/dist/survey.js'
+                )
+            );
+            expect(reload).not.toHaveBeenCalled();
+        });
+        it('ignores an unparseable filename', () => {
+            handleScriptError(
+                errorEvent(new SyntaxError("Unexpected token '<'"), 'not a url')
+            );
+            expect(reload).not.toHaveBeenCalled();
+        });
+        it('ignores errors that are not syntax errors', () => {
+            handleScriptError(
+                errorEvent(
+                    new TypeError('nope'),
+                    'https://openstax.org/dist/chunk-abc.js'
+                )
+            );
+            expect(reload).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listenForStaleChunks', () => {
+        it('recovers from a rejected chunk import', () => {
+            listenForStaleChunks();
+            window.dispatchEvent(
+                Object.assign(new Event('unhandledrejection'), {
+                    reason: chunkError()
+                })
+            );
+            expect(reload).toHaveBeenCalled();
+        });
+        it('recovers from a chunk that parses as markup', () => {
+            listenForStaleChunks();
+            window.dispatchEvent(
+                Object.assign(new Event('error'), {
+                    error: new SyntaxError("Unexpected token '<'"),
+                    filename: 'https://openstax.org/dist/chunk-abc.js'
+                })
+            );
+            expect(reload).toHaveBeenCalled();
+        });
+    });
+});

--- a/test/src/helpers/use-data.test.tsx
+++ b/test/src/helpers/use-data.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {describe, it, expect} from '@jest/globals';
 import {render, screen} from '@testing-library/preact';
-import useFetchedData from '~/helpers/use-data';
+import useFetchedData, {usePromise} from '~/helpers/use-data';
 
 function Component<E>({
     options,
@@ -126,5 +126,18 @@ describe('use-data', () => {
         );
         expect(global.fetch as jest.Mock).toHaveBeenCalledWith('transform');
         await screen.findByText('ok');
+    });
+});
+
+describe('usePromise', () => {
+    it('keeps default value on rejection', async () => {
+        const rejected = Promise.reject(new Error('test error'));
+        function Component() {
+            const data = usePromise(rejected, 'default');
+
+            return <div>{data}</div>;
+        }
+        render(<Component />);
+        await screen.findByText('default');
     });
 });

--- a/test/src/helpers/use-data.test.tsx
+++ b/test/src/helpers/use-data.test.tsx
@@ -142,4 +142,30 @@ describe('usePromise', () => {
         await rejected.catch(() => null);
         screen.getByText('default');
     });
+    it('keeps last resolved value when next promise rejects', async () => {
+        let resolveFirst: (value: string) => void;
+        let rejectSecond: (reason?: Error) => void;
+        const first = new Promise<string>((resolve) => {
+            resolveFirst = resolve;
+        });
+        const second = new Promise<string>((_, reject) => {
+            rejectSecond = reject;
+        });
+
+        function Component({promise}: {promise: Promise<string>}) {
+            const data = usePromise(promise, 'default');
+
+            return <div>{data}</div>;
+        }
+
+        const {rerender} = render(<Component promise={first} />);
+        resolveFirst!('resolved value');
+        await screen.findByText('resolved value');
+
+        rerender(<Component promise={second} />);
+        rejectSecond!(new Error('test error'));
+        await second.catch(() => null);
+
+        screen.getByText('resolved value');
+    });
 });

--- a/test/src/helpers/use-data.test.tsx
+++ b/test/src/helpers/use-data.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {describe, it, expect} from '@jest/globals';
-import {render, screen} from '@testing-library/preact';
+import {act, render, screen} from '@testing-library/preact';
 import useFetchedData, {usePromise} from '~/helpers/use-data';
 
 function Component<E>({
@@ -167,5 +167,34 @@ describe('usePromise', () => {
         await second.catch(() => null);
 
         screen.getByText('resolved value');
+    });
+    it('ignores a stale promise that resolves after a newer one', async () => {
+        let resolveStale: (value: string) => void;
+        let resolveCurrent: (value: string) => void;
+        const stale = new Promise<string>((resolve) => {
+            resolveStale = resolve;
+        });
+        const current = new Promise<string>((resolve) => {
+            resolveCurrent = resolve;
+        });
+
+        function Component({promise}: {promise: Promise<string>}) {
+            const data = usePromise(promise, 'default');
+
+            return <div>{data}</div>;
+        }
+
+        const {rerender} = render(<Component promise={stale} />);
+
+        rerender(<Component promise={current} />);
+        resolveCurrent!('current value');
+        await screen.findByText('current value');
+
+        await act(async () => {
+            resolveStale!('stale value');
+            await stale;
+        });
+
+        screen.getByText('current value');
     });
 });

--- a/test/src/helpers/use-data.test.tsx
+++ b/test/src/helpers/use-data.test.tsx
@@ -138,6 +138,8 @@ describe('usePromise', () => {
             return <div>{data}</div>;
         }
         render(<Component />);
-        await screen.findByText('default');
+        // Await the rejected promise so the rejection handler runs before asserting
+        await rejected.catch(() => null);
+        screen.getByText('default');
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,6 +150,14 @@ module.exports = (env, argv) => {
     console.log('Building', config.mode);
 
     if (config.mode === 'production') {
+        // Strips Sentry's tracing and debug-logging code from the bundle. We
+        // only report errors, so neither ships.
+        config.plugins.push(
+            new webpack.DefinePlugin({
+                __SENTRY_TRACING__: false,
+                __SENTRY_DEBUG__: false
+            })
+        );
         config.output.filename = '[name]-[contenthash].min.js';
         config.devtool = 'source-map';
         config.optimization.splitChunks.maxInitialRequests = 5;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,28 +3110,10 @@
     "@sentry-internal/replay-canvas" "9.47.1"
     "@sentry/core" "9.47.1"
 
-"@sentry/core@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.114.0.tgz#3efe86b92a5379c44dfd0fd4685266b1a30fa898"
-  integrity sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==
-  dependencies:
-    "@sentry/types" "7.114.0"
-    "@sentry/utils" "7.114.0"
-
 "@sentry/core@9.47.1":
   version "9.47.1"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.47.1.tgz#6b95b8a03ade1ca04f8b9b457bc751eb8be0c06a"
   integrity sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==
-
-"@sentry/integrations@^7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.114.0.tgz#baf249cfa9e359510f41e486a75bf184db18927d"
-  integrity sha512-BJIBWXGKeIH0ifd7goxOS29fBA8BkEgVVCahs6xIOXBjX1IRS6PmX0zYx/GP23nQTfhJiubv2XPzoYOlZZmDxg==
-  dependencies:
-    "@sentry/core" "7.114.0"
-    "@sentry/types" "7.114.0"
-    "@sentry/utils" "7.114.0"
-    localforage "^1.8.1"
 
 "@sentry/react@^9.16.1":
   version "9.47.1"
@@ -3141,18 +3123,6 @@
     "@sentry/browser" "9.47.1"
     "@sentry/core" "9.47.1"
     hoist-non-react-statics "^3.3.2"
-
-"@sentry/types@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.114.0.tgz#ab8009d5f6df23b7342121083bed34ee2452e856"
-  integrity sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==
-
-"@sentry/utils@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.114.0.tgz#59d30a79f4acff3c9268de0b345f0bcbc6335112"
-  integrity sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==
-  dependencies:
-    "@sentry/types" "7.114.0"
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -7197,11 +7167,6 @@ ignore@^7.0.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
-
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
@@ -8544,13 +8509,6 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lie@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
-  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
-  dependencies:
-    immediate "~3.0.5"
-
 limiter@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
@@ -8583,13 +8541,6 @@ loader-utils@^2.0.4:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
-
-localforage@^1.8.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
-  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
-  dependencies:
-    lie "3.1.1"
 
 locate-path@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,60 +3068,69 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
   integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
 
-"@sentry-internal/browser-utils@9.47.1":
-  version "9.47.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-9.47.1.tgz#212fd29613e1631c7a490e860845160050962017"
-  integrity sha512-twv6YhrUlPkvKz4/iQDH4KHgcv9t4cMjmZPf4/dCSCXn4/GOjzjx2d74c1w+1KOdS7lcsQzI+MtbK6SeYLiGfQ==
+"@sentry/browser-utils@10.70.0":
+  version "10.70.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser-utils/-/browser-utils-10.70.0.tgz#277a78d6162bd5dfca9846c727598471e7dc0186"
+  integrity sha512-IvjhafF5NFXrPCg5EHbAPGDwIhHxgUcLlHTklZ3DAdA6ky88BJYMfevbcnOEmgavf4nylhCaquRUFNB5+szj+A==
   dependencies:
-    "@sentry/core" "9.47.1"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.70.0"
 
-"@sentry-internal/feedback@9.47.1":
-  version "9.47.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-9.47.1.tgz#b4043e8ba5c687414b3eb091ccfb66c2f1fcfd34"
-  integrity sha512-xJ4vKvIpAT8e+Sz80YrsNinPU0XV7jPxPjdZ4ex8R2mMvx7pM0gq8JiR/sIVmNiOE0WiUDr6VwLDE8j2APSRMA==
+"@sentry/browser@10.70.0":
+  version "10.70.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.70.0.tgz#0305d0a1a644d4878b31a83934c656a0ce5f84c6"
+  integrity sha512-IK6+J+8H06tZe+A8L37TT5ZxxwNtyQatW8zl5RYYJ/e9CsjrM8fPi8I1OT7uquTw8UtjqFHt7bEef/Vy63ksPg==
   dependencies:
-    "@sentry/core" "9.47.1"
+    "@sentry/browser-utils" "10.70.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.70.0"
+    "@sentry/feedback" "10.70.0"
+    "@sentry/replay" "10.70.0"
+    "@sentry/replay-canvas" "10.70.0"
 
-"@sentry-internal/replay-canvas@9.47.1":
-  version "9.47.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-9.47.1.tgz#fd55b9a6bdd60a214a2244a3b7556a096b9fc6ab"
-  integrity sha512-r9nve+l5+elGB9NXSN1+PUgJy790tXN1e8lZNH2ziveoU91jW4yYYt34mHZ30fU9tOz58OpaRMj3H3GJ/jYZVA==
+"@sentry/conventions@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
+  integrity sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==
+
+"@sentry/core@10.70.0":
+  version "10.70.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.70.0.tgz#96eb9f2beab7d4b3b10c1b59ec7833e4dfe5fb73"
+  integrity sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==
   dependencies:
-    "@sentry-internal/replay" "9.47.1"
-    "@sentry/core" "9.47.1"
+    "@sentry/conventions" "^0.16.0"
 
-"@sentry-internal/replay@9.47.1":
-  version "9.47.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-9.47.1.tgz#6b62c0b055917279448caf7a79c273562e93d940"
-  integrity sha512-O9ZEfySpstGtX1f73m3NbdbS2utwPikaFt6sgp74RG4ZX4LlXe99VAjKR464xKECpYsLmj2bYpiK4opURF0pBA==
+"@sentry/feedback@10.70.0":
+  version "10.70.0"
+  resolved "https://registry.yarnpkg.com/@sentry/feedback/-/feedback-10.70.0.tgz#72b3f390f296982f9822aa372686b777ab955f17"
+  integrity sha512-6VQn2ETJjHkk4QQDdx/587/JDfXsk3yBTLZ3UZOMtBVrkmwgk+1FJZ8ULJ3ud1xZcuh2icunIkc7tGVv2axdnw==
   dependencies:
-    "@sentry-internal/browser-utils" "9.47.1"
-    "@sentry/core" "9.47.1"
+    "@sentry/core" "10.70.0"
 
-"@sentry/browser@9.47.1":
-  version "9.47.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-9.47.1.tgz#38da62d2d3b4f25aec066a7e7fdc337d75230b85"
-  integrity sha512-at5JOLziw5QpVYytxTDU6xijdV6lDQ/Rxp/qXJaHXud3gIK4suv2cXW+tupJfwoUoHFCnDNfccjCmPmP0yRqiA==
+"@sentry/react@^10":
+  version "10.70.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-10.70.0.tgz#fc1dd37ce48e306b658b7ab6d401426cfa37e231"
+  integrity sha512-j1d/4hvoaUVKs5GRrfmwUCkiEmkfaeHsk+xgausZlzg5YvmwpF+gyevBLNP26GFEH7nyHXW4l8dbbo0eNieJmw==
   dependencies:
-    "@sentry-internal/browser-utils" "9.47.1"
-    "@sentry-internal/feedback" "9.47.1"
-    "@sentry-internal/replay" "9.47.1"
-    "@sentry-internal/replay-canvas" "9.47.1"
-    "@sentry/core" "9.47.1"
+    "@sentry/browser" "10.70.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.70.0"
 
-"@sentry/core@9.47.1":
-  version "9.47.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.47.1.tgz#6b95b8a03ade1ca04f8b9b457bc751eb8be0c06a"
-  integrity sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==
-
-"@sentry/react@^9.16.1":
-  version "9.47.1"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-9.47.1.tgz#c3eb4136062991329fe368ce5ab32f9c597573c8"
-  integrity sha512-Anqt0hG1R+nktlwEiDc2FmD+6DUGMJOLuArgr7q1cSCdPbK2Gb1eZ2rF57Ui+CDo9XLvlX9QP2is/M08rrVe3w==
+"@sentry/replay-canvas@10.70.0":
+  version "10.70.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay-canvas/-/replay-canvas-10.70.0.tgz#16a3a57ea36bab248925b6d0ca709af7c95012c6"
+  integrity sha512-irzpw22bK5CF3jbecDa0gBUcfjv7tgeUoLAvtIfeHOP5ajmf3o4Cp99a9RQqkfgvkcMeRZBUwE91SQhp6Ank+w==
   dependencies:
-    "@sentry/browser" "9.47.1"
-    "@sentry/core" "9.47.1"
-    hoist-non-react-statics "^3.3.2"
+    "@sentry/core" "10.70.0"
+    "@sentry/replay" "10.70.0"
+
+"@sentry/replay@10.70.0":
+  version "10.70.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-10.70.0.tgz#2138a596a152f07e5076f300ffbeba0bab03817e"
+  integrity sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==
+  dependencies:
+    "@sentry/browser-utils" "10.70.0"
+    "@sentry/core" "10.70.0"
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -6915,7 +6924,7 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoist-non-react-statics@3, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@3, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
Sentry was reporting minified stacks with no context, silently dropping every render error in the app, and billing us for transactions we never look at. This started as promise-rejection handling and grew to cover the reporting pipeline around it.

## Make Sentry reports usable

- **Upload source maps.** `build.yml` uploaded `.map` files to PostHog only. Sentry got a release name and no artifacts, so every frame arrived minified. Now uploaded under the same `osweb@<package.json version>` that `sentry.js` reports. Requires the `SENTRY_AUTH_TOKEN`, `SENTRY_ORG` and `SENTRY_PROJECT` secrets, which are set.
- **Stop swallowing render errors.** `router-context.tsx` called `useErrorBoundary()` with no handler. Preact caught every render error in the route tree and discarded it. It wraps all routes, so nothing that threw during render ever reached Sentry.
- **`ignoreUrls` → `denyUrls`.** `ignoreUrls` was removed in SDK v7 and silently does nothing, so the Google Analytics and PulseInsights filters had never applied.
- **Add context.** No `setUser`, no tags, anywhere. Events now carry the account uuid, `logged_in` and `user_role`, set alongside the existing PulseInsights identify call. Names and emails stay out deliberately.

## Recover from stale chunks instead of muting them

Production chunk filenames are content-hashed, so a deploy invalidates all ~500 of them. A tab opened before a deploy 404s on the next chunk it lazily requests, and the SPA fallback answers with `index.html`, which parses as markup rather than script. That is where the muted `Loading chunk N failed` and `Unexpected token '<'` errors come from, and the tab stayed broken until the user reloaded by hand.

`stale-chunk.ts` reloads instead, which fetches a fresh `index.html` and the chunk names that go with it. `sessionStorage` caps it at two reloads per tab so a genuinely broken deploy cannot spin, and blocked or full storage means no reload at all. Two wire-in points cover every dynamic import: the route-tree error boundary for `React.lazy`, and global `error` / `unhandledrejection` listeners for the layout, page-loader and bootstrap imports that never reach a boundary.

The ignore-list entries stay as they are. Sentry installs its own global handlers at `init`, before these listeners run, so unmuting would bill us for events we are already recovering from.

## Ship less SDK

`@sentry/react` moves 9.47.1 → 10.70.0. For how this repo uses the SDK it is a no-op: none of the APIs v10 removed appear here, and one behaviour change lands in our favour — user IP inference is now gated behind `sendDefaultPii`, which we do not set.

We only report errors, so `browserTracingIntegration` and `tracesSampleRate` are gone, and the production build defines `__SENTRY_TRACING__` and `__SENTRY_DEBUG__` as `false` so that code is stripped rather than merely unreferenced. `@sentry/integrations@7` is also gone — it pinned a second `@sentry/core` (v7) next to v9, and both integrations it supplied are exported by v9/v10 directly.

| | before | after |
|---|---|---|
| `npm.sentry` | 105K | 88K |
| `npm.sentry-internal` | 26K | gone |
| **total** | **131K** | **88K** (−33%) |

The `npm.sentry-internal` chunk existed only to carry the browser-utils, replay and feedback code that tracing pulled in, so this is one fewer request per page load as well.

## Promise rejections

The original scope, plus two more found on the way:

- `cmsFetch` awaits `.json()` so parse errors are caught inside the `try`.
- `useDataFromPromise` sets data to `null` on rejection or a missing promise.
- `usePromise` keeps the last good value on rejection — **and** no longer lets a stale promise clobber newer data. It had no cancellation guard at all, so when the promise prop changed an earlier request that settled late overwrote the newer result. `useFetchedData` rebuilds its promise whenever the url or `resolveTo` changes, so any caller refetching on navigation could show the wrong data.
- The FAQ document fetch had a resolve handler and nothing else, so a failed request became an unhandled rejection.

## Notes for review

- Both stale-value tests originally passed against the *unguarded* code — the assertion ran before the late resolution had flushed, so they met the coverage threshold without proving anything. They now wrap the resolution in `act()` and fail with their guard removed.
- Verified the accounts `/api/user` call still uses `always_200=true` (`accounts-model.ts:3`). It is the only accounts API call in the repo and it has its own rejection handler, so anonymous users do not generate Sentry noise. `sfapi.ts` targets a different service where the flag does not exist, and handles its own errors.
- `.env` and `.claude/` were not gitignored. They are now.

806 tests / 186 suites passing, 100% coverage held, lint clean, production build verified.
