### PR TITLE
Serve K12 subject pages at /k12/<subject>

### DIFF
--- a/src/app/components/shell/router-helpers/page-routes.tsx
+++ b/src/app/components/shell/router-helpers/page-routes.tsx
@@ -124,14 +124,17 @@ const mismatch: Record<string, string> = {
 };
 
 export function usePageDataFromRoute() {
-    const {dir: name, '*': other} = useParams();
+    const {dir, '*': other} = useParams();
+    // K12 subject pages render at /k12/<subject>; their CMS slugs are k12-<subject>
+    const [name, subPath] =
+        dir === 'k12' && other ? [`k12-${other}`, ''] : [dir, other];
     const data = usePageData<PageData>(
         `pages/${mismatch[name as string] ?? name}`,
         true
     );
     const hasError = data && 'error' in data;
 
-    return {name, data, hasError, other};
+    return {name, data, hasError, other: subPath};
 }
 
 export function FlexPageUsingItsOwnLayout({data}: {data: FlexPageData}) {

--- a/test/src/components/shell.test.tsx
+++ b/test/src/components/shell.test.tsx
@@ -24,6 +24,7 @@ import homePage from '../data/home-page';
 import subjectPage from '../data/new-subjects';
 import flexPage from '../data/flex-page';
 import generalPage from '../data/general-page';
+import k12PageData from '../data/k12';
 import ChildrenContainer from '~/../../test/helpers/mock-children-container';
 
 const {useLocation} = RRD;
@@ -85,6 +86,11 @@ describe('shell', () => {
                 return {error: 'intentional'};
             case 'pages/general-page':
                 return camelCaseKeys(transformData(generalPage));
+            case 'pages/k12':
+                return camelCaseKeys(transformData(k12PageData));
+            case 'pages/k12-math':
+                // @ts-expect-error flexPage type
+                return camelCaseKeys(flexPage);
             default:
                 if (path.startsWith('errata/') || path.startsWith('pages/')
                 || path.startsWith('snippets/roles')) {
@@ -284,6 +290,20 @@ describe('shell', () => {
         mockBrowserInitialEntries(['/flex-page/extra/junk']);
         render(AppElement);
         await screen.findByRole('heading', {level: 2, name: 'Apply today to be an OpenStax Partner'});
+    });
+    it('routes "/k12/<subject>" to the "k12-<subject>" CMS page', async () => {
+        setPortalPrefix('');
+        mockBrowserInitialEntriesWithLocation(['/k12/math']);
+        render(AppElement);
+        await screen.findByRole('heading', {level: 2, name: 'Apply today to be an OpenStax Partner'});
+        // Renders in place -- no canonicalization redirect away from the subject URL
+        await screen.findByText('-/k12/math-');
+    });
+    it('routes "/k12" (no subject) to the "k12" CMS page as before', async () => {
+        setPortalPrefix('');
+        mockBrowserInitialEntries(['/k12']);
+        render(AppElement);
+        await screen.findByRole('link', {name: 'Algebra'});
     });
     it('loads general page within a portal route', async () => {
         setPortalPrefix('/landing-page');


### PR DESCRIPTION
## What

`/k12/<subject>` renders the CMS page whose slug is `k12-<subject>` (e.g. `/k12/math` renders the `k12-math` flex page). `/k12` itself is unchanged. Implemented in `usePageDataFromRoute`: when the first path segment is `k12` and a sub-path exists, the fetched slug becomes `k12-<subpath>` and the canonicalization redirect is suppressed for that route.

## Why

`/k12/<subject>` is the canonical URL shape for the K12 subject-group pages. Flex pages are fetched by flat slug from the first path segment, so without this mapping the sub-path routes to the k12 landing page. A companion CMS PR makes Wagtail resolve page-chooser links, `html_url`, and sitemap entries to the same URLs, and a companion bit-deployment PR adds the 301s that make them canonical (both linked below). Unknown subjects (`/k12/nope` → `pages/k12-nope`) 404 through the existing error path.

## Verification

- New tests: `/k12/math` fetches `pages/k12-math`, renders the flex page, and stays at `/k12/math`; `/k12` still fetches `pages/k12`.
- `yarn lint` clean; full `yarn test` green (836 tests, 100% coverage threshold).

## Deploy notes

Release this **before** the companion CMS/bit-deployment deploy — the SPA must serve `/k12/<subject>` before anything redirects to or links to those URLs.

## Companion PRs

- CMS (crawler serving + URL resolution): https://github.com/openstax/openstax-cms/pull/1780
- bit-deployment (301s + crawler map): https://github.com/openstax/bit-deployment/pull/168
