### PR TITLE
Report resource downloads without blocking the navigation

### DIFF
--- a/src/app/components/shell/router-helpers/use-link-handler.ts
+++ b/src/app/components/shell/router-helpers/use-link-handler.ts
@@ -40,6 +40,28 @@ function isPortalRoot(portalPrefix: string) {
     return Boolean(portalPrefix && portalPrefix === pathname);
 }
 
+// The request goes out before the navigation but is never awaited. Awaiting it
+// delays window.open past the click's user activation, and the popup blocker
+// then turns "open the resource in a new tab" into "replace the app with it" —
+// a ~300ms report is safely inside the window, but a retried one is not.
+// keepalive is what makes not-awaiting safe: it lets the request outlive the
+// page when the resource opens via location.assign instead of a new tab.
+function reportDownload(trackingInfo: TrackingInfo) {
+    retry(() =>
+        fetch(`${$.apiOriginAndOldPrefix}/salesforce/download-tracking/`, {
+            method: 'POST',
+            mode: 'cors',
+            keepalive: true,
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(trackingInfo)
+        })
+    ).catch((err) => {
+        console.error(`Unable to download-track: ${err}`);
+    });
+}
+
 export default function useLinkHandler() {
     const navigate = useNavigate();
     const navigateTo = useCallback(
@@ -81,26 +103,9 @@ export default function useLinkHandler() {
             }
 
             if (e.trackingInfo) {
-                retry(() =>
-                    fetch(
-                        `${$.apiOriginAndOldPrefix}/salesforce/download-tracking/`,
-                        {
-                            method: 'POST',
-                            mode: 'cors',
-                            headers: {
-                                'Content-Type': 'application/json'
-                            },
-                            body: JSON.stringify(e.trackingInfo)
-                        }
-                    )
-                )
-                    .catch((err) => {
-                        console.error(`Unable to download-track: ${err}`);
-                    })
-                    .finally(followLink);
-            } else {
-                followLink();
+                reportDownload(e.trackingInfo);
             }
+            followLink();
         },
         [navigateTo, portalPrefix]
     );

--- a/test/src/components/shell/use-link-handler.test.tsx
+++ b/test/src/components/shell/use-link-handler.test.tsx
@@ -216,6 +216,37 @@ describe('use-link-handler', () => {
         );
         await user.click(screen.getByRole('link'));
     });
+    it('opens the resource without waiting for the report', async () => {
+        setPortalPrefix('/portal');
+        const navigate = jest.fn();
+        const open = jest.spyOn(window, 'open').mockReturnValue({} as Window);
+
+        jest.spyOn(linkHelper, 'validUrlClick').mockReturnValue({
+            target: '',
+            href: 'clickHref',
+            preventDefault() {return;},
+            dataset: {}
+        } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+        jest.spyOn(linkHelper, 'stripOpenStaxDomain').mockReturnValue(
+            'whatever'
+        );
+        jest.spyOn(linkHelper, 'isExternal').mockReturnValue(true);
+        (useNavigate as jest.Mock).mockReturnValue(navigate);
+
+        render(<Component track />);
+        // A report that never settles stands in for a slow or retried one. The
+        // resource still has to open, or the popup blocker gets it instead.
+        jest.spyOn(window, 'fetch').mockImplementation(
+            () => new Promise<Response>(() => undefined)
+        );
+        await user.click(screen.getByRole('link'));
+
+        expect(window.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/salesforce/download-tracking/'),
+            expect.objectContaining({keepalive: true})
+        );
+        expect(open).toHaveBeenCalledWith('clickHref', '_blank');
+    });
     it('catches tracking fetch failure', async () => {
         setPortalPrefix('/');
         const navigate = jest.fn();


### PR DESCRIPTION
Follow-up to #2968, addressing [Copilot's review comment](https://github.com/openstax/os-webview/pull/2968) there. Independent of that change — this path predates it.

## The problem

The click handler awaited the download-tracking POST and only opened the resource in `.finally()`:

```js
retry(() => fetch(trackingUrl, {...}))
    .catch(...)
    .finally(followLink);       // ← navigation waits on the report
```

`window.open` outside a click's user activation gets blocked; the blocked call returns `null`, and `handleExternalLink`'s fallback then does `window.location.assign(href)` — replacing the app tab with the asset instead of opening a new one.

## How bad, measured

I tested it on dev with a **real mouse click**, reproducing the tracked-external-link path (deliberately invalid payload, so no row was written):

| | |
| --- | --- |
| Tracking POST round trip | **334 ms** |
| `window.open` after the await | **returned a window — not blocked** |
| App tab | stayed on `dev.openstax.org` |

So the common case is fine: Chrome's transient activation lasts ~5s and survives a fetch.

It breaks when the report is slow. `retry` makes three attempts at 1400ms intervals, so a single first failure pushes the open past 4s — right at the edge in Chrome, and Safari is stricter about `window.open` after any await at all.

## The change

Send the report and follow the link synchronously, inside the activation the click already granted:

```js
if (e.trackingInfo) {
    reportDownload(e.trackingInfo);
}
followLink();
```

`keepalive: true` is what makes not-awaiting safe. `data-local="true"` resources (the give dialog's "Go to your resource") open via `location.assign`, which would otherwise cancel a request still in flight — that is the reason the `await` was there in the first place. With keepalive the request outlives the page instead.

`retry` stays. It just no longer holds the navigation, and on the `location.assign` path the first attempt carries keepalive, so it lands whether or not the retries ever get to run.

I did not take Copilot's suggested approach of pre-opening the tab and navigating it after tracking — it adds a window handle to manage and a visible blank tab, and it doesn't help the `location.assign` path at all.

## Scope

Pre-existing and **not** specific to the link-icon resources from #2968 — every tracked resource download has taken this path since tracking was added. That PR extended an existing pattern; it didn't create it.

## Verification

- New test drives a click whose report never settles and asserts the resource opens anyway, with `keepalive: true` on the request. Fails against the awaiting version, passes with the change.
- 47 suites / 277 tests pass across `components/shell`, `pages/details`, `pages/k12`, `pages/flex-page`.
- `yarn lint:ts` and eslint clean.
