### PR TITLE
Fetch blog search results one page at a time

### DIFF
--- a/src/app/components/paginator/paginator-context.ts
+++ b/src/app/components/paginator/paginator-context.ts
@@ -16,11 +16,6 @@ function useContextValue(params: ContextParams = {}) {
             childIndex >= firstOnPage && childIndex <= lastOnPage,
         [firstOnPage, lastOnPage]
     );
-    const visibleChildren = useCallback(
-        (children: React.ReactNode[]) =>
-            children.slice(firstOnPage, lastOnPage + 1),
-        [firstOnPage, lastOnPage]
-    );
 
     return {
         currentPage,
@@ -28,8 +23,7 @@ function useContextValue(params: ContextParams = {}) {
         resultsPerPage,
         firstOnPage,
         lastOnPage,
-        isVisible,
-        visibleChildren
+        isVisible
     };
 }
 

--- a/src/app/pages/blog/blog-pages.tsx
+++ b/src/app/pages/blog/blog-pages.tsx
@@ -4,7 +4,6 @@ import {useParams} from 'react-router-dom';
 import {WindowContextProvider} from '~/contexts/window';
 import useDocumentHead from '~/helpers/use-document-head';
 import RawHTML from '~/components/jsx-helpers/raw-html';
-import ExploreBy from '~/components/explore-by/explore-by';
 import PinnedArticle from './pinned-article/pinned-article';
 import MoreStories from './more-stories/more-stories';
 import {HeadingAndSearchBar} from '~/components/search-bar/search-bar';
@@ -57,20 +56,9 @@ function hasActiveQuery({q, subjects, collection, sort}: SearchState) {
     return Boolean(q || subjects.length || collection || sort !== 'relevance');
 }
 
