### PR TITLE
Hide the Let Us Know buttons from logged-in students

### DIFF
--- a/src/app/pages/details/common/let-us-know/let-us-know.tsx
+++ b/src/app/pages/details/common/let-us-know/let-us-know.tsx
@@ -6,6 +6,7 @@ import {FontAwesomeIcon, FontAwesomeIconProps} from '@fortawesome/react-fontawes
 import {faUserPlus} from '@fortawesome/free-solid-svg-icons/faUserPlus';
 import {faBook} from '@fortawesome/free-solid-svg-icons/faBook';
 import usePortalContext from '~/contexts/portal';
+import useUserContext from '~/contexts/user';
 import cn from 'classnames';
 import './let-us-know.scss';
 
@@ -61,7 +62,12 @@ function LetUsKnow({title}: {title: string}) {
 }
 
 export default function MaybeLetUsKnow({title}: {title?: string}) {
-    if (!title) {
+    const {userStatus} = useUserContext();
+    // isStudent is just "logged in, not in the Faculty group", which also covers
+    // instructors still awaiting verification -- they keep the buttons.
+    const isStudent = userStatus?.isStudent && !userStatus.pendingVerification;
+
+    if (!title || isStudent) {
         return null;
     }
     return (<LetUsKnow title={title} />);

--- a/test/src/pages/details/let-us-know.test.tsx
+++ b/test/src/pages/details/let-us-know.test.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 import {render, screen} from '@testing-library/preact';
 import ShellContextProvider from '../../../helpers/shell-context';
 import LetUsKnow from '~/pages/details/common/let-us-know/let-us-know';
+import type {UserStatus} from '~/contexts/user';
+
+const mockUseUserContext = jest.fn(() => ({userStatus: {} as UserStatus}));
+
+jest.mock('~/contexts/user', () => ({
+    ...jest.requireActual('~/contexts/user'),
+    __esModule: true,
+    default: () => mockUseUserContext()
+}));
 
 const englishTitle = 'Some book';
 const polishTitle = 'Fizyka dla szkół wyższych. Tom 1';
@@ -23,6 +32,22 @@ describe('details/let-us-know', () => {
     test('handles Polish title', () => {
         render(<Component title={polishTitle} />);
         screen.getByText('Korzystasz z tej książki? Daj nam znać.');
+    });
+    test('hides itself from logged-in students', () => {
+        mockUseUserContext.mockReturnValueOnce({
+            userStatus: {isStudent: true} as UserStatus
+        });
+        const {container} = render(<Component title={englishTitle} />);
+
+        expect(container.textContent).toBe('');
+    });
+    test('stays visible for instructors awaiting verification', () => {
+        mockUseUserContext.mockReturnValueOnce({
+            userStatus: {isStudent: true, pendingVerification: true} as UserStatus
+        });
+        render(<Component title={englishTitle} />);
+
+        screen.getByText('Using this book?', {exact: false});
     });
     test('handles empty title', () => {
         const {container} = render(<Component />);


### PR DESCRIPTION
## What

The **Sign up to learn more** and **Using this book? Let us know.** buttons on book detail pages are now hidden for logged-in students.

## Why

Both buttons lead to instructor forms (`/interest` and `/adoption`). Students fill them out often enough to be noise in the pipeline. Hiding them is the stopgap while we decide what, if anything, to offer students who want to raise their hand.

## How

One guard in `MaybeLetUsKnow`, which covers all four call sites — the desktop details tab (title and Salesforce-abbreviation variants) and the phone view.

```tsx
const isStudent = userStatus?.isStudent && !userStatus.pendingVerification;

if (!title || isStudent) {
    return null;
}
```

`isStudent` in `contexts/user.ts` means "logged in and not in the Faculty group", which also catches instructors still awaiting verification — the `pendingVerification` check keeps the buttons visible for them. Anonymous visitors are unaffected.

## Testing

Two cases added to `test/src/pages/details/let-us-know.test.tsx` (hidden for students, visible for pending-verification instructors). All 149 tests under `test/src/pages/details` pass; `lint:ts` and `lint:js` clean.