### PR TITLE
Remove the duplicate Explore-by-subject image grid from the blog landing page

### DIFF
--- a/src/app/pages/blog/blog-pages.tsx
+++ b/src/app/pages/blog/blog-pages.tsx
@@ -4,7 +4,6 @@ import {useParams} from 'react-router-dom';
 import {WindowContextProvider} from '~/contexts/window';
 import useDocumentHead from '~/helpers/use-document-head';
 import RawHTML from '~/components/jsx-helpers/raw-html';
-import ExploreBy from '~/components/explore-by/explore-by';
 import PinnedArticle from './pinned-article/pinned-article';
 import MoreStories from './more-stories/more-stories';
 import {HeadingAndSearchBar} from '~/components/search-bar/search-bar';
@@ -57,20 +56,9 @@ function hasActiveQuery({q, subjects, collection, sort}: SearchState) {
     return Boolean(q || subjects.length || collection || sort !== 'relevance');
 }
 
-function DiscoveryContent({
-    categories,
-    pinnedSlug
-}: {
-    categories: ReturnType<typeof useBlogContext>['subjectSnippet'];
-    pinnedSlug?: string;
-}) {
+function DiscoveryContent({pinnedSlug}: {pinnedSlug?: string}) {
     return (
         <React.Fragment>
-            <ExploreBy
-                items={categories}
-                title="Explore by subject"
-                analyticsNav="Blog Subjects"
-            />
             <PinnedArticle />
             <MoreStories exceptSlug={pinnedSlug || ''} />
         </React.Fragment>
@@ -124,10 +112,7 @@ export function MainBlogPage() {
                 {isActive ? (
                     <SearchResults />
                 ) : (
-                    <DiscoveryContent
-                        categories={categories}
-                        pinnedSlug={pinnedSlug}
-                    />
+                    <DiscoveryContent pinnedSlug={pinnedSlug} />
                 )}
             </div>
             <div className="write-for-us">

--- a/test/src/components/explore-by.test.tsx
+++ b/test/src/components/explore-by.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/preact';
+import MemoryRouter from '~/../../test/helpers/future-memory-router';
+import ExploreBy from '~/components/explore-by/explore-by';
+
+describe('explore-by', () => {
+    it('renders subject cards with encoded links and optional icons', () => {
+        const {container} = render(
+            <MemoryRouter initialEntries={['/blog']}>
+                <ExploreBy
+                    items={[
+                        {id: 1, name: 'Math & Science', subjectIcon: '/images/math.svg'},
+                        {id: 2, name: 'Biology'}
+                    ]}
+                    title="Explore by subject"
+                    analyticsNav="Blog Subjects"
+                />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByRole('heading', {level: 2, name: 'Explore by subject'})).toBeInTheDocument();
+        expect(container.querySelector('.item-links')).toHaveAttribute('data-analytics-nav', 'Blog Subjects');
+        expect(screen.getByRole('link', {name: 'Math & Science'})).toHaveAttribute(
+            'href',
+            '/explore/subjects/Math%20%26%20Science'
+        );
+        expect(screen.getByRole('link', {name: 'Biology'})).toHaveAttribute(
+            'href',
+            '/explore/subjects/Biology'
+        );
+        expect(container.querySelectorAll('img')).toHaveLength(1);
+        expect(container.querySelector('img')).toHaveAttribute('src', '/images/math.svg');
+    });
+});

--- a/test/src/pages/blog/blog-unified.test.tsx
+++ b/test/src/pages/blog/blog-unified.test.tsx
@@ -23,7 +23,7 @@ describe('Unified MainBlogPage', () => {
         await waitFor(() =>
             expect(screen.getByRole('group', {name: 'Filter by subject'})).toBeInTheDocument()
         );
-        expect(screen.queryByText('Explore by subject')).not.toBeInTheDocument();
+        expect(screen.queryByText('Featured blog post')).not.toBeInTheDocument();
     });
 
     it('uses the CMS news-page title for the heading', async () => {
@@ -37,7 +37,7 @@ describe('Unified MainBlogPage', () => {
     it('shows discovery content and facet controls when no query or facets', async () => {
         renderMainBlog('/blog/');
         await waitFor(() =>
-            expect(screen.getByText('Explore by subject')).toBeInTheDocument()
+            expect(screen.getByText('Featured blog post')).toBeInTheDocument()
         );
         expect(screen.getByRole('group', {name: 'Filter by subject'})).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- The blog landing page had two subject lists: the filter pills and an "Explore by subject" image-card grid. This removes the grid and keeps the pills, which also persist while filtering/browsing.
- The `ExploreBy` component itself is untouched — the webinars page still uses it.

## Test plan
- Updated `blog-unified.test.tsx` to use "Featured blog post" as the discovery-content marker instead of "Explore by subject".
- All 52 blog tests pass; `tsc` and eslint clean.