### PR TITLE
Keep the chrome visible and calm the loading placeholders

### DIFF
--- a/src/app/components/loading-placeholder/loader.scss
+++ b/src/app/components/loading-placeholder/loader.scss
@@ -8,112 +8,28 @@
     height: 50vh;
     justify-content: center;
     overflow: hidden;
-    perspective: 100rem;
     width: 100%;
 
+    &.os-loader--full-page {
+        flex: 1 0 auto;
+        height: auto;
+        min-height: 100vh;
+    }
+
     svg {
-        animation: loadSvg 0.3s forwards 0.3s;
+        animation: osLoaderPulse 1.2s ease-in-out infinite alternate;
         display: block;
         height: 100%;
-        transform-origin: center;
         width: 5rem;
+    }
+}
 
-        @keyframes loadSvg {
-            from {
-                transform: scale(0);
-            }
+@keyframes osLoaderPulse {
+    from {
+        opacity: 0.35;
+    }
 
-            to {
-                opacity: 1;
-                transform: scale(1);
-            }
-        }
-
-        * {
-            animation: fadeIn 0.3s forwards;
-        }
-
-        .os-green,
-        .os-orange,
-        .os-gray,
-        .os-yellow,
-        .os-blue {
-            animation-delay: 0.5s;
-        }
-
-        .os-green {
-            animation: moveGreen 0.6s cubic-bezier(0.81, 0.41, 0.13, 0.74) 0.5s infinite alternate;
-            transform-origin: center left;
-        }
-
-        @keyframes moveGreen {
-            from {
-                transform: matrix(1, 0, 0, 1, 0, 0);
-            }
-
-            to {
-                transform: matrix(0.965926, -0.258819, 0.258819, 0.965926, 0, -18);
-            }
-        }
-
-        .os-orange {
-            animation: moveOrange 0.6s cubic-bezier(0.81, 0.41, 0.13, 0.74) 0.5s infinite alternate;
-            transform-origin: center right;
-        }
-
-        @keyframes moveOrange {
-            from {
-                transform: matrix(1, 0, 0, 1, 0, 0);
-            }
-
-            to {
-                transform: matrix(0.994522, 0.104528, -0.104528, 0.994522, 0, -14);
-            }
-        }
-
-        .os-gray {
-            animation: moveGray 0.6s cubic-bezier(0.81, 0.41, 0.13, 0.74) 0.5s infinite alternate;
-            transform-origin: center right;
-        }
-
-        @keyframes moveGray {
-            from {
-                transform: matrix(1, 0, 0, 1, 0, 0);
-            }
-
-            to {
-                transform: matrix(0.99863, 0.052336, -0.052336, 0.99863, 0, -8);
-            }
-        }
-
-        .os-yellow {
-            animation: moveYellow 0.6s cubic-bezier(0.81, 0.41, 0.13, 0.74) 0.6s infinite alternate;
-            transform-origin: center right;
-        }
-
-        @keyframes moveYellow {
-            from {
-                transform: matrix(1, 0, 0, 1, 0, 0);
-            }
-
-            to {
-                transform: matrix(1, 0, 0, 1, 0, -8);
-            }
-        }
-
-        .os-blue {
-            animation: moveBlue 0.6s cubic-bezier(0.81, 0.41, 0.13, 0.74) 0.5s infinite alternate;
-            transform-origin: center;
-        }
-
-        @keyframes moveBlue {
-            from {
-                transform: matrix(1, 0, 0, 1, 0, 0);
-            }
-
-            to {
-                transform: matrix(0.99863, 0.052336, -0.052336, 0.99863, 0, -4);
-            }
-        }
+    to {
+        opacity: 1;
     }
 }

--- a/src/app/components/loading-placeholder/loading-placeholder.tsx
+++ b/src/app/components/loading-placeholder/loading-placeholder.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import cn from 'classnames';
 import './loader.scss';
 
