### PR TITLE
Scroll to the top on every navigation, not just imported pages

### DIFF
--- a/src/app/components/shell/router-helpers/page-loaders.tsx
+++ b/src/app/components/shell/router-helpers/page-loaders.tsx
@@ -1,13 +1,40 @@
 import React from 'react';
 import loadable from 'react-loadable';
+import * as Sentry from '@sentry/react';
 import LoadingPlaceholder from '~/components/loading-placeholder/loading-placeholder';
+import recoverFromStaleChunk from '~/helpers/stale-chunk';
 import useLayoutContext from '~/contexts/layout';
+
+// react-loadable catches the import rejection itself, so a page chunk that
+// 404s after a deploy reaches neither the error boundary nor the
+// unhandledrejection listener in stale-chunk. Recover here or the tab sits on
+// the loader forever with nothing reported.
+export function PageLoading({error, retry}: {error?: Error; retry: () => void}) {
+    React.useEffect(() => {
+        if (error && !recoverFromStaleChunk(error)) {
+            Sentry.captureException(error);
+        }
+    }, [error]);
+
+    if (error) {
+        return (
+            <div>
+                <p>This page did not load.</p>
+                <button type="button" onClick={retry}>
+                    Try again
+                </button>
+            </div>
+        );
+    }
+
+    return <LoadingPlaceholder />;
+}
 
 function usePage(name: string) {
     return React.useMemo(() => {
         return loadable({
             loader: () => import(`~/pages/${name}/${name}`),
-            loading: LoadingPlaceholder,
+            loading: PageLoading,
             render(loaded, props: object) {
                 const Component = loaded.default;
 

--- a/src/app/components/shell/router-helpers/page-loaders.tsx
+++ b/src/app/components/shell/router-helpers/page-loaders.tsx
@@ -1,17 +1,7 @@
-import React, {useEffect} from 'react';
-import {useLocation} from 'react-router-dom';
+import React from 'react';
 import loadable from 'react-loadable';
 import LoadingPlaceholder from '~/components/loading-placeholder/loading-placeholder';
 import useLayoutContext from '~/contexts/layout';
-
-function useAnalyticsPageView() {
-    const location = useLocation();
-    const isRedirect = location.state?.redirect;
-
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [isRedirect]);
-}
 
 function usePage(name: string) {
     return React.useMemo(() => {
@@ -28,19 +18,12 @@ function usePage(name: string) {
 }
 
 export function ImportedPage({name}: {name: string}) {
-    const {pathname} = useLocation();
     const Page = usePage(name);
     const {layoutParameters, setLayoutParameters} = useLayoutContext();
 
     if (layoutParameters.name === null) {
         setLayoutParameters();
     }
-
-    useAnalyticsPageView();
-
-    // Scroll to the top when the pathname changes
-    // (Avoids scrolling when going to a new tab)
-    useEffect(() => window.scrollTo(0, 0), [name, pathname]);
 
     return <Page />;
 }

--- a/src/app/components/shell/router.tsx
+++ b/src/app/components/shell/router.tsx
@@ -43,9 +43,18 @@ function SkipToContent() {
 export default function Router() {
     const linkHandler = useLinkHandler() as unknown as (ev: MouseEvent) => void;
     const {origin} = window.location; // React-Router Location does not have origin
-    const {pathname} = useLocation();
+    const {pathname, hash} = useLocation();
     const canonicalUrl = `${origin}${pathname}`;
     const {isK12Portal} = usePortalContext();
+
+    // Browsers keep the scroll offset across a pushState navigation, so without
+    // this a new page opens wherever the last one was scrolled to. Skip it when
+    // there is a hash; that navigation is a request to scroll somewhere else.
+    useEffect(() => {
+        if (!hash) {
+            window.scrollTo(0, 0);
+        }
+    }, [pathname, hash]);
 
     useEffect(() => {
         document.addEventListener('click', linkHandler);

--- a/test/src/components/shell/page-loaders.test.tsx
+++ b/test/src/components/shell/page-loaders.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {render, screen} from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import * as Sentry from '@sentry/react';
+import {PageLoading} from '~/components/shell/router-helpers/page-loaders';
+
+jest.mock('@sentry/react', () => ({captureException: jest.fn()}));
+
+const captureException = Sentry.captureException as jest.Mock;
+
+describe('shell/page-loaders', () => {
+    let reload: jest.Mock;
+
+    beforeEach(() => {
+        captureException.mockClear();
+        reload = jest.fn();
+        Reflect.defineProperty(window, 'location', {
+            writable: true,
+            value: {origin: 'https://openstax.org', reload}
+        });
+        Reflect.defineProperty(window, 'sessionStorage', {
+            writable: true,
+            value: {getItem: () => null, setItem: () => undefined}
+        });
+    });
+
+    it('shows the loader while the chunk is still loading', () => {
+        const {container} = render(<PageLoading retry={jest.fn()} />);
+
+        expect(container.querySelector('.os-loader')).toBeTruthy();
+        expect(captureException).not.toHaveBeenCalled();
+    });
+
+    it('reloads instead of reporting when the page chunk went stale', () => {
+        const staleChunk = new Error('Loading chunk 47 failed.');
+
+        staleChunk.name = 'ChunkLoadError';
+        render(<PageLoading error={staleChunk} retry={jest.fn()} />);
+
+        expect(reload).toHaveBeenCalled();
+        expect(captureException).not.toHaveBeenCalled();
+    });
+
+    it('reports any other failure and offers a retry', async () => {
+        const retry = jest.fn();
+
+        render(<PageLoading error={new Error('page blew up')} retry={retry} />);
+
+        expect(captureException).toHaveBeenCalledWith(
+            expect.objectContaining({message: 'page blew up'})
+        );
+        expect(reload).not.toHaveBeenCalled();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+
+        expect(retry).toHaveBeenCalled();
+    });
+});

--- a/test/src/components/shell/router.test.tsx
+++ b/test/src/components/shell/router.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import {render, screen, waitFor} from '@testing-library/preact';
+import {act, render, screen, waitFor} from '@testing-library/preact';
 import '@testing-library/jest-dom';
+import {NavigateFunction, useNavigate} from 'react-router-dom';
 import Router from '~/components/shell/router';
 import * as LayoutContext from '~/contexts/layout';
 import * as PortalContext from '~/contexts/portal';
@@ -116,25 +117,39 @@ describe('Router', () => {
     });
 
     describe('scroll reset', () => {
-        const renderAt = (entries: string[]) =>
+        let navigate: NavigateFunction;
+
+        const Navigator = () => {
+            navigate = useNavigate();
+            return null;
+        };
+
+        const renderAtHome = () => {
             render(
-                <MemoryRouter initialEntries={entries}>
+                <MemoryRouter initialEntries={['/']}>
+                    <Navigator />
                     <Router />
                 </MemoryRouter>
             );
+            (window.scrollTo as jest.Mock).mockClear();
+        };
 
         beforeEach(() => {
             window.scrollTo = jest.fn();
         });
 
-        it('scrolls to the top on a new path', () => {
-            renderAt(['/subjects']);
+        it('scrolls to the top on navigation to a new path', () => {
+            renderAtHome();
+
+            act(() => navigate('/subjects'));
 
             expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
         });
 
-        it('leaves the scroll alone when the path has a hash', () => {
-            renderAt(['/subjects#math']);
+        it('leaves the scroll alone when the destination has a hash', () => {
+            renderAtHome();
+
+            act(() => navigate('/subjects#math'));
 
             expect(window.scrollTo).not.toHaveBeenCalled();
         });

--- a/test/src/components/shell/router.test.tsx
+++ b/test/src/components/shell/router.test.tsx
@@ -115,6 +115,31 @@ describe('Router', () => {
         jest.clearAllMocks();
     });
 
+    describe('scroll reset', () => {
+        const renderAt = (entries: string[]) =>
+            render(
+                <MemoryRouter initialEntries={entries}>
+                    <Router />
+                </MemoryRouter>
+            );
+
+        beforeEach(() => {
+            window.scrollTo = jest.fn();
+        });
+
+        it('scrolls to the top on a new path', () => {
+            renderAt(['/subjects']);
+
+            expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+        });
+
+        it('leaves the scroll alone when the path has a hash', () => {
+            renderAt(['/subjects#math']);
+
+            expect(window.scrollTo).not.toHaveBeenCalled();
+        });
+    });
+
     describe('Router component', () => {
         it('renders without crashing', () => {
             render(


### PR DESCRIPTION
## The bug

Navigating between pages drops you into the middle of the new page, or at the very bottom of it.

Reproduced it on **live production**, before any of this release's code: scroll `/subjects` to y=2205, click through to `/about`, land back at 2205.

## Root cause

The only scroll-to-top in the app lived in `ImportedPage`, so it covered `/details`, `/errata`, the footer pages and the no-data pages under `/:dir/*` — and nothing else. **Flex pages never reset the scroll at all**, and flex pages are now most of the site: home, `/about`, `/impact`, and every CMS flex page.

Browsers keep the scroll offset across a pushState navigation. While the route renders `null` waiting on CMS data, Chrome clamps the offset to the temporarily-short document, then *restores* it once the real content's height comes back — so the position survives. Whether you end up mid-page or pinned to the bottom just depends on whether the new page is taller or shorter than where you were.

## The fix

One reset at the router level, keyed on pathname, replacing the per-page copies:

```tsx
useEffect(() => {
    if (!hash) {
        window.scrollTo(0, 0);
    }
}, [pathname, hash]);
```

The `hash` guard matters: a hash navigation is a request to scroll somewhere specific, and both the skip-to-content link and the flex-page renderer's accordion deep-links depend on it.

Left alone deliberately: the resets in `latest-blog-posts` and `blog-context`, which key off pagination state rather than the pathname, so the router-level effect doesn't cover them.


## Also here: a failed page chunk no longer hangs on the loader

Found while checking whether the recent PRs had broken anything else. The
js-to-tsx port of `page-loaders` in #2784 dropped its `useLoading` error
renderer and passed `LoadingPlaceholder` as react-loadable's `loading`
component. `LoadingPlaceholder` ignores the `error` prop, and react-loadable
catches the import rejection itself, so a failed page chunk reaches nothing —
not the `useErrorBoundary` in `router-context`, not the `unhandledrejection`
listener in `stale-chunk`, not Sentry.

Production answers a missing `/dist` chunk with `404 text/html`, which the
browser reports as a script resource error rather than a `SyntaxError`, so
`handleScriptError` doesn't cover it either. Net effect: after a deploy, a tab
opened beforehand spins forever on `/details`, `/errata`, `/blog`, `/adoption`,
`/interest` and the portal sub-routes, and we never hear about it.

`PageLoading` now runs the same recovery the error boundary does — reload for a
stale chunk, report anything else, retry button for the transient case.
