### PR TITLE
Preserve query strings through tracking and client redirects

### DIFF
--- a/src/app/components/shell/router-helpers/page-routes.tsx
+++ b/src/app/components/shell/router-helpers/page-routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useParams, Routes, Route, Navigate} from 'react-router-dom';
+import {useParams, useLocation, Routes, Route, Navigate} from 'react-router-dom';
 import usePageData from '~/helpers/use-page-data';
 import FlexPage, {
     FlexPageData,
@@ -40,9 +40,11 @@ export function ErrataRoutes() {
 }
 
 export function DetailsRoutes() {
+    const {search} = useLocation();
+
     return (
         <Routes>
-            <Route index element={<Navigate to="/subjects" replace />} />
+            <Route index element={<Navigate to={{pathname: '/subjects', search}} replace />} />
             <Route
                 path="/books/:title"
                 element={<ImportedPage name="details" />}
@@ -58,6 +60,7 @@ export function DetailsRoutes() {
 export function OtherPageRoutes() {
     const dir = assertDefined(useParams().dir);
     const {'*': path} = useParams();
+    const {search} = useLocation();
 
     if (['books', 'textbooks'].includes(dir)) {
         return (
@@ -77,7 +80,7 @@ export function OtherPageRoutes() {
     if (dir === 'general') {
         return (
             <NonPortalRouteWrapper>
-                <Navigate to={`/${path}`} replace />
+                <Navigate to={{pathname: `/${path}`, search}} replace />
             </NonPortalRouteWrapper>
         );
     }
@@ -85,7 +88,7 @@ export function OtherPageRoutes() {
     if (dir === 'home') {
         return (
             <NonPortalRouteWrapper>
-                <Navigate to="/" replace />
+                <Navigate to={{pathname: '/', search}} replace />
             </NonPortalRouteWrapper>
         );
     }
@@ -161,8 +164,9 @@ export function NonFlexPageUsingDefaultLayout({data}: {data: PageData}) {
 
 function RedirectToCanonicalDetailsPage() {
     const {title} = useParams();
+    const {search} = useLocation();
 
-    return <Navigate to={`/details/books/${title}`} replace />;
+    return <Navigate to={{pathname: `/details/books/${title}`, search}} replace />;
 }
 
 const FOOTER_PAGES = [

--- a/src/app/components/shell/router-helpers/portal-page-routes.tsx
+++ b/src/app/components/shell/router-helpers/portal-page-routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Routes, Route, Navigate} from 'react-router-dom';
+import {Routes, Route, Navigate, useLocation} from 'react-router-dom';
 import Error404 from '~/pages/404/404';
 import usePortalContext from '~/contexts/portal';
 import FlexPage, {
@@ -22,6 +22,7 @@ import {ImportedPage} from './page-loaders';
 export function RouteAsPortalOrNot() {
     const {name, data, hasError, other} = usePageDataFromRoute();
     const {portalPrefix, setPortal, setIsK12Portal} = usePortalContext();
+    const {search} = useLocation();
 
     if (!data) {
         return null;
@@ -72,7 +73,7 @@ export function RouteAsPortalOrNot() {
     if (isFlex) {
         if (other) {
             // Non-portal flex pages do not have children; keep it canonical
-            return <Navigate to={`/${name}`} />;
+            return <Navigate to={{pathname: `/${name}`, search}} />;
         }
         return <FlexPageUsingItsOwnLayout data={data} />;
     }

--- a/src/app/components/shell/router-helpers/use-link-handler.ts
+++ b/src/app/components/shell/router-helpers/use-link-handler.ts
@@ -62,6 +62,12 @@ function reportDownload(trackingInfo: TrackingInfo) {
     });
 }
 
+function trackOutboundClick(href: string) {
+    if ('piTracker' in window && window.piTracker instanceof Function) {
+        window.piTracker(href.split('#')[0]);
+    }
+}
+
 export default function useLinkHandler() {
     const navigate = useNavigate();
     const navigateTo = useCallback(
@@ -97,9 +103,10 @@ export default function useLinkHandler() {
                 }
             };
 
-            // Pardot tracking
-            if ('piTracker' in window && window.piTracker instanceof Function) {
-                window.piTracker(fullyQualifiedHref.split('#')[0]);
+            // internal destinations report their own page view, on route
+            // change or on load; only outbound clicks need reporting here
+            if (linkHelper.isExternal(fullyQualifiedHref)) {
+                trackOutboundClick(fullyQualifiedHref);
             }
 
             if (e.trackingInfo) {

--- a/src/app/components/shell/router.tsx
+++ b/src/app/components/shell/router.tsx
@@ -43,8 +43,8 @@ function SkipToContent() {
 export default function Router() {
     const linkHandler = useLinkHandler() as unknown as (ev: MouseEvent) => void;
     const {origin} = window.location; // React-Router Location does not have origin
-    const {pathname, hash} = useLocation();
-    const canonicalUrl = `${origin}${pathname}`;
+    const {pathname, hash, search} = useLocation();
+    const trackedUrl = `${origin}${pathname}${search}`;
     const {isK12Portal} = usePortalContext();
 
     // Browsers keep the scroll offset across a pushState navigation, so without
@@ -64,9 +64,9 @@ export default function Router() {
 
     useEffect(() => {
         if ('piTracker' in window && window.piTracker instanceof Function) {
-            window.piTracker(canonicalUrl);
+            window.piTracker(trackedUrl);
         }
-    }, [canonicalUrl]);
+    }, [trackedUrl]);
 
     // Initialize GTM only when isK12Portal is explicitly false
     // isK12Portal starts as true (GTM disabled), then routing logic sets it to false when safe

--- a/test/src/components/shell.test.tsx
+++ b/test/src/components/shell.test.tsx
@@ -51,7 +51,7 @@ describe('shell', () => {
     function LocationDisplay() {
         const loc = useLocation();
 
-        return <div>-{loc.pathname}-</div>;
+        return <div>-{loc.pathname}{loc.search}-</div>;
     }
     function mockBrowserInitialEntriesWithLocation(entries: string[]) {
         BrowserRouter.mockImplementationOnce(({children}) => (
@@ -165,6 +165,20 @@ describe('shell', () => {
 
         render(AppElement);
         await screen.findByText('-/anything-');
+    });
+    it('preserves the query string through the "general" redirect', async () => {
+        mockBrowserInitialEntriesWithLocation(['/general/anything?utm_source=test']);
+
+        render(AppElement);
+        await screen.findByText('-/anything?utm_source=test-');
+    });
+    it('includes the query string when calling piTracker', async () => {
+        w.piTracker = (path: string) => piTracker(path);
+        mockBrowserInitialEntries(['/adoption?utm_source=test']);
+
+        render(AppElement);
+        await screen.findByRole('combobox');
+        await waitFor(() => expect(piTracker).toHaveBeenCalledWith(expect.stringContaining('?utm_source=test')));
     });
     it('routes adoption (no CMS page data) page', async () => {
         mockBrowserInitialEntries(['/adoption']);

--- a/test/src/components/shell/router.test.tsx
+++ b/test/src/components/shell/router.test.tsx
@@ -228,6 +228,22 @@ describe('Router', () => {
             expect(typeof window.piTracker).toBe('function');
         });
 
+        it('includes the query string when calling piTracker', async () => {
+            const mockPiTracker = jest.fn();
+
+            window.piTracker = (url: string) => mockPiTracker(url);
+
+            render(
+                <MemoryRouter initialEntries={['/subjects?utm_source=test']}>
+                    <Router />
+                </MemoryRouter>
+            );
+
+            await waitFor(() => {
+                expect(mockPiTracker).toHaveBeenCalledWith(expect.stringContaining('?utm_source=test'));
+            });
+        });
+
         it('does not call piTracker if it does not exist', () => {
             delete window.piTracker;
 

--- a/test/src/components/shell/use-link-handler.test.tsx
+++ b/test/src/components/shell/use-link-handler.test.tsx
@@ -29,7 +29,7 @@ function setPortalPrefix(portalPrefix: string, isK12Portal: boolean = false) {
 }
 
 type WindowWithPiTracker = (typeof window) & {
-    piTracker: (path: string) => void;
+    piTracker?: (path: string) => void;
 }
 const w = window as WindowWithPiTracker;
 const piTracker = jest.fn();
@@ -124,12 +124,13 @@ describe('use-link-handler', () => {
         console.error = saveError;
         expect(notPrevented).not.toBeCalled();
     });
-    it('calls piTracker if available', async () => {
+    it('calls piTracker for external links', async () => {
         setPortalPrefix('/portal');
         const navigate = jest.fn();
 
         w.piTracker = (path: string) => piTracker(path);
 
+        jest.spyOn(linkHelper, 'isExternal').mockReturnValue(true);
         jest.spyOn(linkHelper, 'validUrlClick').mockReturnValue({
             target: 'clickTarget',
             href: 'clickHref',
@@ -145,6 +146,42 @@ describe('use-link-handler', () => {
         await user.click(screen.getByRole('link'));
         expect(notPrevented).not.toBeCalled();
         expect(piTracker).toBeCalledWith('clickHref');
+    });
+    it('tolerates external clicks when piTracker is absent', async () => {
+        setPortalPrefix('/portal');
+        delete w.piTracker;
+
+        jest.spyOn(linkHelper, 'isExternal').mockReturnValue(true);
+        jest.spyOn(linkHelper, 'validUrlClick').mockReturnValue({
+            target: 'clickTarget',
+            href: 'clickHref',
+            dataset: {}
+        } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        render(<Component />);
+        await user.click(screen.getByRole('link'));
+        expect(piTracker).not.toBeCalled();
+    });
+    it('does not call piTracker for internal links', async () => {
+        setPortalPrefix('/portal');
+        const navigate = jest.fn();
+
+        w.piTracker = (path: string) => piTracker(path);
+
+        jest.spyOn(linkHelper, 'isExternal').mockReturnValue(false);
+        jest.spyOn(linkHelper, 'validUrlClick').mockReturnValue({
+            href: 'clickHref',
+            dataset: {}
+        } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+        jest.spyOn(linkHelper, 'stripOpenStaxDomain').mockReturnValue(
+            'whatever'
+        );
+        (useNavigate as jest.Mock).mockReturnValue(navigate);
+
+        render(<Component />);
+        await user.click(screen.getByRole('link'));
+        expect(piTracker).not.toBeCalled();
+        expect(navigate).toBeCalledWith('whatever', {x: 0, y: 0});
     });
     it('handles external URL opening local', async () => {
         setPortalPrefix('/portal');


### PR DESCRIPTION
## What

Preserves the query string (UTM/campaign parameters) in the two places the SPA was dropping it before analytics could read it:

1. **Pardot tracking** — `router.tsx` built the tracked URL from `origin + pathname` only, so every `window.piTracker()` call reported campaign-tagged visits as untagged page views. The tracked URL now includes `location.search`.
2. **Client-side redirects** — five `Navigate` calls redirected to bare pathnames, stripping the query before GTM/Pardot read the URL: the `/details/:title` canonicalization, the `details` index redirect, the `general/*` and `home/*` rewrites, and the non-portal flex-page canonicalization. Each now carries `search` through.

GA/GTM page views were unaffected (they read `location.href` directly); Pardot was blind to UTMs on all page views, and both were blind on client-redirected paths.

## Verification

- New tests: a redirecting path with `?utm_source=test` keeps its query at the destination; `piTracker` receives the full URL including the query string.
- `yarn lint` clean; full `yarn test` green (839 tests, 100% coverage threshold).

## Related

Server-side counterpart merged in openstax/bit-deployment#168 (exact-path nginx redirects now match query-tagged URLs and carry the query through).

## Double-count fix (second commit)

The click handler reported every link click to Pardot as a page view, and internal navigations were then reported again by the route-change effect — two page views per click. The click-side report now fires only for external links (outbound clicks), where no route change or destination page load reports the view. Verified in `pd.js` itself: `piTracker()` records a page view per call with no deduplication.