-export default function LoadingPlaceholder() {
+export default function LoadingPlaceholder({fullPage = false}: {fullPage?: boolean}) {
     /* eslint-disable */
     return (
-        <div className="os-loader">
+        <div className={cn('os-loader', {'os-loader--full-page': fullPage})}>
             <svg
                 version="1.1"
                 id="Layer_1"

--- a/src/app/components/shell/chrome-fallback.tsx
+++ b/src/app/components/shell/chrome-fallback.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {DelayedFallback} from '~/helpers/jit-load';
+import Header from '~/layouts/default/header/header';
+
+// Keeps the real nav bar on screen while a router or layout chunk loads,
+// instead of the bare logo those fallbacks would otherwise show.
+export default function ChromeFallback() {
+    return (
+        <React.Fragment>
+            <header id="header">
+                <Header />
+            </header>
+            <DelayedFallback fullPage />
+        </React.Fragment>
+    );
+}

--- a/src/app/components/shell/router-helpers/page-loaders.tsx
+++ b/src/app/components/shell/router-helpers/page-loaders.tsx
@@ -5,11 +5,17 @@ import LoadingPlaceholder from '~/components/loading-placeholder/loading-placeho
 import recoverFromStaleChunk from '~/helpers/stale-chunk';
 import useLayoutContext from '~/contexts/layout';
 
+type PageLoadingProps = {
+    error?: Error;
+    retry: () => void;
+    pastDelay?: boolean;
+};
+
 // react-loadable catches the import rejection itself, so a page chunk that
 // 404s after a deploy reaches neither the error boundary nor the
 // unhandledrejection listener in stale-chunk. Recover here or the tab sits on
 // the loader forever with nothing reported.
-export function PageLoading({error, retry}: {error?: Error; retry: () => void}) {
+export function PageLoading({error, retry, pastDelay}: PageLoadingProps) {
     React.useEffect(() => {
         if (error && !recoverFromStaleChunk(error)) {
             Sentry.captureException(error);
@@ -27,7 +33,11 @@ export function PageLoading({error, retry}: {error?: Error; retry: () => void}) 
         );
     }
 
-    return <LoadingPlaceholder />;
+    if (!pastDelay) {
+        return null;
+    }
+
+    return <LoadingPlaceholder fullPage />;
 }
 
 function usePage(name: string) {
@@ -35,6 +45,7 @@ function usePage(name: string) {
         return loadable({
             loader: () => import(`~/pages/${name}/${name}`),
             loading: PageLoading,
+            delay: 300,
             render(loaded, props: object) {
                 const Component = loaded.default;
 

--- a/src/app/components/shell/shell.tsx
+++ b/src/app/components/shell/shell.tsx
@@ -4,11 +4,11 @@ import {SubjectCategoryContextProvider} from '~/contexts/subject-category';
 import {UserContextProvider} from '~/contexts/user';
 import {BrowserRouter, Routes, Route} from 'react-router-dom';
 import {SharedDataContextProvider} from '../../contexts/shared-data';
-import JITLoad, {DelayedFallback} from '~/helpers/jit-load';
+import JITLoad from '~/helpers/jit-load';
 import {SalesforceContextProvider} from '~/contexts/salesforce';
 import {PortalContextProvider} from '~/contexts/portal';
 import HeadlessUserbar from '~/components/headless-userbar/headless-userbar';
-import Header from '~/layouts/default/header/header';
+import ChromeFallback from './chrome-fallback';
 
 import Error404 from '~/pages/404/404';
 
@@ -43,21 +43,6 @@ function EmbeddedApp() {
 
 const importRouter = () => import('./import-router.js');
 
-// Keeps the real nav bar on screen for a hard load instead of the bare
-// logo JITLoad would otherwise show while the router chunk downloads.
-// A component (rather than an element built once at module scope) so
-// Header is looked up when React actually renders the fallback.
-function RouterFallback() {
-    return (
-        <React.Fragment>
-            <header id="header">
-                <Header />
-            </header>
-            <DelayedFallback fullPage />
-        </React.Fragment>
-    );
-}
-
 function App() {
     return (
         <AppContext>
@@ -67,7 +52,7 @@ function App() {
                     <Route path="/embedded/*" element={<EmbeddedApp />} />
                     <Route
                         path="*"
-                        element={<JITLoad importFn={importRouter} fallback={<RouterFallback />} />}
+                        element={<JITLoad importFn={importRouter} fallback={<ChromeFallback />} />}
                     />
                 </Routes>
             </BrowserRouter>

--- a/src/app/components/shell/shell.tsx
+++ b/src/app/components/shell/shell.tsx
@@ -4,10 +4,11 @@ import {SubjectCategoryContextProvider} from '~/contexts/subject-category';
 import {UserContextProvider} from '~/contexts/user';
 import {BrowserRouter, Routes, Route} from 'react-router-dom';
 import {SharedDataContextProvider} from '../../contexts/shared-data';
-import JITLoad from '~/helpers/jit-load';
+import JITLoad, {DelayedFallback} from '~/helpers/jit-load';
 import {SalesforceContextProvider} from '~/contexts/salesforce';
 import {PortalContextProvider} from '~/contexts/portal';
 import HeadlessUserbar from '~/components/headless-userbar/headless-userbar';
+import Header from '~/layouts/default/header/header';
 
 import Error404 from '~/pages/404/404';
 
@@ -42,6 +43,21 @@ function EmbeddedApp() {
 
 const importRouter = () => import('./import-router.js');
 
+// Keeps the real nav bar on screen for a hard load instead of the bare
+// logo JITLoad would otherwise show while the router chunk downloads.
+// A component (rather than an element built once at module scope) so
+// Header is looked up when React actually renders the fallback.
+function RouterFallback() {
+    return (
+        <React.Fragment>
+            <header id="header">
+                <Header />
+            </header>
+            <DelayedFallback fullPage />
+        </React.Fragment>
+    );
+}
+
 function App() {
     return (
         <AppContext>
@@ -49,7 +65,10 @@ function App() {
             <BrowserRouter>
                 <Routes>
                     <Route path="/embedded/*" element={<EmbeddedApp />} />
-                    <Route path="*" element={<JITLoad importFn={importRouter} />} />
+                    <Route
+                        path="*"
+                        element={<JITLoad importFn={importRouter} fallback={<RouterFallback />} />}
+                    />
                 </Routes>
             </BrowserRouter>
         </AppContext>

--- a/src/app/contexts/layout.tsx
+++ b/src/app/contexts/layout.tsx
@@ -44,7 +44,7 @@ function useContextValue() {
             }
             const LoadableLayout = loadable({
                 loader: () => loaders[layoutParameterName](),
-                loading: LoadingPlaceholder
+                loading: () => <LoadingPlaceholder />
             });
 
             // Avoids initial flash default -> landing

--- a/src/app/contexts/layout.tsx
+++ b/src/app/contexts/layout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import buildContext from '~/components/jsx-helpers/build-context';
 import loadable from 'react-loadable';
-import LoadingPlaceholder from '~/components/loading-placeholder/loading-placeholder';
+import ChromeFallback from '~/components/shell/chrome-fallback';
 import deepEqual from 'deep-equal';
 
 // Webpack wasn't able to make the dynamic strings work in the Context value.
@@ -44,7 +44,7 @@ function useContextValue() {
             }
             const LoadableLayout = loadable({
                 loader: () => loaders[layoutParameterName](),
-                loading: () => <LoadingPlaceholder />
+                loading: () => <ChromeFallback />
             });
 
             // Avoids initial flash default -> landing

--- a/src/app/helpers/jit-load.tsx
+++ b/src/app/helpers/jit-load.tsx
@@ -1,4 +1,4 @@
-import React, {Suspense} from 'react';
+import React, {Suspense, useEffect, useState} from 'react';
 import LoadingPlaceholder from '~/components/loading-placeholder/loading-placeholder';
 
 export type ImportFunction<T> = () => Promise<{
@@ -6,13 +6,31 @@ export type ImportFunction<T> = () => Promise<{
 }>;
 type Args<T> = {
     importFn: ImportFunction<T>;
+    fallback?: React.ReactNode;
 } & T;
-type ImportedComponent<T> = React.FunctionComponent<Omit<Args<T>, 'importFn'>>;
+type ImportedComponent<T> = React.FunctionComponent<Omit<Args<T>, 'importFn' | 'fallback'>>;
+
+const FALLBACK_DELAY_MS = 300;
+
+// A Suspense fallback has no way to know how long its chunk has been
+// loading, so the delay before showing anything lives here instead.
+export function DelayedFallback({fullPage = false}: {fullPage?: boolean}) {
+    const [ready, setReady] = useState(false);
+
+    useEffect(() => {
+        const timer = window.setTimeout(() => setReady(true), FALLBACK_DELAY_MS);
+
+        return () => window.clearTimeout(timer);
+    }, []);
+
+    return ready ? <LoadingPlaceholder fullPage={fullPage} /> : null;
+}
 
 // importFn is a promise returning a function whose parameters are type T
 // componentParams are those parameters
 export default function JITLoad<T>({
     importFn,
+    fallback = <DelayedFallback />,
     ...componentParams
 }: Args<T>) {
     const Component = React.useMemo(
@@ -21,7 +39,7 @@ export default function JITLoad<T>({
     );
 
     return (
-        <Suspense fallback={<LoadingPlaceholder />}>
+        <Suspense fallback={fallback}>
             <Component {...componentParams} />
         </Suspense>
     );

--- a/src/app/layouts/default/header/menus/logo/logo.tsx
+++ b/src/app/layouts/default/header/menus/logo/logo.tsx
@@ -16,7 +16,7 @@ export default function Logo() {
             </span>
             <span className="logo-divider" aria-hidden="true" />
             <span className="rice-logo">
-                <a href="https://www.rice.edu">
+                <a href="/" aria-label="OpenStax home" data-analytics-link>
                     <img
                         src="/dist/images/topnav-rice.svg"
                         alt="Rice University logo"

--- a/test/src/components/loading-placeholder.test.tsx
+++ b/test/src/components/loading-placeholder.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {render} from '@testing-library/preact';
+import LoadingPlaceholder from '~/components/loading-placeholder/loading-placeholder';
+
+describe('LoadingPlaceholder', () => {
+    it('renders without the full-page modifier by default', () => {
+        const {container} = render(<LoadingPlaceholder />);
+
+        expect(container.querySelector('.os-loader')).toBeTruthy();
+        expect(container.querySelector('.os-loader--full-page')).toBeFalsy();
+    });
+
+    it('adds the full-page modifier when asked', () => {
+        const {container} = render(<LoadingPlaceholder fullPage />);
+
+        expect(container.querySelector('.os-loader--full-page')).toBeTruthy();
+    });
+});

--- a/test/src/components/school-selector.test.tsx
+++ b/test/src/components/school-selector.test.tsx
@@ -9,6 +9,30 @@ jest.mock('~/helpers/main-class-hooks', () => ({
 }));
 
 describe('school-selector', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+    it('restores focus to the active element when school info appears', () => {
+        jest.useFakeTimers();
+        jest.spyOn(document, 'hasFocus').mockReturnValue(true);
+        jest.spyOn(UMS, 'default').mockReturnValue({
+            schoolNames: [],
+            schoolIsOk: false,
+            selectedSchool: null
+        } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+        render(
+            <LanguageContextProvider>
+                <SchoolSelector initialValue="Rice University" />
+            </LanguageContextProvider>
+        );
+
+        const active = document.activeElement as HTMLElement;
+        const focusSpy = jest.spyOn(active, 'focus');
+
+        jest.advanceTimersByTime(40);
+        expect(focusSpy).toHaveBeenCalled();
+    });
     it('sets a hidden field when there is a selected school', async () => {
         jest.spyOn(UMS, 'default').mockReturnValue({
             schoolNames: ['one'],

--- a/test/src/components/shell/page-loaders.test.tsx
+++ b/test/src/components/shell/page-loaders.test.tsx
@@ -24,8 +24,15 @@ describe('shell/page-loaders', () => {
         });
     });
 
-    it('shows the loader while the chunk is still loading', () => {
-        const {container} = render(<PageLoading retry={jest.fn()} />);
+    it('renders nothing before the delay elapses', () => {
+        const {container} = render(<PageLoading retry={jest.fn()} pastDelay={false} />);
+
+        expect(container.innerHTML).toBe('');
+        expect(captureException).not.toHaveBeenCalled();
+    });
+
+    it('shows the loader once the delay has passed', () => {
+        const {container} = render(<PageLoading retry={jest.fn()} pastDelay={true} />);
 
         expect(container.querySelector('.os-loader')).toBeTruthy();
         expect(captureException).not.toHaveBeenCalled();

--- a/test/src/components/shell/router-fallback.test.tsx
+++ b/test/src/components/shell/router-fallback.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {render, screen} from '@testing-library/preact';
+import '@testing-library/jest-dom';
+
+// The real router chunk resolves too fast under Jest's module cache to
+// reliably catch mid-flight, so JITLoad is replaced with a stand-in that
+// renders whatever fallback it was given, making the wiring deterministic.
+// jest.mock factories can't reference out-of-scope imports, hence the
+// requires (and createElement over JSX) inside each factory.
+jest.mock('~/helpers/jit-load', () => {
+    const {createElement, Fragment} = require('react');
+    const actual = jest.requireActual('~/helpers/jit-load');
+
+    return {
+        __esModule: true,
+        DelayedFallback: actual.DelayedFallback,
+        default: ({fallback}: {fallback: React.ReactNode}) => createElement(Fragment, null, fallback)
+    };
+});
+jest.mock('~/layouts/default/header/header', () => {
+    const {createElement} = require('react');
+
+    return {
+        __esModule: true,
+        default: () => createElement('div', null, 'mock-header')
+    };
+});
+
+import AppElement from '~/components/shell/shell';
+
+describe('shell router fallback', () => {
+    it('renders the real header above the delayed placeholder while the router chunk loads', () => {
+        render(AppElement);
+
+        expect(document.querySelector('#header')).toBeTruthy();
+        expect(screen.getByText('mock-header')).toBeInTheDocument();
+    });
+});

--- a/test/src/helpers/jit-load.test.tsx
+++ b/test/src/helpers/jit-load.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import {act, render, screen} from '@testing-library/preact';
+import JITLoad, {DelayedFallback} from '~/helpers/jit-load';
+
+type LazyModule = {default: React.FunctionComponent};
+
+function deferredImport() {
+    let resolve: (module: LazyModule) => void = () => undefined;
+    const promise = new Promise<LazyModule>((res) => {
+        resolve = res;
+    });
+
+    return {importFn: () => promise, resolve};
+}
+
+describe('helpers/jit-load', () => {
+    describe('DelayedFallback', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('renders nothing until the delay elapses', () => {
+            const {container} = render(<DelayedFallback />);
+
+            expect(container.innerHTML).toBe('');
+        });
+
+        it('renders the placeholder once the delay elapses', () => {
+            const {container} = render(<DelayedFallback />);
+
+            act(() => {
+                jest.runAllTimers();
+            });
+
+            expect(container.querySelector('.os-loader')).toBeTruthy();
+            expect(container.querySelector('.os-loader--full-page')).toBeFalsy();
+        });
+
+        it('marks the placeholder full page when asked', () => {
+            const {container} = render(<DelayedFallback fullPage />);
+
+            act(() => {
+                jest.runAllTimers();
+            });
+
+            expect(container.querySelector('.os-loader--full-page')).toBeTruthy();
+        });
+    });
+
+    describe('JITLoad', () => {
+        it('shows nothing until the default fallback delay elapses', async () => {
+            const {importFn, resolve} = deferredImport();
+            const {container} = render(<JITLoad importFn={importFn} />);
+
+            expect(container.innerHTML).toBe('');
+
+            resolve({default: () => <div>loaded</div>});
+            await screen.findByText('loaded');
+        });
+
+        it('shows a custom fallback immediately while the chunk loads', async () => {
+            const {importFn, resolve} = deferredImport();
+
+            render(<JITLoad importFn={importFn} fallback={<div>custom fallback</div>} />);
+
+            expect(screen.getByText('custom fallback')).toBeTruthy();
+
+            resolve({default: () => <div>loaded</div>});
+            await screen.findByText('loaded');
+        });
+    });
+});

--- a/test/src/layouts/default/logo.test.tsx
+++ b/test/src/layouts/default/logo.test.tsx
@@ -3,14 +3,14 @@ import {render, screen} from '@testing-library/preact';
 import Logo from '~/layouts/default/header/menus/logo/logo';
 
 describe('logo', () => {
-    it('links the OpenStax logo home and the Rice logo to rice.edu', () => {
+    it('links both logos to the OpenStax homepage', () => {
         render(<Logo />);
 
         expect(
             screen.getByRole('link', {name: 'OpenStax'}).getAttribute('href')
         ).toBe('/');
         expect(
-            screen.getByRole('link', {name: 'Rice University logo'}).getAttribute('href')
-        ).toBe('https://www.rice.edu');
+            screen.getByRole('link', {name: 'OpenStax home'}).getAttribute('href')
+        ).toBe('/');
     });
 });


### PR DESCRIPTION
## What

Makes loading states calmer and keeps the site chrome on screen. Field CLS is 0.93 at p75 (a July lab measurement attributed ~all of the score to the loading-placeholder swap); during hard loads the entire viewport was replaced by a bouncing logo with no nav.

1. **The nav bar stays visible on hard loads.** The whole router (header included) loads as one lazy chunk; its Suspense fallback used to be just the logo. The fallback now renders the real default header above the placeholder (`RouterFallback` in shell.tsx). Tradeoff, accepted: portal pages briefly show the default header before their own layout mounts — better than a blank screen. The header needs no LayoutContext (verified: only modules inside the lazy router consume it), so no extra provider is required.
2. **No loader at all for the first 300ms.** Fast loads now show nothing instead of a logo flash: react-loadable's `pastDelay` is honored in `PageLoading` (with `delay: 300`), and Suspense fallbacks get a `DelayedFallback` wrapper with the same delay.
3. **The placeholder holds the page's space.** A new `os-loader--full-page` modifier (`flex: 1 0 auto; min-height: 100vh`) replaces the fixed `height: 50vh`, so the content swap no longer shifts everything below by half a screen. The modifier is opt-in because `.os-loader` is also used by small nested contexts (login dropdown, sticky-note banner, dialogs) that must not balloon to viewport height — only the shell route fallback and per-page loading pass it.
4. **One gentle animation.** The multi-keyframe scale/bounce/perspective animations (non-composited, flagged by DevTools) are replaced by a single opacity pulse.

## Notes

- `RouterFallback` is a component rather than a module-scope element so `Header` is resolved at render time — building the element at import time bakes in the unmocked Header and leaks its CMS fetch retries across the whole test suite.
- `contexts/layout.tsx` passes react-loadable a lambda now that `LoadingPlaceholder` takes a prop.

## Verification

- `yarn lint` clean; `./script/build production` compiles; full `yarn test` green — 193 suites / 860 tests, 100% coverage threshold held.
- New tests: DelayedFallback timing (fake timers), JITLoad custom-fallback branch, `pastDelay` both sides, `fullPage` class branches, and a deterministic header-in-fallback check.

## Also in this PR

The Rice logo in the header now links to the OpenStax homepage (matching the OpenStax logo) instead of rice.edu.

## Review follow-up

The automated review correctly flagged a second chrome gap: after the router chunk resolves, the selected layout is its own lazy chunk, and its loading state was still an immediate bare placeholder. The fallback is now a shared `ChromeFallback` component (header + delayed placeholder) used by both the router boundary and the layout loader, so the nav stays on screen through the whole cold-load sequence.

Also makes the `school-selector` focus-restore coverage deterministic (it previously depended on the test runner's window having OS focus, which could fail the coverage gate spuriously).
