### PR TITLE
Update hidden fields in chat component

### DIFF
--- a/src/app/components/chat/chat.tsx
+++ b/src/app/components/chat/chat.tsx
@@ -249,11 +249,11 @@ export default function Chat() {
         const school = userStatus?.school || userModel?.accountsModel?.school_name;
 
         if (userStatus?.id || userModel?.id) {
-            hiddenFields.OpenStax_Id = String(userStatus?.id ?? userModel?.id);
+            hiddenFields['OpenStax_Id'] = String(userStatus?.id ?? userModel?.id);
         }
 
         if (uuid) {
-            hiddenFields.OpenStax_UUID = uuid;
+            hiddenFields['OpenStax_UUID'] = uuid;
         }
 
         prechatAPI.setHiddenPrechatFields(hiddenFields);

--- a/src/app/components/chat/chat.tsx
+++ b/src/app/components/chat/chat.tsx
@@ -237,7 +237,7 @@ export default function Chat() {
         // so we can safely access it without additional null checks
         const prechatAPI = assertDefined(window.embeddedservice_bootstrap?.prechatAPI);
 
-        // Set hidden fields: sProduct and UUID (not editable by user)
+        // Set hidden fields: Product and UUID (not editable by user)
         const hiddenFields: Record<string, string> = {
             Product: 'Website'
         };
@@ -248,12 +248,9 @@ export default function Chat() {
         const email = userStatus?.email || userModel?.email;
         const school = userStatus?.school || userModel?.accountsModel?.school_name;
 
-        if (userStatus?.id || userModel?.id) {
-            hiddenFields['OpenStax_Id'] = String(userStatus?.id ?? userModel?.id);
-        }
 
         if (uuid) {
-            hiddenFields['OpenStax_UUID'] = uuid;
+            hiddenFields.OpenStax_UUID = uuid; // eslint-disable-line camelcase
         }
 
         prechatAPI.setHiddenPrechatFields(hiddenFields);

--- a/src/app/components/chat/chat.tsx
+++ b/src/app/components/chat/chat.tsx
@@ -239,7 +239,7 @@ export default function Chat() {
 
         // Set hidden fields: sProduct and UUID (not editable by user)
         const hiddenFields: Record<string, string> = {
-            sProduct: 'Website'
+            Product: 'Website'
         };
         const visibleFields: Record<string, VisibleFieldArg> = {};
         const uuid = userStatus?.uuid || userModel?.uuid;
@@ -248,9 +248,12 @@ export default function Chat() {
         const email = userStatus?.email || userModel?.email;
         const school = userStatus?.school || userModel?.accountsModel?.school_name;
 
+        if (userStatus?.id || userModel?.id) {
+            hiddenFields.OpenStax_Id = String(userStatus?.id ?? userModel?.id);
+        }
 
         if (uuid) {
-            hiddenFields.OpenStax_UUID__c = uuid; // eslint-disable-line camelcase
+            hiddenFields.OpenStax_UUID = uuid;
         }
 
         prechatAPI.setHiddenPrechatFields(hiddenFields);

--- a/test/src/components/chat.test.tsx
+++ b/test/src/components/chat.test.tsx
@@ -117,7 +117,7 @@ describe('Chat', () => {
         });
     });
 
-    it('sets sProduct for anonymous users', async () => {
+    it('sets Product for anonymous users', async () => {
         (UserContext.default as jest.Mock).mockReturnValue({});
 
         render(<Chat />);
@@ -134,7 +134,7 @@ describe('Chat', () => {
 
         await waitFor(() => {
             expect(mockEmbeddedService.prechatAPI.setHiddenPrechatFields).toHaveBeenCalledWith({
-                sProduct: 'Website'
+                Product: 'Website'
             });
             expect(mockEmbeddedService.prechatAPI.setVisiblePrechatFields).toHaveBeenCalledWith({});
         });
@@ -168,10 +168,10 @@ describe('Chat', () => {
         jest.advanceTimersByTime(250);
 
         await waitFor(() => {
-            // Hidden fields: sProduct and UUID only
+            // Hidden fields: Product and UUID only
             expect(mockEmbeddedService.prechatAPI.setHiddenPrechatFields).toHaveBeenCalledWith({
-                sProduct: 'Website',
-                OpenStax_UUID__c: 'test-uuid-123'
+                Product: 'Website',
+                OpenStax_UUID: 'test-uuid-123'
             });
 
             // Visible, editable fields: Name, Email, School
@@ -208,10 +208,10 @@ describe('Chat', () => {
         jest.advanceTimersByTime(250);
 
         await waitFor(() => {
-            // Hidden fields: sProduct and UUID
+            // Hidden fields: Product and UUID
             expect(mockEmbeddedService.prechatAPI.setHiddenPrechatFields).toHaveBeenCalledWith({
-                sProduct: 'Website',
-                OpenStax_UUID__c: 'test-uuid-123'
+                Product: 'Website',
+                OpenStax_UUID: 'test-uuid-123'
             });
 
             // Only FirstName should be set as visible field (others are missing)
@@ -308,7 +308,7 @@ describe('Chat', () => {
 
         // Verify initial fields (anonymous user)
         expect(mockEmbeddedService.prechatAPI.setHiddenPrechatFields).toHaveBeenCalledWith({
-            sProduct: 'Website'
+            Product: 'Website'
         });
         expect(mockEmbeddedService.prechatAPI.setVisiblePrechatFields).toHaveBeenCalledWith({});
 
@@ -333,10 +333,10 @@ describe('Chat', () => {
 
         // Verify fields updated with user information
         await waitFor(() => {
-            // Hidden fields: sProduct and UUID
+            // Hidden fields: Product and UUID
             expect(mockEmbeddedService.prechatAPI.setHiddenPrechatFields).toHaveBeenCalledWith({
-                sProduct: 'Website',
-                OpenStax_UUID__c: 'test-uuid-456'
+                Product: 'Website',
+                OpenStax_UUID: 'test-uuid-456'
             });
 
             // Visible fields: Name, Email, School
@@ -563,8 +563,8 @@ describe('Chat', () => {
         await waitFor(() => {
             // Should use userStatus fields (not userModel)
             expect(mockEmbeddedService.prechatAPI.setHiddenPrechatFields).toHaveBeenCalledWith({
-                sProduct: 'Website',
-                OpenStax_UUID__c: 'status-uuid-789'
+                Product: 'Website',
+                OpenStax_UUID: 'status-uuid-789'
             });
 
             expect(mockEmbeddedService.prechatAPI.setVisiblePrechatFields).toHaveBeenCalledWith({


### PR DESCRIPTION
Prechat variables are set wrong on the uuid and the product. Also adding in the account id for good measure.