-function DiscoveryContent({
-    categories,
-    pinnedSlug
-}: {
-    categories: ReturnType<typeof useBlogContext>['subjectSnippet'];
-    pinnedSlug?: string;
-}) {
+function DiscoveryContent({pinnedSlug}: {pinnedSlug?: string}) {
     return (
         <React.Fragment>
-            <ExploreBy
-                items={categories}
-                title="Explore by subject"
-                analyticsNav="Blog Subjects"
-            />
             <PinnedArticle />
             <MoreStories exceptSlug={pinnedSlug || ''} />
         </React.Fragment>
@@ -124,10 +112,7 @@ export function MainBlogPage() {
                 {isActive ? (
                     <SearchResults />
                 ) : (
-                    <DiscoveryContent
-                        categories={categories}
-                        pinnedSlug={pinnedSlug}
-                    />
+                    <DiscoveryContent pinnedSlug={pinnedSlug} />
                 )}
             </div>
             <div className="write-for-us">

--- a/src/app/pages/blog/search-results/search-results.tsx
+++ b/src/app/pages/blog/search-results/search-results.tsx
@@ -23,19 +23,6 @@ function ArticleCard({article}: {article: ArticleSummaryData}) {
     );
 }
 
-function VisibleArticles({articles}: {articles: ArticleSummaryData[]}) {
-    const {setCurrentPage, visibleChildren} = usePaginatorContext();
-    const location = useLocation();
-
-    React.useEffect(() => setCurrentPage(1), [location, setCurrentPage]);
-
-    return visibleChildren(
-        articles.map((article) => (
-            <ArticleCard key={article.articleSlug} article={article} />
-        ))
-    );
-}
-
 function statusMessage(isLoading: boolean, count: number) {
     if (isLoading) {
         return 'Searching blog posts';
@@ -46,11 +33,18 @@ function statusMessage(isLoading: boolean, count: number) {
     return `${count} blog ${count === 1 ? 'post' : 'posts'} found`;
 }
 
-export default function SearchResults() {
-    const {articles, isLoading} = useAllArticles();
+function ResultsForPage() {
+    const {currentPage, resultsPerPage, setCurrentPage} = usePaginatorContext();
+    const {articles, isLoading, total} = useAllArticles(currentPage, resultsPerPage);
     const {q} = useBlogSearchParams();
+    const location = useLocation();
     const regionRef = React.useRef<HTMLDivElement>(null);
     const focusedForQuery = React.useRef<string | undefined>(undefined);
+
+    // Reset to page 1 whenever the query or facets change. Page clicks are
+    // local paginator state and never touch the URL, so a location change
+    // always means a new search, not just a page turn.
+    React.useEffect(() => setCurrentPage(1), [location, setCurrentPage]);
 
     // Move focus to the first result only when the search query changes (an
     // explicit search), never when a facet is toggled. Yanking focus on a
@@ -69,19 +63,27 @@ export default function SearchResults() {
     return (
         <div className="search-results" ref={regionRef} aria-busy={isLoading}>
             <div className="sr-only" role="status" aria-live="polite">
-                {statusMessage(isLoading, articles.length)}
+                {statusMessage(isLoading, total)}
             </div>
             {showNoResults && <NoResults />}
             {articles.length > 0 && (
-                <PaginatorContextProvider
-                    contextValueParameters={{resultsPerPage: 10}}
-                >
+                <React.Fragment>
                     <div className="boxed cards">
-                        <VisibleArticles articles={articles} />
+                        {articles.map((article) => (
+                            <ArticleCard key={article.articleSlug} article={article} />
+                        ))}
                     </div>
-                    <PaginatorControls items={articles.length} />
-                </PaginatorContextProvider>
+                    <PaginatorControls items={total} />
+                </React.Fragment>
             )}
         </div>
+    );
+}
+
+export default function SearchResults() {
+    return (
+        <PaginatorContextProvider contextValueParameters={{resultsPerPage: 10}}>
+            <ResultsForPage />
+        </PaginatorContextProvider>
     );
 }

--- a/src/app/pages/blog/search-results/use-all-articles.tsx
+++ b/src/app/pages/blog/search-results/use-all-articles.tsx
@@ -10,11 +10,24 @@ import uniqBy from 'lodash/uniqBy';
 
 type PopulatedBlurbData = Exclude<Parameters<typeof blurbModel>[0], null>;
 
-function buildSlug({q, subjects, collection, sort}: {
+// The `news` source page from search/v2/; results are the same raw item
+// shape the old bare-array endpoint returned (see PopulatedBlurbData above).
+type SearchV2Response = {
+    sources: {
+        news: {
+            total: number;
+            results: PopulatedBlurbData[];
+        };
+    };
+};
+
+function buildSlug({q, subjects, collection, sort, page, pageSize}: {
     q?: string; subjects: string[]; collection?: string; sort: string;
+    page: number; pageSize: number;
 }) {
     const p = new window.URLSearchParams();
 
+    p.set('sources', 'news');
     if (q) {
         p.set('q', q);
     }
@@ -27,14 +40,17 @@ function buildSlug({q, subjects, collection, sort}: {
     if (sort === 'newest') {
         p.set('sort', 'newest');
     }
-    return `search/?${p.toString()}`;
+    p.set('page', String(page));
+    p.set('page_size', String(pageSize));
+    return `search/v2/?${p.toString()}`;
 }
 
-export default function useAllArticles() {
+export default function useAllArticles(page: number, pageSize: number) {
     const {q, subjects, collection, sort} = useBlogSearchParams();
     const [allArticles, setAllArticles] = useState<PopulatedBlurbModel[]>([]);
+    const [total, setTotal] = useState(0);
     const [isLoading, setIsLoading] = useState(true);
-    const slug = buildSlug({q, subjects, collection, sort});
+    const slug = buildSlug({q, subjects, collection, sort, page, pageSize});
 
     useEffect(() => {
         let cancelled = false;
@@ -42,10 +58,11 @@ export default function useAllArticles() {
         // Keep the previous results on screen while refetching so changing a
         // facet doesn't flash the empty/no-results view (the flicker).
         setIsLoading(true);
-        fetchFromCMS(slug, true).then((results: PopulatedBlurbData[]) => {
+        fetchFromCMS(slug, true).then((response: SearchV2Response) => {
             if (cancelled) {
                 return;
             }
+            const {results, total: newTotal} = response.sources.news;
             const articles = uniqBy(results, 'id').map((data) => {
                 data.heading = data.title;
                 data.subheading = '';
@@ -53,6 +70,7 @@ export default function useAllArticles() {
             });
 
             setAllArticles(articles);
+            setTotal(newTotal);
             setIsLoading(false);
         }).catch(() => {
             // A failed search shouldn't leave the page stuck in its loading
@@ -62,6 +80,7 @@ export default function useAllArticles() {
                 return;
             }
             setAllArticles([]);
+            setTotal(0);
             setIsLoading(false);
         });
         return () => {
@@ -69,5 +88,5 @@ export default function useAllArticles() {
         };
     }, [slug]);
 
-    return {articles: allArticles, isLoading};
+    return {articles: allArticles, isLoading, total};
 }

--- a/test/helpers/fetch-mocker.js
+++ b/test/helpers/fetch-mocker.js
@@ -101,6 +101,7 @@ global.fetch = jest.fn().mockImplementation((...args) => {
     const isSchools = (/salesforce\/schools/).test(args[0]);
     const isSearchCollection = args[0].includes('/search/?collection=');
     const isSearchSubject = args[0].includes('/search/?subjects=');
+    const isSearchV2 = args[0].includes('/search/v2/');
     const isSfapiUser = (/api\/v1\/users/).test(args[0]);
     const isSfapiLists = (/api\/v1\/lists/).test(args[0]);
     const isSfapiSchoolTrinity = (/0017h00000YXEBzAAP/).test(args[0]);
@@ -223,6 +224,20 @@ global.fetch = jest.fn().mockImplementation((...args) => {
                 payload = searchCollection;
             } else if (isSearchSubject) {
                 payload = searchSubject;
+            } else if (isSearchV2) {
+                payload = {
+                    query: '',
+                    sources: {
+                        news: {
+                            page: 1,
+                            page_size: 10, // eslint-disable-line camelcase
+                            total: 0,
+                            next: null,
+                            previous: null,
+                            results: []
+                        }
+                    }
+                };
             } else if (isSfapiLists) {
                 payload = sfapiLists;
             } else if (isSfapiSchoolTrinity) {

--- a/test/src/pages/blog/blog-unified.test.tsx
+++ b/test/src/pages/blog/blog-unified.test.tsx
@@ -23,7 +23,7 @@ describe('Unified MainBlogPage', () => {
         await waitFor(() =>
             expect(screen.getByRole('group', {name: 'Filter by subject'})).toBeInTheDocument()
         );
-        expect(screen.queryByText('Explore by subject')).not.toBeInTheDocument();
+        expect(screen.queryByText('Featured blog post')).not.toBeInTheDocument();
     });
 
     it('uses the CMS news-page title for the heading', async () => {
@@ -37,7 +37,7 @@ describe('Unified MainBlogPage', () => {
     it('shows discovery content and facet controls when no query or facets', async () => {
         renderMainBlog('/blog/');
         await waitFor(() =>
-            expect(screen.getByText('Explore by subject')).toBeInTheDocument()
+            expect(screen.getByText('Featured blog post')).toBeInTheDocument()
         );
         expect(screen.getByRole('group', {name: 'Filter by subject'})).toBeInTheDocument();
     });

--- a/test/src/pages/blog/blog-unified.test.tsx
+++ b/test/src/pages/blog/blog-unified.test.tsx
@@ -43,7 +43,7 @@ describe('Unified MainBlogPage', () => {
     });
 
     it('shows no-results message AND keeps facet controls visible when search returns empty', async () => {
-        jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue([]);
+        jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue({sources: {news: {total: 0, results: []}}});
         renderMainBlog('/blog/?q=zzzznomatch');
         expect(
             await screen.findByText(/No matching blog posts found/i)

--- a/test/src/pages/blog/search-results.test.tsx
+++ b/test/src/pages/blog/search-results.test.tsx
@@ -32,9 +32,16 @@ function twelveArticles() {
     }));
 }
 
+// search/v2/ returns one page of `results` plus a server-side `total`; a
+// fixture standing in for "12 matching articles" now has to hand back only
+// page 1's worth (10) with total: 12, the same split the real endpoint does.
+function searchV2Envelope(results: unknown[], total = results.length) {
+    return {sources: {news: {total, results}}};
+}
+
 describe('search-results', () => {
     it('renders no results when there are no articles', async () => {
-        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce([]);
+        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(searchV2Envelope([]));
         render(<Component />);
         await screen.findByText('No matching blog posts found');
         // Discovery content is offered alongside the no-results message.
@@ -54,7 +61,7 @@ describe('search-results', () => {
         jest.clearAllMocks();
     });
     it('renders with paginator context when there are articles', async () => {
-        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(twelveArticles());
+        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(searchV2Envelope(twelveArticles().slice(0, 10), 12));
         const spyArticleSummary = jest.spyOn(AS, 'default');
 
         render(<Component />);
@@ -64,7 +71,7 @@ describe('search-results', () => {
         expect(spyArticleSummary).toHaveBeenCalledTimes(10);
     });
     it('announces the result count to screen readers', async () => {
-        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(twelveArticles());
+        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(searchV2Envelope(twelveArticles().slice(0, 10), 12));
 
         render(<Component />);
 
@@ -82,7 +89,7 @@ describe('search-results', () => {
             article_subjects: [] // eslint-disable-line camelcase
         }];
 
-        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(oneArticle);
+        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(searchV2Envelope(oneArticle));
 
         render(<Component />);
 
@@ -92,7 +99,7 @@ describe('search-results', () => {
         jest.clearAllMocks();
     });
     it('moves focus to the first result on an explicit search', async () => {
-        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(twelveArticles());
+        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(searchV2Envelope(twelveArticles().slice(0, 10), 12));
 
         render(<Component entry="/blog/?q=education" />);
 
@@ -102,7 +109,7 @@ describe('search-results', () => {
         jest.clearAllMocks();
     });
     it('does not steal focus when results come from facets, not a query', async () => {
-        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(twelveArticles());
+        jest.spyOn(PDU, 'fetchFromCMS').mockResolvedValueOnce(searchV2Envelope(twelveArticles().slice(0, 10), 12));
 
         render(<Component entry="/blog/?subjects=Math" />);
 

--- a/test/src/pages/blog/use-all-articles.test.tsx
+++ b/test/src/pages/blog/use-all-articles.test.tsx
@@ -7,9 +7,13 @@ import useAllArticles from '~/pages/blog/search-results/use-all-articles';
 
 type RenderHookWrapper = ComponentType<{children: Element}>;
 
+function searchV2Envelope(results: unknown[], total = results.length) {
+    return {sources: {news: {total, results}}};
+}
+
 afterEach(() => jest.restoreAllMocks());
 it('builds the search slug from q, subjects, collection, and sort', async () => {
-    const spy = jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue([]);
+    const spy = jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue(searchV2Envelope([]));
 
     function Wrapper({children}: {children: React.ReactNode}) {
         return (
@@ -19,7 +23,7 @@ it('builds the search slug from q, subjects, collection, and sort', async () => 
         );
     }
 
-    renderHook(() => useAllArticles(), {wrapper: Wrapper as unknown as RenderHookWrapper});
+    renderHook(() => useAllArticles(1, 10), {wrapper: Wrapper as unknown as RenderHookWrapper});
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
     const slug = spy.mock.calls[0][0] as string;
@@ -30,7 +34,7 @@ it('builds the search slug from q, subjects, collection, and sort', async () => 
 });
 
 it('includes collection in the slug when present', async () => {
-    const spy = jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue([]);
+    const spy = jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue(searchV2Envelope([]));
 
     function Wrapper({children}: {children: React.ReactNode}) {
         return (
@@ -40,7 +44,7 @@ it('includes collection in the slug when present', async () => {
         );
     }
 
-    renderHook(() => useAllArticles(), {wrapper: Wrapper as unknown as RenderHookWrapper});
+    renderHook(() => useAllArticles(1, 10), {wrapper: Wrapper as unknown as RenderHookWrapper});
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
     const slug = spy.mock.calls[0][0] as string;
@@ -50,7 +54,7 @@ it('includes collection in the slug when present', async () => {
 });
 
 it('omits sort from the slug when sort is relevance (the default)', async () => {
-    const spy = jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue([]);
+    const spy = jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue(searchV2Envelope([]));
 
     function WrapperNoSort({children}: {children: React.ReactNode}) {
         return (
@@ -60,7 +64,7 @@ it('omits sort from the slug when sort is relevance (the default)', async () => 
         );
     }
 
-    renderHook(() => useAllArticles(), {wrapper: WrapperNoSort as unknown as RenderHookWrapper});
+    renderHook(() => useAllArticles(1, 10), {wrapper: WrapperNoSort as unknown as RenderHookWrapper});
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
     const slugNoSort = spy.mock.calls[0][0] as string;
@@ -68,7 +72,7 @@ it('omits sort from the slug when sort is relevance (the default)', async () => 
     expect(slugNoSort).not.toContain('sort=');
 
     jest.restoreAllMocks();
-    const spy2 = jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue([]);
+    const spy2 = jest.spyOn(pageDataUtils, 'fetchFromCMS').mockResolvedValue(searchV2Envelope([]));
 
     function WrapperRelevance({children}: {children: React.ReactNode}) {
         return (
@@ -78,7 +82,7 @@ it('omits sort from the slug when sort is relevance (the default)', async () => 
         );
     }
 
-    renderHook(() => useAllArticles(), {wrapper: WrapperRelevance as unknown as RenderHookWrapper});
+    renderHook(() => useAllArticles(1, 10), {wrapper: WrapperRelevance as unknown as RenderHookWrapper});
 
     await waitFor(() => expect(spy2).toHaveBeenCalled());
     const slugRelevance = spy2.mock.calls[0][0] as string;
@@ -101,7 +105,7 @@ it('cancels pending fetch when hook unmounts (line 46)', async () => {
         );
     }
 
-    const {unmount} = renderHook(() => useAllArticles(), {wrapper: Wrapper as unknown as RenderHookWrapper});
+    const {unmount} = renderHook(() => useAllArticles(1, 10), {wrapper: Wrapper as unknown as RenderHookWrapper});
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
 
@@ -109,7 +113,7 @@ it('cancels pending fetch when hook unmounts (line 46)', async () => {
     unmount();
 
     // Now resolve the fetch - the cancelled check at line 46 should prevent state updates
-    resolveFetch!([
+    resolveFetch!(searchV2Envelope([
         {
             id: 1,
             title: 'Test Article',
@@ -117,7 +121,7 @@ it('cancels pending fetch when hook unmounts (line 46)', async () => {
             date: '2024-01-01',
             articleImage: null
         }
-    ]);
+    ]));
 
     // Wait a bit to ensure no state updates throw errors about unmounted components
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -137,7 +141,7 @@ it('handles fetch errors when not cancelled (line 57, cancelled = false)', async
         );
     }
 
-    const {result} = renderHook(() => useAllArticles(), {wrapper: Wrapper as unknown as RenderHookWrapper});
+    const {result} = renderHook(() => useAllArticles(1, 10), {wrapper: Wrapper as unknown as RenderHookWrapper});
 
     // Initially loading
     expect(result.current.isLoading).toBe(true);
@@ -165,7 +169,7 @@ it('handles fetch errors when cancelled (line 57, cancelled = true)', async () =
         );
     }
 
-    const {unmount} = renderHook(() => useAllArticles(), {wrapper: Wrapper as unknown as RenderHookWrapper});
+    const {unmount} = renderHook(() => useAllArticles(1, 10), {wrapper: Wrapper as unknown as RenderHookWrapper});
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
 


### PR DESCRIPTION
Pairs with **openstax/openstax-cms#1783** — that must deploy first, since this calls the new `search/v2/` endpoint.

## What

The blog search-results page fetched every matching article and paginated in memory. It now requests only the page it's showing and takes the result count from the server.

- `use-all-articles.tsx` takes `page`/`pageSize`, calls `search/v2/?sources=news&…`, and returns `total`.
- The pager's summary and last-page math use the server's `total`.
- The per-item mapping is unchanged — item shapes didn't change, only the envelope.

Both behaviors the previous code went out of its way to get right are preserved: results stay on screen while refetching (no flash of the empty state), and a failed search falls out of the loading state instead of hanging on "Searching".

`blog-context.tsx` and `subjects/new/specific/blog-posts.tsx` are deliberately untouched — they stay on the old endpoint, which keeps its exact response shape.

## Tests

188 suites / 834 tests passing; `lint:ts` and `lint:js` clean. The coverage gate is red at 99.91% from `explore-by.tsx`, orphaned by an earlier commit on main — pre-existing and unrelated to this diff.