### PR TITLE
Drop per-page scroll resets that bypass the hash guard

### DIFF
--- a/src/app/pages/blog/blog-pages.tsx
+++ b/src/app/pages/blog/blog-pages.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import useBlogContext from './blog-context';
 import {useParams} from 'react-router-dom';
 import {WindowContextProvider} from '~/contexts/window';
@@ -142,13 +142,6 @@ export function ArticlePage() {
     // where :slug is a required route parameter
     const slug = assertDefined(useParams().slug);
     const [articleData, setArticleData] = React.useState<ArticleData>();
-
-    useEffect(
-        () => {
-            window.scrollTo(0, 0);
-        },
-        [slug]
-    );
 
     return (
         <WindowContextProvider>

--- a/src/app/pages/footer-page/footer-page.tsx
+++ b/src/app/pages/footer-page/footer-page.tsx
@@ -46,11 +46,6 @@ export default function LoadFooterPage() {
     const slug = `pages${slugEnd}`;
     const data = usePageData<PageData>(slug);
 
-    React.useLayoutEffect(
-        () => window.scrollTo(0, 0),
-        [pathname]
-    );
-
     if (!data) {
         return null;
     }

--- a/test/src/pages/blog/blog.test.tsx
+++ b/test/src/pages/blog/blog.test.tsx
@@ -54,8 +54,6 @@ describe('blog pages', () => {
         expect(screen.queryByText('No matching blog posts found')).toBeNull();
     });
     test('Article page', async () => {
-        window.scrollTo = jest.fn();
-
         render(
             <MemoryRouter initialEntries={['/blog/blog-article']}>
                 <BlogContextProvider>
@@ -67,7 +65,6 @@ describe('blog pages', () => {
         );
         expect(await screen.findAllByText('Read more')).toHaveLength(3);
         expect(screen.queryAllByRole('link')).toHaveLength(7);
-        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
     });
 
     test('assertTType throws for invalid value', () => {


### PR DESCRIPTION
Follow-up to #2967, addressing Copilot's review comment on `router.tsx`.

#2967 added a router-level scroll reset that skips scrolling when the URL has a hash — a fragment navigation is a request to scroll somewhere specific. But footer pages and blog articles each kept their own `scrollTo(0, 0)` keyed on the same pathname, so navigating to one of those URLs with a fragment still jumped to the top.

Both were redundant with the router effect, so this is a straight deletion rather than adding a second hash guard.

- `footer-page.tsx` — removed the `useLayoutEffect` reset keyed on `pathname`
- `blog-pages.tsx` (`ArticlePage`) — removed the reset keyed on `slug`
- `blog.test.tsx` — dropped the assertion covering the deleted effect; `router.test.tsx` covers scroll reset through a real navigation

Pagination resets are untouched: `latest-blog-posts` is keyed on `page` and `blog-context`'s `setPath` handles search-only navigations. Neither changes the pathname, so the router effect doesn't fire for them.

## Testing

- `yarn test` — 834 tests pass, coverage thresholds met
- `yarn lint:ts` clean