### PR TITLE
Name Sentry releases after the deployed tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             echo "version=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
           else
-            echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+            echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
           fi
       -
         name: "Build osweb"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,22 @@ jobs:
         name: "Lint osweb"
         run: yarn lint
       -
-        name: "Build osweb"
-        run: ./script/build production
-      -
+        # Tag builds are releases; the tag names the Sentry/runtime release so
+        # each deploy gets its own release instead of sharing the stale
+        # package.json version. Branch builds keep the package.json fallback.
         name: "Read osweb version"
         id: osweb_version
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "version=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          fi
+      -
+        name: "Build osweb"
+        run: ./script/build production
+        env:
+          RELEASE_VERSION: ${{ steps.osweb_version.outputs.version }}
       -
         name: "Run tests"
         run: ./script/test
@@ -52,8 +62,8 @@ jobs:
           api-key: ${{ secrets.POSTHOG_CLI_API_KEY }}
       -
         # Uploads the .map files to Sentry under the same release name sentry.js
-        # reports (osweb@<package.json version>), so exceptions resolve to real
-        # source instead of minified bundles. Runs after the PostHog upload so
+        # reports (osweb@<release version>, baked into the bundle at build time),
+        # so exceptions resolve to real source instead of minified bundles. Runs after the PostHog upload so
         # Sentry's debug IDs are injected into the assets we actually ship.
         # Symbolication is a diagnostic aid, so a failure here should never
         # block a release.

--- a/src/app/sentry.js
+++ b/src/app/sentry.js
@@ -95,7 +95,7 @@ function beforeSend(event, hint) {
 
 Sentry.init({
     dsn: 'https://68df3e19624c434eb975dafa316c03ff@o484761.ingest.sentry.io/5691260',
-    release: `osweb@${packageVersion}`,
+    release: `osweb@${process.env.RELEASE_VERSION || packageVersion}`,
     integrations: [Sentry.extraErrorDataIntegration()],
     environment: window.location.hostname,
     ignoreErrors,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,7 +81,7 @@ const config = {
         new CopyWebpackPlugin({
             patterns: [{from: 'src/images', to: 'images'}]
         }),
-        new webpack.EnvironmentPlugin({API_ORIGIN}),
+        new webpack.EnvironmentPlugin({API_ORIGIN, RELEASE_VERSION: ''}),
         new ESLintPlugin({fix: true}),
         new FaviconsWebpackPlugin('./src/images/favicon.svg'),
         new HtmlWebpackPlugin({


### PR DESCRIPTION
## What

Sentry (and runtime) release names now come from the git tag on tag builds, with `package.json`'s `version` as the fallback for branch builds.

- `build.yml`: the version-read step is tag-aware and runs before the build; the build step receives `RELEASE_VERSION` so webpack can bake it into the bundle.
- `webpack.config.js`: passes `RELEASE_VERSION` through `EnvironmentPlugin` (default empty).
- `sentry.js`: `release: osweb@${process.env.RELEASE_VERSION || packageVersion}` — the runtime SDK and the uploaded source maps always agree, from the same build-time value.

## Why

`package.json`'s `version` has been stuck at `2.160.2` since release tags moved to date-based names — the manual bump step from the README stopped happening. Every deploy since then has reported errors and uploaded source maps into the same single Sentry release, `osweb@2.160.2`, making release attribution and regression tracking meaningless. (Symbolication itself survived thanks to injected debug IDs.) With this change, the next tag deploy appears in Sentry as its own release, e.g. `osweb@v2026.09.03`.

## Verification

- Built with `RELEASE_VERSION=v0.0.0-test`: the value is baked into the main bundle; built with the variable unset: compiles and falls back to the package.json version.
- `yarn lint` clean, full `yarn test` green (861 tests, 100% coverage threshold — `sentry.js`/`webpack.config.js` are outside the coverage net by config).
- Workflow YAML parses.
