### PR TITLE
Report every resource access, not only downloads

### DIFF
--- a/src/app/pages/details/common/resource-box/left-content.tsx
+++ b/src/app/pages/details/common/resource-box/left-content.tsx
@@ -108,7 +108,11 @@ function LeftButton({model, variant}: {model: ResourceModel & LinkIsSet; variant
     // instructor's too whenever the click beat the user request.
     const trackDownloadClick = React.useCallback(
         (event: TrackedMouseEvent) => {
-            trackLink(event, model.bookModel.id.toString());
+            // A malformed CMS resource can reach the exclamation-icon fallback
+            // with no book attached; trackLink treats a missing id as
+            // "nothing to report", and throwing here would abort the click
+            // before the resource opens.
+            trackLink(event, model.bookModel?.id.toString());
         },
         [model.bookModel]
     );
@@ -117,10 +121,10 @@ function LeftButton({model, variant}: {model: ResourceModel & LinkIsSet; variant
     const ariaLabel = isDownload ? `Download ${model.heading}` : `Go to ${model.heading}`;
 
     function openDialog(event: TrackedMouseEvent) {
-        if (!isDownload) {
-            return;
-        }
-        if (enabled && open()) {
+        // The donation nudge is for downloads only, but every resource counts as
+        // a resource access — link-icon resources (Canvas cartridges, OER
+        // Commons items) have to report too.
+        if (isDownload && enabled && open()) {
             event.preventDefault();
             return;
         }

--- a/test/src/pages/details/left-content.test.tsx
+++ b/test/src/pages/details/left-content.test.tsx
@@ -126,6 +126,34 @@ describe('left-content', () => {
         expect(trackLink).toHaveBeenCalledWith(expect.anything(), '1');
         trackLink.mockRestore();
     });
+    it.each([
+        ['Instructor', 'an instructor'],
+        ['Student', 'a student']
+    ])(
+        'reports a link-icon resource for %s resources',
+        async (search) => {
+            const trackLink = jest.spyOn(TL, 'default');
+
+            mockUseUserContext.mockReturnValue({
+                userStatus: {isInstructor: search === 'Instructor'}
+            });
+            const model = {
+                link,
+                ...baseModel,
+                iconType: 'external-link-alt'
+            };
+
+            render(<Component model={model} search={search} />);
+
+            await user.click(screen.getByRole('link'));
+
+            // The donation nudge is for downloads; a link resource goes straight
+            // through, but still has to be reported.
+            expect(screen.queryByText('Go to your resource')).toBeNull();
+            expect(trackLink).toHaveBeenCalledWith(expect.anything(), '1');
+            trackLink.mockRestore();
+        }
+    );
     it('still reports the download when the dialog is capped', async () => {
         const trackLink = jest.spyOn(TL, 'default');
 


### PR DESCRIPTION
## The bug

Instructor and student resources that the CMS marks as a **link** rather than a download were never reported to Salesforce. No `ResourceDownload` row, ever — not for Canvas Course Cartridges, not for OER Commons items, not for anything else that renders with the external-link icon.

`left-content.tsx`, before:

```js
function openDialog(event: TrackedMouseEvent) {
    if (!isDownload) {
        return;          // ← resource opens, trackLink never runs
    }
    ...
    trackDownloadClick(event);
}
```

`isDownload` is `icon === faDownload`. Everything else took the early return. The anchors carry correct `data-track` and `data-variant` — only the guard stopped them.

## Verified on dev

Signed in as a confirmed instructor:

| Surface | Result |
| --- | --- |
| Download-icon resource, detail page | POST → **201**, row lands in the admin |
| Download-icon resource via the give dialog | POST → **201** |
| K12 subject resource | wired correctly |
| **Link-icon resource** (Canvas Course Cartridge) | `window.open` fires, **no POST** |

Consistent with the data: the `resource_downloads` table on dev holds zero cartridge/Canvas/OER rows.

## The change

The donation nudge is download-only, so it keeps the `isDownload` check. Reporting isn't, so it moves out from behind the early return:

```js
if (isDownload && enabled && open()) {
    event.preventDefault();
    return;
}
trackDownloadClick(event);
```

This covers the instructor tab, the student tab, and the flex-page table resource cells, which all render through the same `LeftButton`.

Also guarded the book id. A malformed CMS resource can reach the exclamation-icon fallback with no book attached; now that those clicks report, reading through an absent `bookModel` would throw inside the document click handler and stop the resource from opening at all. `trackLink` already treats a missing id as nothing to report, so passing `undefined` is the correct quiet no-op — this surfaced as a real failure in `featured-resources.test.tsx`, not a hypothetical.

## Note for reviewers

This widens what a `ResourceDownload` row means: link-shaped resources now file alongside file downloads. That is deliberate — the metric is instructor and student resource *access*, and a Canvas cartridge opened through Instructure is exactly that. Expect row volume to rise once it ships.

## Verification

- New tests cover the link-icon case on both the Instructor and Student tabs; both fail without the change and pass with it.
- 47 suites / 276 tests pass across `pages/details`, `pages/flex-page`, `pages/k12` and `components/shell`.
- `yarn lint:ts` and eslint clean.
