### PR TITLE
Resolve resource tables nested in FAQ items; survive CMS outages; renderer null-target guard

### DIFF
--- a/src/app/layouts/default/header/menus/main-menu/main-menu.tsx
+++ b/src/app/layouts/default/header/menus/main-menu/main-menu.tsx
@@ -57,7 +57,7 @@ function MenusFromStructure({structure}: {structure: MenuItemData[]}) {
 }
 
 function MenusFromCMS() {
-    const structure = useDataFromSlug('oxmenus');
+    const structure = useDataFromSlug<MenuItemData[]>('oxmenus');
 
     // fetchFromCMS resolves with an {error} object (not an array) when the
     // CMS is unreachable, so a truthiness check alone lets it through to .map.

--- a/src/app/layouts/default/header/menus/main-menu/main-menu.tsx
+++ b/src/app/layouts/default/header/menus/main-menu/main-menu.tsx
@@ -59,7 +59,9 @@ function MenusFromStructure({structure}: {structure: MenuItemData[]}) {
 function MenusFromCMS() {
     const structure = useDataFromSlug('oxmenus') as MenuItemData[] | undefined;
 
-    if (!structure) {
+    // fetchFromCMS resolves with an {error} object (not an array) when the
+    // CMS is unreachable, so a truthiness check alone lets it through to .map.
+    if (!Array.isArray(structure)) {
         return null;
     }
 

--- a/src/app/layouts/default/header/menus/main-menu/main-menu.tsx
+++ b/src/app/layouts/default/header/menus/main-menu/main-menu.tsx
@@ -57,7 +57,7 @@ function MenusFromStructure({structure}: {structure: MenuItemData[]}) {
 }
 
 function MenusFromCMS() {
-    const structure = useDataFromSlug('oxmenus') as MenuItemData[] | undefined;
+    const structure = useDataFromSlug('oxmenus');
 
     // fetchFromCMS resolves with an {error} object (not an array) when the
     // CMS is unreachable, so a truthiness check alone lets it through to .map.

--- a/src/app/pages/details/common/resource-box/resource-box-utils.tsx
+++ b/src/app/pages/details/common/resource-box/resource-box-utils.tsx
@@ -18,6 +18,10 @@ function encodeLocation(search: string) {
 }
 
 export type ResourceData = {
+    // The through-row's own pk (BookFacultyResources/BookStudentResources),
+    // distinct from `resource.id` (the underlying Resource row) - this is
+    // what a resource_ref marker's `resourceId` matches against.
+    id?: number;
     linkExternal?: string;
     linkDocumentUrl?: string;
     linkDocument?: {

--- a/src/app/pages/flex-page/block-map.ts
+++ b/src/app/pages/flex-page/block-map.ts
@@ -4,7 +4,7 @@ import * as blocks from '@openstax/flex-page-renderer/blocks/index';
 import RawHTML from '~/components/jsx-helpers/raw-html';
 import {FAQBlock} from './blocks/FAQBlock';
 import {BookListBlock} from './blocks/BookListBlock';
-import {TableResourceLinksBlock} from './blocks/TableResourceLinksBlock';
+import {tableBlockEntry} from './blocks/TableResourceLinksBlock';
 
 // The renderer's html block sets the markup with dangerouslySetInnerHTML, and
 // innerHTML never executes <script> tags. RawHTML's `embed` mode re-creates them
@@ -27,5 +27,5 @@ export const blockMap = {
     html: {Component: HTMLBlock, config: blocks.html.config},
     faq: {Component: FAQBlock, config: FAQBlock.blockConfig},
     book_list: {Component: BookListBlock, config: BookListBlock.blockConfig},
-    table: {Component: TableResourceLinksBlock, config: blocks.table.config}
+    table: tableBlockEntry
 } as const;

--- a/src/app/pages/flex-page/blocks/FAQBlock.tsx
+++ b/src/app/pages/flex-page/blocks/FAQBlock.tsx
@@ -4,6 +4,7 @@ import RawHTML from '~/components/jsx-helpers/raw-html';
 import AccordionGroup from '~/components/accordion-group/accordion-group';
 import {ContentBlockRoot, type BlockData} from '@openstax/flex-page-renderer/ContentBlockRoot';
 import * as blocks from '@openstax/flex-page-renderer/blocks/index';
+import {tableBlockEntry} from './TableResourceLinksBlock';
 import {Image, type ImageFields} from '@openstax/flex-page-renderer/components/Image';
 import './FAQBlock.scss';
 
@@ -14,6 +15,11 @@ type FAQImageItem = {id: string; type: 'image'; value: {image: ImageFields; alt_
 type FAQContentItem = FAQImageItem | BlockData<typeof blocks>[number];
 
 const isFAQImage = (item: FAQContentItem): item is FAQImageItem => item.type === 'image';
+
+// Same override the page-level block map applies: without it a table inside
+// an FAQ item renders the renderer's stock TableBlock and its resource_ref
+// cells never resolve past the CMS's "View on book page" fallback.
+const faqBlocks = {...blocks, table: tableBlockEntry};
 
 export interface FAQBlockConfig {
     id: string;
@@ -38,7 +44,7 @@ export function FAQBlock({data}: {data: FAQBlockConfig}): React.ReactElement {
                 <RawHTML html={d.value.answer} />
                 {(d.value.content ?? []).map((item) => isFAQImage(item)
                     ? <Image key={item.id} image={item.value.image} alt={item.value.alt_text} />
-                    : <ContentBlockRoot key={item.id} data={[item]} blocks={blocks} />)}
+                    : <ContentBlockRoot key={item.id} data={[item]} blocks={faqBlocks} />)}
             </>
         }))
     , [data]);

--- a/src/app/pages/flex-page/blocks/TableResourceLinksBlock.tsx
+++ b/src/app/pages/flex-page/blocks/TableResourceLinksBlock.tsx
@@ -12,6 +12,14 @@ import {TableResourceCell} from './TableResourceCell';
 
 const Delegate = blocks.table.Component;
 
+// The block-map entry for `table`, shared with FAQBlock so tables nested
+// inside FAQ items resolve resource_ref markers too - FAQBlock can't import
+// the block map itself without a module cycle (block-map imports FAQBlock).
+export const tableBlockEntry = {
+    Component: TableResourceLinksBlock,
+    config: blocks.table.config
+};
+
 // Wraps the renderer's table block through its TableCellContext render slot
 // so cells carrying a resource_ref marker (an access-locked instructor/
 // student resource the CMS couldn't resolve server-side - its output is

--- a/src/app/pages/flex-page/blocks/table-resource-links-utils.ts
+++ b/src/app/pages/flex-page/blocks/table-resource-links-utils.ts
@@ -14,6 +14,10 @@ export type ResourceRefValue = {
     bookId: number;
     heading: string;
     resourceType: string;
+    // Newer markers carry the resources-API row's own id for an exact match;
+    // cached table JSON up to 30 days old predates this field, so it's
+    // optional and the heading match below stays the fallback.
+    resourceId?: number;
 };
 
 type ResourceRefConfigEntry = {type: 'resource_ref'; value: ResourceRefValue};
@@ -90,20 +94,73 @@ function headingOf(resource: ResourceData, isStudent: boolean): string | undefin
 
 function findMatchingResource(
     resources: ResourceData[] | undefined,
-    heading: string,
+    ref: ResourceRefValue,
     isStudent: boolean
 ): ResourceData | undefined {
     if (!resources) {
         return undefined;
     }
 
-    const target = normalizeHeading(heading);
+    // Id match first: the heading join drifts silently when the CMS and
+    // resources-API headings diverge, so an id on the marker wins outright.
+    // No id (older cached markers) or no row with that id falls through to
+    // the heading match, which must keep working either way.
+    if (ref.resourceId !== undefined) {
+        const byId = resources.find((r) => r.id === ref.resourceId);
+
+        if (byId) {
+            return byId;
+        }
+    }
+
+    const target = normalizeHeading(ref.heading);
 
     return resources.find((r) => {
         const candidate = headingOf(r, isStudent);
 
         return candidate && normalizeHeading(candidate) === target;
     });
+}
+
+// Module-level so every table on a page - and every concurrent mount of the
+// same book - shares one in-flight request instead of one per table (a page
+// like /k12-math with 18 marked tables over 12 distinct books was issuing
+// ~50 requests). Keyed on slug+verified since both affect the response.
+// Holds the *promise*, not the resolved payload, so two callers racing
+// before the first fetch settles still collapse onto one request.
+const resourcesCache = new Map<string, Promise<BookResourcesPayload | undefined>>();
+const unmatchedTelemetrySent = new Set<string>();
+
+export function resetResourcesCacheForTesting(): void {
+    resourcesCache.clear();
+    unmatchedTelemetrySent.clear();
+}
+
+function fetchBookResources(
+    slug: string,
+    isVerified: boolean | undefined
+): Promise<BookResourcesPayload | undefined> {
+    const cacheKey = `${slug}|${isVerified}`;
+    const cached = resourcesCache.get(cacheKey);
+
+    if (cached) {
+        return cached;
+    }
+
+    const title = slug.replace('books/', '');
+    const url = `books/resources/?slug=${title}&x=${isVerified ? 'x' : 'y'}`;
+    const promise = fetchFromCMS(url).then((raw) => {
+        if (raw?.error) {
+            // Don't cache a failure forever - a later mount should retry
+            // rather than being stuck with `undefined` for the page's life.
+            resourcesCache.delete(cacheKey);
+            return undefined;
+        }
+        return camelCaseKeys(raw) as object as BookResourcesPayload;
+    });
+
+    resourcesCache.set(cacheKey, promise);
+    return promise;
 }
 
 // Fetches `books/resources/` for every distinct book slug referenced by the
@@ -114,7 +171,8 @@ function findMatchingResource(
 // the rules of hooks (the number/identity of hook calls must stay constant
 // across renders). This hook calls `fetchFromCMS` directly instead - the same
 // call `useResources` makes internally - so behavior (URL shape, camelCasing,
-// the `x=` verified param) stays identical without invoking that hook.
+// the `x=` verified param) stays identical without invoking that hook. The
+// per-slug request itself is shared across every table via `resourcesCache`.
 export function useResourcesBySlug(
     slugs: string[],
     isVerified: boolean | undefined
@@ -135,18 +193,8 @@ export function useResourcesBySlug(
         let cancelled = false;
 
         Promise.all(
-            distinctSlugs.map((slug) => {
-                const title = slug.replace('books/', '');
-                const url = `books/resources/?slug=${title}&x=${isVerified ? 'x' : 'y'}`;
-
-                return fetchFromCMS(url).then((raw) => {
-                    const payload = raw?.error
-                        ? undefined
-                        : (camelCaseKeys(raw) as object as BookResourcesPayload);
-
-                    return [slug, payload] as const;
-                });
-            })
+            distinctSlugs.map((slug) => fetchBookResources(slug, isVerified)
+                .then((payload) => [slug, payload] as const))
         ).then((entries) => {
             if (cancelled) {
                 return;
@@ -187,13 +235,38 @@ function resolveOne(
     const isStudent = isStudentRef(location.ref);
     const resource = findMatchingResource(
         isStudent ? payload.bookStudentResources : payload.bookFacultyResources,
-        location.ref.heading,
+        location.ref,
         isStudent
     );
 
     return resource
         ? {...location, status: 'resolved', resource, bookId: location.ref.bookId}
         : {...location, status: 'unmatched'};
+}
+
+function unmatchedTelemetryKey(ref: ResourceRefValue): string {
+    return `${ref.bookSlug}|${normalizeHeading(ref.heading)}|${ref.resourceType.toLowerCase()}`;
+}
+
+// An unmatched marker still renders the CMS's own fallback link, so it fails
+// silently by design - both recent table bugs (a bad heading join, a stale
+// slug) were invisible until someone happened to click through. This is the
+// only signal that a marker went unresolved in production.
+function reportUnmatched(ref: ResourceRefValue): void {
+    const key = unmatchedTelemetryKey(ref);
+
+    if (unmatchedTelemetrySent.has(key)) {
+        return;
+    }
+    unmatchedTelemetrySent.add(key);
+
+    window.dataLayer ||= [];
+    window.dataLayer.push({
+        event: 'resourceRefUnmatched',
+        bookSlug: ref.bookSlug,
+        heading: ref.heading,
+        resourceType: ref.resourceType
+    });
 }
 
 // The multi-slug resolution hook: given every resource_ref marker found in a
@@ -213,9 +286,18 @@ export function useResourceRefResolutions(refs: ResourceRefLocation[]): Resource
     );
     const {isVerified} = useUserContext();
     const resourcesBySlug = useResourcesBySlug(slugs, isVerified);
-
-    return React.useMemo(
+    const resolutions = React.useMemo(
         () => refs.map((location) => resolveOne(location, resourcesBySlug[location.ref.bookSlug])),
         [refs, resourcesBySlug]
     );
+
+    // An effect, not inline in the memo above: reporting is a side effect
+    // (dataLayer.push), and the memo body needs to stay a pure derivation.
+    React.useEffect(() => {
+        resolutions
+            .filter((resolution) => resolution.status === 'unmatched')
+            .forEach((resolution) => reportUnmatched(resolution.ref));
+    }, [resolutions]);
+
+    return resolutions;
 }

--- a/test/src/layouts/default/main-menu.test.tsx
+++ b/test/src/layouts/default/main-menu.test.tsx
@@ -4,6 +4,7 @@ import ShellContextProvider from '../../../helpers/shell-context';
 import MainMenu from '~/layouts/default/header/menus/main-menu/main-menu';
 import MemoryRouter from '../../../helpers/future-memory-router';
 import * as ULC from '~/contexts/language';
+import * as PDU from '~/helpers/page-data-utils';
 
 jest.mock('~/models/give-today', () => jest.fn().mockReturnValue({}));
 
@@ -28,6 +29,18 @@ describe('main-menu', () => {
 
         await screen.findByRole('link', {name: 'Math'});
         expect(screen.queryByRole('link', {name: 'Spanish'})).toBeNull();
+    });
+    // fetchFromCMS resolves with a truthy {error} object when the CMS is
+    // unreachable; the menu must not .map over it (Sentry: e.map is not a
+    // function during the 8/25-8/26 CMS outages).
+    it('renders no CMS menus when the fetch resolves with an error object', async () => {
+        const spy = jest.spyOn(PDU, 'useDataFromSlug')
+            .mockReturnValue({error: new Error('Failed to fetch'), slug: 'oxmenus'});
+
+        expect(() => render(<Component />)).not.toThrow();
+
+        await screen.findByRole('link', {name: '🍎 For K12 Teachers'});
+        spy.mockRestore();
     });
     it('hides k12 item in Spanish', async () => {
         const spyLang = jest.spyOn(ULC, 'default').mockReturnValue({language: 'es', setLanguage: jest.fn()});

--- a/test/src/pages/flex-page/blocks/FAQBlock.test.tsx
+++ b/test/src/pages/flex-page/blocks/FAQBlock.test.tsx
@@ -3,6 +3,7 @@ import {render, screen, waitFor} from '@testing-library/preact';
 import {LanguageContextProvider} from '~/contexts/language';
 import MemoryRouter from '~/../../test/helpers/future-memory-router';
 import {FAQBlock, type FAQBlockConfig} from '~/pages/flex-page/blocks/FAQBlock';
+import {resetResourcesCacheForTesting} from '~/pages/flex-page/blocks/table-resource-links-utils';
 
 const mockUseUserContext = jest.fn();
 
@@ -80,6 +81,7 @@ describe('FAQBlock', () => {
     beforeEach(() => {
         mockFetchFromCMS.mockReset();
         mockUseUserContext.mockReset();
+        resetResourcesCacheForTesting();
     });
 
     // Regression: FAQBlock used to hand ContentBlockRoot the renderer's raw

--- a/test/src/pages/flex-page/blocks/FAQBlock.test.tsx
+++ b/test/src/pages/flex-page/blocks/FAQBlock.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {render, screen, waitFor} from '@testing-library/preact';
+import {LanguageContextProvider} from '~/contexts/language';
+import MemoryRouter from '~/../../test/helpers/future-memory-router';
+import {FAQBlock, type FAQBlockConfig} from '~/pages/flex-page/blocks/FAQBlock';
+
+const mockUseUserContext = jest.fn();
+
+jest.mock('~/contexts/user', () => ({
+    ...jest.requireActual('~/contexts/user'),
+    __esModule: true,
+    default: () => mockUseUserContext()
+}));
+
+const mockFetchFromCMS = jest.fn();
+
+jest.mock('~/helpers/page-data-utils', () => ({
+    ...jest.requireActual('~/helpers/page-data-utils'),
+    fetchFromCMS: (...args: [string]) => mockFetchFromCMS(...args)
+}));
+
+/* eslint-disable camelcase */
+
+function Wrap({children}: React.PropsWithChildren) {
+    return (
+        <MemoryRouter initialEntries={['/some-flex-page']}>
+            <LanguageContextProvider>{children}</LanguageContextProvider>
+        </MemoryRouter>
+    );
+}
+
+// A faq whose item content nests a table carrying a resource_ref marker -
+// the k12 subject pages' structure. The marker keys are camelCase because
+// usePageData camelCases the page payload before blocks see it.
+function faqWithMarkedTable(): FAQBlockConfig {
+    return {
+        id: 'faq-1',
+        type: 'faq',
+        value: [{
+            id: 'q1',
+            value: {
+                question: 'Answer Guides',
+                slug: 'answer-guides',
+                answer: '<p>the guides</p>',
+                document: null,
+                content: [{
+                    id: 'table-1',
+                    type: 'table',
+                    value: {
+                        caption: '',
+                        columns: [{header: 'Resource'}],
+                        rows: [{
+                            cells: [{
+                                content: '',
+                                cta: [{
+                                    text: 'View on book page',
+                                    aria_label: '',
+                                    target: {value: '/details/books/biology-2e?Instructor%20resources', type: 'internal'},
+                                    config: [{
+                                        type: 'resource_ref',
+                                        value: {
+                                            bookSlug: 'biology-2e',
+                                            bookId: 46,
+                                            heading: 'Instructor’s Manual',
+                                            resourceType: 'Instructor'
+                                        }
+                                    }]
+                                }]
+                            }]
+                        }],
+                        config: []
+                    }
+                } as unknown as NonNullable<FAQBlockConfig['value'][number]['value']['content']>[number]]
+            }
+        }]
+    };
+}
+
+describe('FAQBlock', () => {
+    beforeEach(() => {
+        mockFetchFromCMS.mockReset();
+        mockUseUserContext.mockReset();
+    });
+
+    // Regression: FAQBlock used to hand ContentBlockRoot the renderer's raw
+    // block set, so a table nested in a faq item rendered the stock
+    // TableBlock and its resource_ref cells never resolved past the CMS's
+    // "View on book page" fallback.
+    it('resolves resource_ref markers in tables nested inside faq items', async () => {
+        mockUseUserContext.mockReturnValue({userStatus: {isInstructor: true}, isVerified: true});
+        mockFetchFromCMS.mockResolvedValue({
+            book_faculty_resources: [{
+                resource: {heading: 'Instructor’s Manual', resource_unlocked: false},
+                link_text: 'Download',
+                link_document: {file: 'https://files.example.com/resource.pdf'}
+            }]
+        });
+
+        render(<Wrap><FAQBlock data={faqWithMarkedTable()} /></Wrap>);
+
+        await waitFor(() => {
+            expect(mockFetchFromCMS).toHaveBeenCalledWith(
+                expect.stringContaining('books/resources/?slug=biology-2e')
+            );
+        });
+        await waitFor(() => {
+            const link = document.querySelector('a[href="https://files.example.com/resource.pdf"]');
+
+            expect(link).not.toBe(null);
+        });
+        expect(screen.getByText('Answer Guides')).toBeTruthy();
+    });
+});

--- a/test/src/pages/flex-page/blocks/TableResourceLinksBlock.data-identity.test.tsx
+++ b/test/src/pages/flex-page/blocks/TableResourceLinksBlock.data-identity.test.tsx
@@ -39,6 +39,7 @@ jest.mock('@openstax/flex-page-renderer/blocks/index', () => ({
 }));
 
 import {TableResourceLinksBlock} from '~/pages/flex-page/blocks/TableResourceLinksBlock';
+import {resetResourcesCacheForTesting} from '~/pages/flex-page/blocks/table-resource-links-utils';
 import {blockMap} from '~/pages/flex-page/block-map';
 
 // resource_ref markers are snake_case (the CMS/marker contract).
@@ -85,6 +86,7 @@ describe('TableResourceLinksBlock data identity', () => {
         mockDelegateRender.mockClear();
         mockFetchFromCMS.mockReset();
         mockUseUserContext.mockReset();
+        resetResourcesCacheForTesting();
     });
 
     it('hands the delegate the exact same data object for a marker-free table', () => {

--- a/test/src/pages/flex-page/blocks/TableResourceLinksBlock.test.tsx
+++ b/test/src/pages/flex-page/blocks/TableResourceLinksBlock.test.tsx
@@ -9,6 +9,7 @@ import type {
 import {LanguageContextProvider} from '~/contexts/language';
 import MemoryRouter from '~/../../test/helpers/future-memory-router';
 import {TableResourceLinksBlock} from '~/pages/flex-page/blocks/TableResourceLinksBlock';
+import {resetResourcesCacheForTesting} from '~/pages/flex-page/blocks/table-resource-links-utils';
 
 const mockUseUserContext = jest.fn();
 
@@ -87,6 +88,7 @@ describe('TableResourceLinksBlock', () => {
     beforeEach(() => {
         mockFetchFromCMS.mockReset();
         mockUseUserContext.mockReset();
+        resetResourcesCacheForTesting();
     });
 
     it('renders the delegate for a marker-free table with no fetch', () => {

--- a/test/src/pages/flex-page/blocks/table-resource-links-utils.test.tsx
+++ b/test/src/pages/flex-page/blocks/table-resource-links-utils.test.tsx
@@ -6,6 +6,7 @@ import {
     findResourceRefs,
     normalizeHeading,
     useResourceRefResolutions,
+    resetResourcesCacheForTesting,
     type TableBlockConfig,
     type TableCellConfig
 } from '~/pages/flex-page/blocks/table-resource-links-utils';
@@ -162,20 +163,24 @@ function studentResourcesPayload(heading: string, extra: Record<string, unknown>
     };
 }
 
-function ResolutionsHarness({refs}: {refs: Parameters<typeof useResourceRefResolutions>[0]}) {
+function ResolutionsHarness({
+    refs,
+    testId = 'resolutions'
+}: {refs: Parameters<typeof useResourceRefResolutions>[0]; testId?: string}) {
     const resolutions = useResourceRefResolutions(refs);
 
-    return <pre data-testid="resolutions">{JSON.stringify(resolutions)}</pre>;
+    return <pre data-testid={testId}>{JSON.stringify(resolutions)}</pre>;
 }
 
-function readResolutions() {
-    return JSON.parse(screen.getByTestId('resolutions').textContent ?? '[]');
+function readResolutions(testId = 'resolutions') {
+    return JSON.parse(screen.getByTestId(testId).textContent ?? '[]');
 }
 
 describe('useResourceRefResolutions', () => {
     beforeEach(() => {
         mockFetchFromCMS.mockReset();
         mockUseUserContext.mockReset();
+        resetResourcesCacheForTesting();
     });
 
     it('reports loading for every ref before the fetch resolves', () => {
@@ -347,5 +352,216 @@ describe('useResourceRefResolutions', () => {
 
         expect(readResolutions()).toEqual([]);
         expect(mockFetchFromCMS).not.toHaveBeenCalled();
+    });
+});
+
+describe('id-first matching', () => {
+    beforeEach(() => {
+        mockFetchFromCMS.mockReset();
+        mockUseUserContext.mockReset();
+        resetResourcesCacheForTesting();
+    });
+
+    it('matches by resourceId even when the marker heading disagrees with the API row', async () => {
+        mockUseUserContext.mockReturnValue({isVerified: true});
+        mockFetchFromCMS.mockResolvedValue(facultyResourcesPayload('API Heading Drifted', {id: 999}));
+        const cta = resourceRefCta({
+            config: [{
+                type: 'resource_ref',
+                value: {
+                    bookSlug: 'biology-2e',
+                    bookId: 46,
+                    heading: 'A Totally Different Heading',
+                    resourceType: 'Instructor',
+                    resourceId: 999
+                }
+            }]
+        });
+        const refs = findResourceRefs(tableWithCells([[{cta: [cta]}]]));
+
+        render(<ResolutionsHarness refs={refs} />);
+
+        await waitFor(() => {
+            const [resolution] = readResolutions();
+
+            expect(resolution.status).toBe('resolved');
+        });
+        expect(readResolutions()[0].resource.id).toBe(999);
+    });
+
+    it('still matches by heading when the marker carries no resourceId (cached pre-id markers)', async () => {
+        mockUseUserContext.mockReturnValue({isVerified: true});
+        mockFetchFromCMS.mockResolvedValue(facultyResourcesPayload('Instructor’s Manual', {id: 42}));
+        // resourceRefCta's default value has no resourceId at all.
+        const refs = findResourceRefs(tableWithCells([[{cta: [resourceRefCta()]}]]));
+
+        render(<ResolutionsHarness refs={refs} />);
+
+        await waitFor(() => {
+            const [resolution] = readResolutions();
+
+            expect(resolution.status).toBe('resolved');
+        });
+        expect(readResolutions()[0].resource.id).toBe(42);
+    });
+
+    it('falls back to the heading match when resourceId matches no row in the pool', async () => {
+        mockUseUserContext.mockReturnValue({isVerified: true});
+        mockFetchFromCMS.mockResolvedValue(facultyResourcesPayload('Instructor’s Manual', {id: 5}));
+        const cta = resourceRefCta({
+            config: [{
+                type: 'resource_ref',
+                value: {
+                    bookSlug: 'biology-2e',
+                    bookId: 46,
+                    heading: 'Instructor’s Manual',
+                    resourceType: 'Instructor',
+                    resourceId: 123456
+                }
+            }]
+        });
+        const refs = findResourceRefs(tableWithCells([[{cta: [cta]}]]));
+
+        render(<ResolutionsHarness refs={refs} />);
+
+        await waitFor(() => {
+            const [resolution] = readResolutions();
+
+            expect(resolution.status).toBe('resolved');
+        });
+        expect(readResolutions()[0].resource.id).toBe(5);
+    });
+});
+
+describe('per-slug request cache', () => {
+    beforeEach(() => {
+        mockFetchFromCMS.mockReset();
+        mockUseUserContext.mockReset();
+        resetResourcesCacheForTesting();
+    });
+
+    it('shares a single fetchFromCMS call across two tables referencing the same book and verified flag', async () => {
+        mockUseUserContext.mockReturnValue({isVerified: true});
+        mockFetchFromCMS.mockResolvedValue(facultyResourcesPayload('Instructor’s Manual'));
+        const refsA = findResourceRefs(tableWithCells([[{cta: [resourceRefCta()]}]]));
+        const refsB = findResourceRefs(tableWithCells([[{cta: [resourceRefCta()]}]]));
+
+        render(
+            <React.Fragment>
+                <ResolutionsHarness refs={refsA} testId="a" />
+                <ResolutionsHarness refs={refsB} testId="b" />
+            </React.Fragment>
+        );
+
+        await waitFor(() => {
+            expect(readResolutions('a')[0].status).toBe('resolved');
+            expect(readResolutions('b')[0].status).toBe('resolved');
+        });
+        expect(mockFetchFromCMS).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache an error payload - a later mount for the same key refetches', async () => {
+        mockUseUserContext.mockReturnValue({isVerified: true});
+        mockFetchFromCMS.mockResolvedValueOnce({error: 'not found'});
+        const refs = findResourceRefs(tableWithCells([[{cta: [resourceRefCta()]}]]));
+
+        const {unmount} = render(<ResolutionsHarness refs={refs} />);
+
+        // Let fetchBookResources's own `.then` run (it deletes the cache
+        // entry on an error payload) before the second mount checks it.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(mockFetchFromCMS).toHaveBeenCalledTimes(1);
+        unmount();
+
+        mockFetchFromCMS.mockResolvedValueOnce(facultyResourcesPayload('Instructor’s Manual'));
+        render(<ResolutionsHarness refs={refs} />);
+
+        await waitFor(() => {
+            const [resolution] = readResolutions();
+
+            expect(resolution.status).toBe('resolved');
+        });
+        expect(mockFetchFromCMS).toHaveBeenCalledTimes(2);
+    });
+});
+
+type DataLayerEvent = {event: string; [key: string]: unknown};
+
+function unmatchedTelemetryEvents(): DataLayerEvent[] {
+    return (window.dataLayer as unknown as DataLayerEvent[]).filter((e) => e.event === 'resourceRefUnmatched');
+}
+
+describe('unmatched telemetry', () => {
+    beforeEach(() => {
+        mockFetchFromCMS.mockReset();
+        mockUseUserContext.mockReset();
+        resetResourcesCacheForTesting();
+        window.dataLayer = [];
+    });
+
+    afterEach(() => {
+        window.dataLayer = [];
+    });
+
+    it('pushes one resourceRefUnmatched event for a distinct unmatched ref, deduped across mounts', async () => {
+        mockUseUserContext.mockReturnValue({isVerified: true});
+        mockFetchFromCMS.mockResolvedValue(facultyResourcesPayload('Some Unrelated Resource'));
+        // Two separate tables both reference the same unmatched marker (same
+        // slug/heading/type but distinct ResolutionsHarness mounts, so each
+        // computes its own resolutions array) - this is what actually
+        // exercises the "already reported" branch of the dedup check, unlike
+        // a single component re-rendering with the same memoized resolutions.
+        const refsA = findResourceRefs(tableWithCells([[{cta: [resourceRefCta()]}]]));
+        const refsB = findResourceRefs(tableWithCells([[{cta: [resourceRefCta()]}]]));
+
+        render(
+            <React.Fragment>
+                <ResolutionsHarness refs={refsA} testId="a" />
+                <ResolutionsHarness refs={refsB} testId="b" />
+            </React.Fragment>
+        );
+
+        await waitFor(() => {
+            expect(readResolutions('a')[0].status).toBe('unmatched');
+            expect(readResolutions('b')[0].status).toBe('unmatched');
+        });
+
+        // The telemetry push happens in a useEffect, which - unlike the
+        // status-driven state update above - flushes on its own schedule
+        // rather than in the same commit `waitFor` just observed, so it
+        // needs its own poll.
+        await waitFor(() => {
+            expect(unmatchedTelemetryEvents()).toEqual([{
+                event: 'resourceRefUnmatched',
+                bookSlug: 'biology-2e',
+                heading: 'Instructor’s Manual',
+                resourceType: 'Instructor'
+            }]);
+        });
+    });
+
+    it('does not push a resourceRefUnmatched event for a resolved ref', async () => {
+        mockUseUserContext.mockReturnValue({isVerified: true});
+        mockFetchFromCMS.mockResolvedValue(facultyResourcesPayload('Instructor’s Manual'));
+        const refs = findResourceRefs(tableWithCells([[{cta: [resourceRefCta()]}]]));
+
+        render(<ResolutionsHarness refs={refs} />);
+
+        await waitFor(() => {
+            const [resolution] = readResolutions();
+
+            expect(resolution.status).toBe('resolved');
+        });
+
+        // Give the reporting effect a chance to flush (it runs on its own
+        // schedule, separate from the status-driven render above) before
+        // confirming it had nothing to report.
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+
+        expect(unmatchedTelemetryEvents()).toEqual([]);
     });
 });


### PR DESCRIPTION
Fixes and hardening from tonight's Sentry/prod-tables investigation, plus the design-review follow-ups. Companion CMS PR: openstax/openstax-cms#1779.

## 1. Resource tables inside FAQ accordions never resolved (the prod "View on book page" issue)

`FAQBlock` handed `ContentBlockRoot` the renderer's **raw block set** instead of the page block map, so any table nested in an FAQ item rendered the stock TableBlock — its `resource_ref` markers never resolved and every locked resource kept the CMS's static "View on book page" fallback. That's all 18 tables on /k12-math (they all sit in FAQ accordions). Top-level tables were unaffected, which is why the same build looked correct on test pages and made this masquerade as an environment difference.

Fix: share the block-map `table` entry (`tableBlockEntry`) with FAQBlock via the TableResourceLinksBlock module (FAQBlock can't import the block map without a module cycle). Verified in the browser against the prod API: all 12 referenced books' `books/resources` fetches fire and marked cells render the real resource-box buttons.

## 2. Main menu crashed the header during CMS outages

`fetchFromCMS` resolves with a truthy `{error}` object when `fetch` itself throws; `MenusFromCMS` was the one `useDataFromSlug` consumer that only checked truthiness before `.map` — Sentry `e.map is not a function` during the 8/25–8/26 CMS outages. Now guarded with `Array.isArray`.

## 3. Marker matching hardened: id-first, request dedupe, unmatched telemetry

- **Id-first matching**: markers now match the resources-API row by its `id` (emitted by openstax/openstax-cms#1779), falling back to the normalized-heading join for cached table JSON (up to 30 days) that predates `resource_id` — the heading join drifts silently when headings diverge (live example on prod today: prealgebra-2e's "Links to Literacy").
- **Request dedupe**: one in-flight `books/resources/` request per slug+verified across all tables on a page via a module-level promise cache (/k12-math: ~50 requests → 12). Error responses aren't cached, so later mounts retry.
- **Unmatched telemetry**: a `resourceRefUnmatched` GTM event (deduped per slug+heading+type) fires when a marker resolves with nothing to show — unmatched markers fail silently by design, which is exactly why both table bugs went unnoticed.

This also makes the `Student` resource path actually resolvable — the CMS PR adds `book_student_resources` to the endpoint; the matching code here reads it.

## 4. Renderer bump → LinkComponent null-target guard (pending tag)

openstax/flex-pages#36 makes `LinkComponent` render nothing for a CTA whose author never set a link target (`target: null`), instead of crashing the page tree (Sentry OSWEB-D5M — six live CTAs across five prod pages). The `renderer-1.1.25-rc.1` bump commit lands here once the tag is published; final non-RC pin after flex-pages#36 merges.

## Tests

- Regression tests for the FAQ nesting bug, the menu crash, id-first/heading-fallback matching, the per-slug request cache (including error-not-cached), and telemetry dedup
- Full suite: 189 suites / 843 tests green at 100% coverage; `yarn lint` clean
