### PR TITLE
Survive a flex page that has no layout field

### DIFF
--- a/src/app/components/shell/router-helpers/portal-page-routes.tsx
+++ b/src/app/components/shell/router-helpers/portal-page-routes.tsx
@@ -33,7 +33,7 @@ export function RouteAsPortalOrNot() {
     }
 
     const isFlex = !hasError && isFlexPage(data);
-    const isPortal = isFlex && data.layout[0]?.type === 'landing';
+    const isPortal = isFlex && data.layout?.[0]?.type === 'landing';
 
     if (isPortal) {
         if (portalPrefix !== `/${name}`) {

--- a/src/app/pages/flex-page/flex-page.tsx
+++ b/src/app/pages/flex-page/flex-page.tsx
@@ -9,7 +9,7 @@ import './flex-page.scss';
 
 export type FlexPageData = {
     meta?: {type: string};
-    layout: [{type: LayoutName}?];
+    layout?: [{type: LayoutName}?];
     body: BlockData<typeof blockMap>;
     schoolData: null | {
         industry: string;
@@ -37,7 +37,7 @@ export function LayoutUsingData({
     children: React.ReactNode;
 }) {
     const {layoutParameters, setLayoutParameters} = useLayoutContext();
-    const layoutName = data.layout[0]?.type || warnAndUseDefault();
+    const layoutName = data.layout?.[0]?.type || warnAndUseDefault();
 
     if (layoutParameters.name !== layoutName) {
         setLayoutParameters({

--- a/src/app/sentry.js
+++ b/src/app/sentry.js
@@ -59,7 +59,9 @@ const ignoreMessages = [
     'Java object is gone',
     'Java bridge method invocation error',
     // Browser extensions talking to a background page that has gone away.
-    'Invalid call to runtime.sendMessage()'
+    'Invalid call to runtime.sendMessage()',
+    // A third-party tag fired by GTM; the whole stack is inside gtm.js.
+    'AviviD is not defined'
 ];
 
 const denyUrls = [

--- a/test/src/pages/flex-page.test.tsx
+++ b/test/src/pages/flex-page.test.tsx
@@ -52,6 +52,26 @@ describe('flex-page', () => {
         expect(console.warn).toHaveBeenCalledWith('No layout set for page');
         console.warn = saveWarn;
     });
+    // The CMS omits the field entirely on some pages, not just leaves it empty
+    it('warns and renders with default when layout is absent', () => {
+        const saveWarn = console.warn;
+
+        console.warn = jest.fn();
+        body = [heroBlock()];
+        render(
+            <ShellContextProvider>
+                <MemoryRouter initialEntries={['']}>
+                    <LayoutContextProvider>
+                        <LayoutUsingData data={{body, schoolData: null}} >
+                            content
+                        </LayoutUsingData>
+                    </LayoutContextProvider>
+                </MemoryRouter>
+            </ShellContextProvider>
+        );
+        expect(console.warn).toHaveBeenCalledWith('No layout set for page');
+        console.warn = saveWarn;
+    });
     it('renders heroBlock with top image alignment', () => {
         const modBlock = heroBlock();
 


### PR DESCRIPTION
The first bug found *because* of last night's source-map work, rather than in spite of it.

## What it is

`undefined is not an object (evaluating 'e.layout[0]')` has been arriving as an anonymous frame in `chunk-83d9bac…` for weeks — unattributable. Now that maps resolve, it points straight at `LayoutUsingData`:

```ts
const layoutName = data.layout[0]?.type || warnAndUseDefault();
```

The optional chain guards a missing *element* but not a missing *array*. A page whose CMS data omits `layout` entirely throws — and `warnAndUseDefault()` was sitting right there as the intended fallback the whole time.

Homepage, 73 events in the 8 hours after yesterday's deploy (`OSWEB-D9Y`).

## Why nothing caught it

The type promised the array always exists:

```ts
layout: [{type: LayoutName}?];
```

so the unguarded index was invisible to the compiler. Making the field optional matches what the CMS actually sends, and turning the compiler back into a guard immediately surfaced **a second copy of the same bug** — `portal-page-routes.tsx:36`, deciding whether a page is a portal:

```ts
const isPortal = isFlex && data.layout[0]?.type === 'landing';
```

Both are now `data.layout?.[0]?.type`. `tsc` is clean, so there are no others.

## Also: ignore `AviviD is not defined`

165 events in a day, **zero** users. Every frame below the Sentry wrapper is inside `gtm.js` — a third-party tag Google Tag Manager fires, with nothing of ours in the stack. Verified before muting rather than assumed.

## Verification

There was already a test for `layout: []`. This adds one for the field being *absent*, which is the case production actually hits. It fails without the fix with the real error:

```
✕ warns and renders with default when layout is absent
  TypeError: Cannot read properties of undefined (reading '0')
```

and passes with it. `yarn test` — 865 passing, 100% coverage. `yarn lint` clean.

## Note on the issue that reported this

`OSWEB-D5K` went quiet after yesterday's deploy and `OSWEB-D9Y` appeared — same bug, new fingerprint, because symbolicated frames change the grouping hash. Worth expecting more of that as old issues re-group; a quiet issue isn't necessarily a fixed one.
